### PR TITLE
fastjet/internal/predicates: change over to mat

### DIFF
--- a/fastjet/internal/predicates/incircle_test.go
+++ b/fastjet/internal/predicates/incircle_test.go
@@ -6,8 +6,6 @@ package predicates
 
 import (
 	"testing"
-
-	"gonum.org/v1/gonum/mat"
 )
 
 func TestIncircle(t *testing.T) {
@@ -96,31 +94,4 @@ func BenchmarkRobustIncircle(b *testing.B) {
 			robustIncircle(setBig(test.x1), setBig(test.y1), setBig(test.x2), setBig(test.y2), setBig(test.x3), setBig(test.y3), setBig(test.x), setBig(test.y))
 		}
 	}
-}
-
-// matIncircle determines the relative position using the mat package.
-//
-// It first computes the conditional number of the matrix. When the condition number
-// is higher than the Condition Tolerance, then we assume the matrix is singular and
-// the determinant is 0. If the determinant is not 0 the sign of the determinant is computed.
-// |x1 y1 x1^2+y1^2 1|
-// |x2 y2 x2^2+y2^2 1|
-// |x3 y3 x3^2+y3^2 1|
-// |x  y  x^2 +y^2  1|
-// FIXME once LU.Cond() is exported do the factorization here to improve performance
-func matIncircle(x1, y1, x2, y2, x3, y3, x, y float64) RelativePosition {
-	m := mat.NewDense(4, 4, []float64{x1, y1, x1*x1 + y1*y1, 1, x2, y2, x2*x2 + y2*y2, 1, x3, y3, x3*x3 + y3*y3, 1, x, y, x*x + y*y, 1})
-	cond := mat.Cond(m, 1)
-	if cond > mat.ConditionTolerance {
-		return On
-	}
-	// Since only the sign is needed LogDet achieves the result in faster time.
-	_, sign := mat.LogDet(m)
-	switch sign {
-	case 1:
-		return Inside
-	case -1:
-		return Outside
-	}
-	return IndeterminatePosition
 }

--- a/fastjet/internal/predicates/orientation_test.go
+++ b/fastjet/internal/predicates/orientation_test.go
@@ -6,8 +6,6 @@ package predicates
 
 import (
 	"testing"
-
-	"gonum.org/v1/gonum/mat"
 )
 
 func TestOrientation(t *testing.T) {
@@ -133,34 +131,4 @@ func BenchmarkRobustOrientation(b *testing.B) {
 			robustOrientation(setBig(test.x1), setBig(test.y1), setBig(test.x2), setBig(test.y2), setBig(test.x), setBig(test.y))
 		}
 	}
-}
-
-// matOrientation determines the orientation using the mat package.
-//
-// It first computes the conditional number of the matrix. When the condition number
-// is higher than the Condition Tolerance, then we assume the matrix is singular and
-// the determinant is 0. If the determinant is not 0 the sign of the determinant is computed.
-//  | x1 y1 1 |
-//  | x2 y2 1 |
-//  | x  y  1 |
-// FIXME once LU.Cond() is exported do the factorization here to improve performance
-func matOrientation(x1, y1, x2, y2, x, y float64) OrientationKind {
-	if (x1 == x2 && x2 == x) || (y1 == y2 && y2 == y) {
-		// points are horizontally or vertically aligned
-		return Colinear
-	}
-	m := mat.NewDense(3, 3, []float64{x1, y1, 1, x2, y2, 1, x, y, 1})
-	cond := mat.Cond(m, 1)
-	if cond > mat.ConditionTolerance {
-		return Colinear
-	}
-	// Since only the sign is needed LogDet achieves the result in faster time.
-	_, sign := mat.LogDet(m)
-	switch sign {
-	case 1:
-		return CCW
-	case -1:
-		return CW
-	}
-	return IndeterminateOrientation
 }


### PR DESCRIPTION
This PR changes the close case predicates testing over to using the mat package. It also changes the mat functions up, to do the factorization in place.