### PR TITLE
all: migrate to gonum.org/v1/gonum

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ hep
 
 [![Build Status](https://secure.travis-ci.org/go-hep/hep.png)](http://travis-ci.org/go-hep/hep)
 [![GoDoc](https://godoc.org/go-hep.org/x/hep?status.svg)](https://godoc.org/go-hep.org/x/hep)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.574888.svg)](https://doi.org/10.5281/zenodo.574888)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.597940.svg)](https://doi.org/10.5281/zenodo.597940)
 
 `hep` is a set of libraries and tools to perform High Energy Physics analyses with ease and [Go](https://golang.org)
 

--- a/fads/btagging.go
+++ b/fads/btagging.go
@@ -10,9 +10,9 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/gonum/stat/distuv"
 	"go-hep.org/x/hep/fmom"
 	"go-hep.org/x/hep/fwk"
+	"gonum.org/v1/gonum/stat/distuv"
 )
 
 type btagclassifier struct {

--- a/fads/calo.go
+++ b/fads/calo.go
@@ -11,8 +11,8 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/gonum/stat/distuv"
 	"go-hep.org/x/hep/fwk"
+	"gonum.org/v1/gonum/stat/distuv"
 )
 
 type etaphiBin struct {

--- a/fads/efficiency.go
+++ b/fads/efficiency.go
@@ -9,8 +9,8 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/gonum/stat/distuv"
 	"go-hep.org/x/hep/fwk"
+	"gonum.org/v1/gonum/stat/distuv"
 )
 
 type Efficiency struct {

--- a/fads/energy_smearing.go
+++ b/fads/energy_smearing.go
@@ -10,9 +10,9 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/gonum/stat/distuv"
 	"go-hep.org/x/hep/fmom"
 	"go-hep.org/x/hep/fwk"
+	"gonum.org/v1/gonum/stat/distuv"
 )
 
 type EnergySmearing struct {

--- a/fads/momentum_smearing.go
+++ b/fads/momentum_smearing.go
@@ -10,9 +10,9 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/gonum/stat/distuv"
 	"go-hep.org/x/hep/fmom"
 	"go-hep.org/x/hep/fwk"
+	"gonum.org/v1/gonum/stat/distuv"
 )
 
 type MomentumSmearing struct {

--- a/fads/tautagging.go
+++ b/fads/tautagging.go
@@ -10,9 +10,9 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/gonum/stat/distuv"
 	"go-hep.org/x/hep/fmom"
 	"go-hep.org/x/hep/fwk"
+	"gonum.org/v1/gonum/stat/distuv"
 )
 
 type tauclassifier struct {

--- a/fastjet/algorithm_test.go
+++ b/fastjet/algorithm_test.go
@@ -16,8 +16,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gonum/floats"
 	"go-hep.org/x/hep/fastjet"
+	"gonum.org/v1/gonum/floats"
 )
 
 func TestInclusiveJetAlgorithms(t *testing.T) {

--- a/fastjet/clustersequence_area_test.go
+++ b/fastjet/clustersequence_area_test.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gonum/floats"
 	"go-hep.org/x/hep/fastjet"
+	"gonum.org/v1/gonum/floats"
 )
 
 func TestClusterSequenceArea(t *testing.T) {

--- a/fit/curve1d.go
+++ b/fit/curve1d.go
@@ -5,7 +5,7 @@
 package fit
 
 import (
-	"github.com/gonum/optimize"
+	"gonum.org/v1/gonum/optimize"
 )
 
 // Curve1D returns the result of a non-linear least squares to fit

--- a/fit/curve1d_test.go
+++ b/fit/curve1d_test.go
@@ -14,13 +14,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gonum/floats"
-	"github.com/gonum/optimize"
 	"github.com/gonum/plot/plotter"
 	"github.com/gonum/plot/vg"
 	"go-hep.org/x/hep/fit"
 	"go-hep.org/x/hep/hbook"
 	"go-hep.org/x/hep/hplot"
+	"gonum.org/v1/gonum/floats"
+	"gonum.org/v1/gonum/optimize"
 )
 
 func TestCurve1D(t *testing.T) {

--- a/fit/fit.go
+++ b/fit/fit.go
@@ -6,7 +6,7 @@
 package fit // import "go-hep.org/x/hep/fit"
 
 import (
-	"github.com/gonum/diff/fd"
+	"gonum.org/v1/gonum/diff/fd"
 )
 
 // Func1D describes a 1D function to fit some data.

--- a/fit/hist.go
+++ b/fit/hist.go
@@ -5,8 +5,8 @@
 package fit
 
 import (
-	"github.com/gonum/optimize"
 	"go-hep.org/x/hep/hbook"
+	"gonum.org/v1/gonum/optimize"
 )
 
 // H1D returns the fit of histogram h with function f and optimization method m.

--- a/fit/hist_test.go
+++ b/fit/hist_test.go
@@ -10,14 +10,14 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/gonum/floats"
-	"github.com/gonum/optimize"
 	"github.com/gonum/plot/plotter"
 	"github.com/gonum/plot/vg"
-	"github.com/gonum/stat/distuv"
 	"go-hep.org/x/hep/fit"
 	"go-hep.org/x/hep/hbook"
 	"go-hep.org/x/hep/hplot"
+	"gonum.org/v1/gonum/floats"
+	"gonum.org/v1/gonum/optimize"
+	"gonum.org/v1/gonum/stat/distuv"
 )
 
 func TestH1D(t *testing.T) {

--- a/fit/run.go
+++ b/fit/run.go
@@ -12,12 +12,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gonum/optimize"
 	"github.com/gonum/plot"
 	"github.com/gonum/plot/plotter"
 	"github.com/gonum/plot/vg"
 	"go-hep.org/x/hep/fit"
 	"go-hep.org/x/hep/hplot"
+	"gonum.org/v1/gonum/optimize"
 )
 
 func fitFunc(x float64, p []float64) float64 {

--- a/hbook/README.md
+++ b/hbook/README.md
@@ -68,7 +68,7 @@ func ExampleH2D() {
 
 	dist, ok := distmv.NewNormal(
 		[]float64{0, 1},
-		mat64.NewSymDense(2, []float64{4, 0, 0, 2}),
+		mat.NewSymDense(2, []float64{4, 0, 0, 2}),
 		rand.New(rand.NewSource(1234)),
 	)
 	if !ok {

--- a/hbook/h1d_test.go
+++ b/hbook/h1d_test.go
@@ -15,10 +15,10 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/gonum/floats"
 	"github.com/gonum/plot/plotter"
-	"github.com/gonum/stat/distuv"
 	"go-hep.org/x/hep/hbook"
+	"gonum.org/v1/gonum/floats"
+	"gonum.org/v1/gonum/stat/distuv"
 )
 
 func ExampleH1D() {

--- a/hbook/h2d_test.go
+++ b/hbook/h2d_test.go
@@ -12,10 +12,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/gonum/matrix/mat64"
 	"github.com/gonum/plot/plotter"
-	"github.com/gonum/stat/distmv"
 	"go-hep.org/x/hep/hbook"
+	"gonum.org/v1/gonum/mat"
+	"gonum.org/v1/gonum/stat/distmv"
 )
 
 func TestH2D(t *testing.T) {
@@ -292,7 +292,7 @@ func ExampleH2D() {
 
 	dist, ok := distmv.NewNormal(
 		[]float64{0, 1},
-		mat64.NewSymDense(2, []float64{4, 0, 0, 2}),
+		mat.NewSymDense(2, []float64{4, 0, 0, 2}),
 		rand.New(rand.NewSource(1234)),
 	)
 	if !ok {

--- a/hbook/p1d_test.go
+++ b/hbook/p1d_test.go
@@ -14,9 +14,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/gonum/matrix/mat64"
-	"github.com/gonum/stat/distmv"
 	"go-hep.org/x/hep/hbook"
+	"gonum.org/v1/gonum/mat"
+	"gonum.org/v1/gonum/stat/distmv"
 )
 
 func TestP1D(t *testing.T) {
@@ -101,7 +101,7 @@ func ExampleP1D() {
 	p := hbook.NewP1D(100, -10, 10)
 	dist, ok := distmv.NewNormal(
 		[]float64{0, 1},
-		mat64.NewSymDense(2, []float64{4, 0, 0, 2}),
+		mat.NewSymDense(2, []float64{4, 0, 0, 2}),
 		rand.New(rand.NewSource(1234)),
 	)
 	if !ok {

--- a/hbook/rootcnv/testdata/gen-2d-data.go
+++ b/hbook/rootcnv/testdata/gen-2d-data.go
@@ -12,8 +12,8 @@ import (
 	"math/rand"
 	"os"
 
-	"github.com/gonum/matrix/mat64"
-	"github.com/gonum/stat/distmv"
+	"gonum.org/v1/gonum/mat"
+	"gonum.org/v1/gonum/stat/distmv"
 )
 
 func main() {
@@ -21,7 +21,7 @@ func main() {
 
 	dist, ok := distmv.NewNormal(
 		[]float64{0, 1},
-		mat64.NewSymDense(2, []float64{4, 0, 0, 2}),
+		mat.NewSymDense(2, []float64{4, 0, 0, 2}),
 		rand.New(rand.NewSource(1234)),
 	)
 	if !ok {

--- a/hplot/README.md
+++ b/hplot/README.md
@@ -173,7 +173,7 @@ func ExampleH2D(t *testing.T) {
 
 	dist, ok := distmv.NewNormal(
 		[]float64{0, 1},
-		mat64.NewSymDense(2, []float64{4, 0, 0, 2}),
+		mat.NewSymDense(2, []float64{4, 0, 0, 2}),
 		rand.New(rand.NewSource(1234)),
 	)
 	if !ok {
@@ -215,7 +215,7 @@ func ExampleS2D(t *testing.T) {
 
 	dist, ok := distmv.NewNormal(
 		[]float64{0, 1},
-		mat64.NewSymDense(2, []float64{4, 0, 0, 2}),
+		mat.NewSymDense(2, []float64{4, 0, 0, 2}),
 		rand.New(rand.NewSource(1234)),
 	)
 	if !ok {

--- a/hplot/h1d_test.go
+++ b/hplot/h1d_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 
 	"github.com/gonum/plot/vg"
-	"github.com/gonum/stat/distuv"
 	"go-hep.org/x/hep/hbook"
 	"go-hep.org/x/hep/hplot"
+	"gonum.org/v1/gonum/stat/distuv"
 )
 
 // An example of making a 1D-histogram.

--- a/hplot/h2d_test.go
+++ b/hplot/h2d_test.go
@@ -8,13 +8,13 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/gonum/matrix/mat64"
 	"github.com/gonum/plot"
 	"github.com/gonum/plot/plotter"
 	"github.com/gonum/plot/vg"
-	"github.com/gonum/stat/distmv"
 	"go-hep.org/x/hep/hbook"
 	"go-hep.org/x/hep/hplot"
+	"gonum.org/v1/gonum/mat"
+	"gonum.org/v1/gonum/stat/distmv"
 )
 
 func TestH2D(t *testing.T) {
@@ -29,7 +29,7 @@ func ExampleH2D(t *testing.T) {
 
 	dist, ok := distmv.NewNormal(
 		[]float64{0, 1},
-		mat64.NewSymDense(2, []float64{4, 0, 0, 2}),
+		mat.NewSymDense(2, []float64{4, 0, 0, 2}),
 		rand.New(rand.NewSource(1234)),
 	)
 	if !ok {

--- a/hplot/hplot_test.go
+++ b/hplot/hplot_test.go
@@ -19,10 +19,10 @@ import (
 	"github.com/gonum/plot/vg/draw"
 	"github.com/gonum/plot/vg/vgimg"
 	"github.com/gonum/plot/vg/vgtex"
-	"github.com/gonum/stat/distuv"
 	"go-hep.org/x/hep/hbook"
 	"go-hep.org/x/hep/hplot"
 	"go-hep.org/x/hep/hplot/internal/cmpimg"
+	"gonum.org/v1/gonum/stat/distuv"
 )
 
 func checkPlot(t *testing.T, ref string) {

--- a/hplot/s2d_test.go
+++ b/hplot/s2d_test.go
@@ -10,12 +10,12 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/gonum/matrix/mat64"
 	"github.com/gonum/plot/plotter"
 	"github.com/gonum/plot/vg"
-	"github.com/gonum/stat/distmv"
 	"go-hep.org/x/hep/hbook"
 	"go-hep.org/x/hep/hplot"
+	"gonum.org/v1/gonum/mat"
+	"gonum.org/v1/gonum/stat/distmv"
 )
 
 // ExampleS2D draws some scatter points.
@@ -24,7 +24,7 @@ func ExampleS2D(t *testing.T) {
 
 	dist, ok := distmv.NewNormal(
 		[]float64{0, 1},
-		mat64.NewSymDense(2, []float64{4, 0, 0, 2}),
+		mat.NewSymDense(2, []float64{4, 0, 0, 2}),
 		rand.New(rand.NewSource(1234)),
 	)
 	if !ok {

--- a/hplot/ticks.go
+++ b/hplot/ticks.go
@@ -8,8 +8,8 @@ import (
 	"math"
 	"strconv"
 
-	"github.com/gonum/floats"
 	"github.com/gonum/plot"
+	"gonum.org/v1/gonum/floats"
 )
 
 const (

--- a/hplot/tiledplot_test.go
+++ b/hplot/tiledplot_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/gonum/plot/vg"
 	"github.com/gonum/plot/vg/draw"
-	"github.com/gonum/stat/distuv"
 	"go-hep.org/x/hep/hbook"
 	"go-hep.org/x/hep/hplot"
+	"gonum.org/v1/gonum/stat/distuv"
 )
 
 // An example of making a tile-plot


### PR DESCRIPTION
Migrate to `gonum.org/v1/gonum/...` where possible (*ie:* drop `gonum/plot` from the migration for the moment)