### PR TITLE
fastjet/internal/delaunay: implement hierarchical delaunay insertion

### DIFF
--- a/fastjet/internal/delaunay/delaunay.go
+++ b/fastjet/internal/delaunay/delaunay.go
@@ -7,27 +7,357 @@ package delaunay
 import (
 	"fmt"
 	"math/rand"
+
+	"go-hep.org/x/hep/fastjet/internal/predicates"
 )
 
+// Delaunay holds necessary information for the delaunay triangulation.
 type Delaunay struct {
+	// triangles is a slice of all triangles that have been created. It is used to get the final
+	// list of triangles in the delaunay triangulation.
+	triangles triangles
+	// root is a triangle that contains all points. It is used as the starting point in the hierarchy
+	// to locate a point. The variable root's nil-ness also indicates which method to use to locate a point.
+	root *Triangle
+	r    *rand.Rand
 }
 
+// HierarchicalDelaunay creates a Delaunay Triangulation using the delaunay hierarchy.
+//
+// The worst case time complexity is O(n*log(n)).
+//
+// The three root points (-2^100,-2^100), (2^100,-2^100) and (0,2^100) can't be in the circumcircle of any three non-collinear points in the
+// triangulation. Additionally all points have to be inside the Triangle formed by these three points.
+// If any of these conditions doesn't apply use the WalkDelaunay function instead.
+// 2^100 = 1.27e30
+//
+// To locate a point this algorithm uses a Directed Acyclic Graph with a single root.
+// All triangles in the current triangulation are leaf triangles.
+// To find the triangle which contains the point, the algorithm follows the graph until
+// a leaf is reached.
 func HierarchicalDelaunay() *Delaunay {
-	panic(fmt.Errorf("delaunay: HierarchicalDelaunay not implemented"))
+	a := NewPoint(-1<<100, -1<<100)
+	b := NewPoint(1<<100, -1<<100)
+	c := NewPoint(0, 1<<100)
+	root := NewTriangle(a, b, c)
+	return &Delaunay{
+		root: root,
+	}
 }
 
 func WalkDelaunay(points []*Point, r *rand.Rand) *Delaunay {
 	panic(fmt.Errorf("delaunay: WalkDelaunay not implemented"))
 }
 
+// Triangles returns the triangles that form the delaunay triangulation.
 func (d *Delaunay) Triangles() []*Triangle {
-	panic(fmt.Errorf("delaunay: Triangles not implemented"))
+	// rt are triangles that contain the root points
+	rt := make(triangles, len(d.root.A.adjacentTriangles)+len(d.root.B.adjacentTriangles)+len(d.root.C.adjacentTriangles))
+	n := copy(rt, d.root.A.adjacentTriangles)
+	n += copy(rt[n:], d.root.B.adjacentTriangles)
+	copy(rt[n:], d.root.C.adjacentTriangles)
+	// make a copy so that the original slice is not modified
+	triangles := make(triangles, len(d.triangles))
+	copy(triangles, d.triangles)
+	// keep only the triangles that are in the current triangulation
+	triangles = triangles.keepCurrentTriangles()
+	// remove all triangles that contain the root points
+	return triangles.remove(rt...)
 }
 
+// Insert inserts the point into the triangulation. It returns the points
+// whose nearest neighbor changed due to the insertion. The slice may contain
+// duplicates.
 func (d *Delaunay) Insert(p *Point) (updatedNearestNeighbor []*Point) {
-	panic(fmt.Errorf("delaunay: Insert not implemented"))
+	if len(p.adjacentTriangles) == 0 {
+		p.adjacentTriangles = make(triangles, 0)
+	}
+	p.adjacentTriangles = p.adjacentTriangles[:0]
+	t, l := d.locatePointHierarchy(p, d.root)
+	switch l {
+	case inside:
+		return d.insertInside(p, t)
+	case onEdge:
+		return d.insertOnEdge(p, t)
+	}
+	panic(fmt.Errorf("delaunay: no triangle containing point %v", p))
 }
 
+// Remove removes the point from the triangulation. It returns the points
+// whose nearest neighbor changed due to the removal. The slice may contain
+// duplicates.
 func (d *Delaunay) Remove(p *Point) (updatedNearestNeighbor []*Point) {
 	panic(fmt.Errorf("delaunay: Remove not implemented"))
+}
+
+// locatePointHierarchy locates the point using the delaunay hierarchy.
+//
+// It returns the triangle that contains the point and the location
+// indicates whether it is on an edge or not. The worst case time complexity
+// for locating a point is O(log(n)).
+func (d *Delaunay) locatePointHierarchy(p *Point, t *Triangle) (*Triangle, location) {
+	l := p.inTriangle(t)
+	if l == outside {
+		return nil, l
+	}
+	if len(t.children) == 0 {
+		// leaf triangle
+		return t, l
+	}
+	// go down the children to eventually reach a leaf triangle
+	for _, child := range t.children {
+		t, l = d.locatePointHierarchy(p, child)
+		if l != outside {
+			return t, l
+		}
+	}
+	panic(fmt.Errorf("delaunay: error locating Point %v in Triangle %v", p, t))
+}
+
+// insertInside inserts a point inside a triangle. It returns the points whose nearest
+// neighbor changed during the process.
+func (d *Delaunay) insertInside(p *Point, t *Triangle) []*Point {
+	// form three new triangles
+	t1 := NewTriangle(t.A, t.B, p)
+	t2 := NewTriangle(t.B, t.C, p)
+	t3 := NewTriangle(t.C, t.A, p)
+	updated := t1.add()
+	updtemp := t2.add()
+	updated = append(updated, updtemp...)
+	updtemp = t3.add()
+	updated = append(updated, updtemp...)
+	updtemp = t.remove()
+	updated = append(updated, updtemp...)
+	t.children = append(t.children, t1, t2, t3)
+	d.triangles = append(d.triangles, t1, t2, t3)
+	// change the edges so it is a valid delaunay triangulation
+	updtemp = d.swapDelaunay(t1, p)
+	updated = append(updated, updtemp...)
+	updtemp = d.swapDelaunay(t2, p)
+	updated = append(updated, updtemp...)
+	updtemp = d.swapDelaunay(t3, p)
+	updated = append(updated, updtemp...)
+	return updated
+}
+
+// insertOnEdge inserts a point on an Edge between two triangles. It returns the points
+// whose nearest neighbor changed.
+func (d *Delaunay) insertOnEdge(p *Point, t *Triangle) []*Point {
+	// To increase performance find the points in t, where p1 has the least adjacent triangles and
+	// p2 the second least.
+	var p1, p2, p3 *Point
+	if len(t.A.adjacentTriangles) < len(t.B.adjacentTriangles) {
+		if len(t.C.adjacentTriangles) < len(t.A.adjacentTriangles) {
+			p1 = t.C
+			p2 = t.A
+			p3 = t.B
+		} else {
+			p1 = t.A
+			if len(t.C.adjacentTriangles) < len(t.B.adjacentTriangles) {
+				p2 = t.C
+				p3 = t.B
+			} else {
+				p2 = t.B
+				p3 = t.C
+			}
+		}
+	} else {
+		if len(t.C.adjacentTriangles) < len(t.B.adjacentTriangles) {
+			p1 = t.C
+			p2 = t.B
+			p3 = t.A
+		} else {
+			p1 = t.B
+			if len(t.A.adjacentTriangles) < len(t.C.adjacentTriangles) {
+				p2 = t.A
+				p3 = t.C
+			} else {
+				p2 = t.C
+				p3 = t.A
+			}
+		}
+	}
+	// pA1 and pA2 will be the points adjacent to the edge. pO1 and pO2 will be the points opposite to the edge
+	var pA1, pA2, pO1, pO2 *Point
+	// find second triangle adjacent to edge
+	var t2 *Triangle
+	// exactly two points in each adjacent triangle to the edge have to be adjacent to that edge.
+	found := false
+	for _, ta := range p1.adjacentTriangles {
+		if !ta.Equals(t) && p.inTriangle(ta) == onEdge {
+			found = true
+			t2 = ta
+			break
+		}
+	}
+	if found {
+		pA1 = p1
+		found = false
+		for _, ta := range p2.adjacentTriangles {
+			if ta.Equals(t2) {
+				found = true
+				break
+			}
+		}
+		if found {
+			pA2 = p2
+			pO1 = p3
+		} else {
+			pA2 = p3
+			pO1 = p2
+		}
+	} else {
+		pO1 = p1
+		for _, ta := range p2.adjacentTriangles {
+			if !ta.Equals(t) && p.inTriangle(ta) == onEdge {
+				found = true
+				t2 = ta
+				break
+			}
+		}
+		if !found {
+			panic(fmt.Errorf("delaunay: can't find second triangle with edge to %v and %v on edge", t, p))
+		}
+		pA1 = p2
+		pA2 = p3
+	}
+	switch {
+	case !t2.A.Equals(pA1) && !t2.A.Equals(pA2):
+		pO2 = t2.A
+	case !t2.B.Equals(pA1) && !t2.B.Equals(pA2):
+		pO2 = t2.B
+	case !t2.C.Equals(pA1) && !t2.C.Equals(pA2):
+		pO2 = t2.C
+	default:
+		panic(fmt.Errorf("delaunay: no point in %v that is not adjacent to the edge of %v", t2, p))
+	}
+	// form four new triangles
+	nt1 := NewTriangle(pA1, p, pO1)
+	nt2 := NewTriangle(pA1, p, pO2)
+	nt3 := NewTriangle(pA2, p, pO1)
+	nt4 := NewTriangle(pA2, p, pO2)
+	updated := nt1.add()
+	updtemp := nt2.add()
+	updated = append(updated, updtemp...)
+	updtemp = nt3.add()
+	updated = append(updated, updtemp...)
+	updtemp = nt4.add()
+	updated = append(updated, updtemp...)
+	updtemp = t.remove()
+	updated = append(updated, updtemp...)
+	updtemp = t2.remove()
+	updated = append(updated, updtemp...)
+	t.children = append(t.children, nt1, nt3)
+	t2.children = append(t2.children, nt2, nt4)
+	d.triangles = append(d.triangles, nt1, nt2, nt3, nt4)
+	// change the edges so it is a valid delaunay triangulation
+	updtemp = d.swapDelaunay(nt1, p)
+	updated = append(updated, updtemp...)
+	updtemp = d.swapDelaunay(nt2, p)
+	updated = append(updated, updtemp...)
+	updtemp = d.swapDelaunay(nt3, p)
+	updated = append(updated, updtemp...)
+	updtemp = d.swapDelaunay(nt4, p)
+	updated = append(updated, updtemp...)
+	return updated
+}
+
+// swapDelaunay finds the triangle adjacent to t and opposite to p.
+// Then it checks whether p is in the circumcircle. If p is in the circumcircle
+// that means that the triangle is not a valid delaunay triangle.
+// Therefore the edge in between the two triangles is swapped, creating
+// two new triangles that need to be checked.
+// It returns the points whose nearest neighbors changed during the
+// process.
+func (d *Delaunay) swapDelaunay(t *Triangle, p *Point) []*Point {
+	// find points in the triangle that are not p
+	var p2, p3 *Point
+	switch {
+	case p.Equals(t.A):
+		p2 = t.B
+		p3 = t.C
+	case p.Equals(t.B):
+		p2 = t.C
+		p3 = t.A
+	case p.Equals(t.C):
+		p2 = t.A
+		p3 = t.B
+	default:
+		panic(fmt.Errorf("delaunay: can't find point %v in Triangle %v", p, t))
+	}
+	// find triangle opposite to p
+	var ta *Triangle
+loop:
+	for _, t1 := range p2.adjacentTriangles {
+		for _, t2 := range p3.adjacentTriangles {
+			if !t1.Equals(t) && t1.Equals(t2) {
+				ta = t1
+				break loop
+			}
+		}
+
+	}
+	var updated []*Point
+	if ta == nil {
+		return updated
+	}
+	pos := predicates.Incircle(ta.A.x, ta.A.y, ta.B.x, ta.B.y, ta.C.x, ta.C.y, p.x, p.y)
+	// swap edges if p is inside the circumcircle of ta
+	if pos == predicates.Inside {
+		var nt1, nt2 *Triangle
+		nt1, nt2, updated = d.swapEdge(t, ta)
+		updtemp := d.swapDelaunay(nt1, p)
+		updated = append(updated, updtemp...)
+		updtemp = d.swapDelaunay(nt2, p)
+		updated = append(updated, updtemp...)
+	}
+	return updated
+}
+
+// swapEdge swaps edge between two triangles.
+// The edge in the middle of the two triangles is removed and
+// an edge between the two opposite points is added.
+func (d *Delaunay) swapEdge(t1, t2 *Triangle) (nt1, nt2 *Triangle, updated []*Point) {
+	// find points adjacent and opposite to edge
+	var adj1, adj2, opp1, opp2 *Point
+	switch {
+	case !t1.A.Equals(t2.A) && !t1.A.Equals(t2.B) && !t1.A.Equals(t2.C):
+		adj1 = t1.A
+		opp1 = t1.B
+		opp2 = t1.C
+	case !t1.B.Equals(t2.A) && !t1.B.Equals(t2.B) && !t1.B.Equals(t2.C):
+		adj1 = t1.B
+		opp1 = t1.A
+		opp2 = t1.C
+	case !t1.C.Equals(t2.A) && !t1.C.Equals(t2.B) && !t1.C.Equals(t2.C):
+		adj1 = t1.C
+		opp1 = t1.B
+		opp2 = t1.A
+	default:
+		panic(fmt.Errorf("delaunay: triangle T1%v is equal to T2%v", t1, t2))
+	}
+	switch {
+	case !t2.A.Equals(t1.A) && !t2.A.Equals(t1.B) && !t2.A.Equals(t1.C):
+		adj2 = t2.A
+	case !t2.B.Equals(t1.A) && !t2.B.Equals(t1.B) && !t2.B.Equals(t1.C):
+		adj2 = t2.B
+	case !t2.C.Equals(t1.A) && !t2.C.Equals(t1.B) && !t2.C.Equals(t1.C):
+		adj2 = t2.C
+	default:
+		panic(fmt.Errorf("delaunay: triangle T2%v is equal to T1%v", t2, t1))
+	}
+	// create two new triangles
+	nt1 = NewTriangle(adj1, adj2, opp1)
+	nt2 = NewTriangle(adj1, adj2, opp2)
+	updated = nt1.add()
+	updtemp := nt2.add()
+	updated = append(updated, updtemp...)
+	updtemp = t1.remove()
+	updated = append(updated, updtemp...)
+	updtemp = t2.remove()
+	updated = append(updated, updtemp...)
+	t1.children = append(t1.children, nt1, nt2)
+	t2.children = append(t2.children, nt1, nt2)
+	d.triangles = append(d.triangles, nt1, nt2)
+	return nt1, nt2, updated
 }

--- a/fastjet/internal/delaunay/delaunay_test.go
+++ b/fastjet/internal/delaunay/delaunay_test.go
@@ -1,0 +1,299 @@
+// Copyright 2017 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package delaunay
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+const tol = 1e-3
+
+func TestHierarchicalDelaunayInsertSmall(t *testing.T) {
+	// NewPoint(x, y)
+	p1 := NewPoint(0, 0)
+	p2 := NewPoint(0, 2)
+	p3 := NewPoint(1, 0)
+	p4 := NewPoint(4, 4)
+	ps := []*Point{
+		p1,
+		p2,
+		p3,
+		p4,
+	}
+	d := HierarchicalDelaunay()
+	for _, p := range ps {
+		d.Insert(p)
+	}
+	exp := []*Triangle{
+		NewTriangle(p1, p2, p3),
+		NewTriangle(p2, p3, p4),
+	}
+	ts := d.Triangles()
+	got, want := len(ts), len(exp)
+	if got != want {
+		t.Errorf("got=%d delaunay triangles, want=%d", got, want)
+	}
+	for i := range ts {
+		ok := false
+		for j := range exp {
+			if ts[i].Equals(exp[j]) {
+				ok = true
+				// remove triangles that have been matched from slice,
+				// in case there are duplicate triangles.
+				exp = append(exp[:j], exp[j+1:]...)
+				break
+			}
+		}
+		if !ok {
+			t.Errorf("Triangle T%s not as expected", ts[i])
+		}
+	}
+	var (
+		nn []*Point
+		nd []float64
+	)
+	for _, p := range ps {
+		n, d := p.NearestNeighbor()
+		nn = append(nn, n)
+		nd = append(nd, d)
+	}
+	expN := []*Point{p3, p1, p1, p2}
+	expD := []float64{1.0, 2.0, 1.0, 4.4721}
+	got, want = len(nn), len(expN)
+	if got != want {
+		t.Errorf("got=%d nearest neighbors, want=%d", got, want)
+	}
+	for i := range nn {
+		if !nn[i].Equals(expN[i]) {
+			t.Errorf("got=N%s nearest neighbor, want=N%s", nn[i], expN[i])
+		}
+		if math.Abs(nd[i]-expD[i]) > tol {
+			t.Errorf("got=%f distance, want=%f for point P%s with neighbour N%s", nd[i], expD[i], ps[i], nn[i])
+		}
+	}
+}
+
+func TestHierarchicalDelaunayInsertMedium(t *testing.T) {
+	// NewPoint(x, y)
+	p1 := NewPoint(-1.5, 3.2)
+	p2 := NewPoint(1.8, 3.3)
+	p3 := NewPoint(-3.7, 1.5)
+	p4 := NewPoint(-1.5, 1.3)
+	p5 := NewPoint(0.8, 1.2)
+	p6 := NewPoint(3.3, 1.5)
+	p7 := NewPoint(-4, -1)
+	p8 := NewPoint(-2.3, -0.7)
+	p9 := NewPoint(0, -0.5)
+	p10 := NewPoint(2, -1.5)
+	p11 := NewPoint(3.7, -0.8)
+	p12 := NewPoint(-3.5, -2.9)
+	p13 := NewPoint(-0.9, -3.9)
+	p14 := NewPoint(2, -3.5)
+	p15 := NewPoint(3.5, -2.25)
+	ps := []*Point{p1, p2, p3, p4, p5, p6, p7, p8,
+		p9, p10, p11, p12, p13, p14, p15}
+	d := HierarchicalDelaunay()
+	for _, p := range ps {
+		d.Insert(p)
+	}
+	ts := d.Triangles()
+	exp := []*Triangle{
+		NewTriangle(p1, p3, p4),
+		NewTriangle(p1, p4, p5),
+		NewTriangle(p1, p5, p2),
+		NewTriangle(p2, p5, p6),
+		NewTriangle(p3, p4, p8),
+		NewTriangle(p3, p8, p7),
+		NewTriangle(p4, p8, p9),
+		NewTriangle(p4, p9, p5),
+		NewTriangle(p5, p9, p10),
+		NewTriangle(p5, p10, p6),
+		NewTriangle(p6, p10, p11),
+		NewTriangle(p7, p8, p12),
+		NewTriangle(p8, p12, p13),
+		NewTriangle(p8, p13, p9),
+		NewTriangle(p9, p13, p10),
+		NewTriangle(p10, p13, p14),
+		NewTriangle(p10, p14, p15),
+		NewTriangle(p10, p15, p11),
+	}
+	got, want := len(ts), len(exp)
+	if got != want {
+		t.Errorf("got=%d delaunay triangles, want=%d", got, want)
+	}
+	for i := range ts {
+		ok := false
+		for j := range exp {
+			if ts[i].Equals(exp[j]) {
+				ok = true
+				// remove triangles that have been matched from slice,
+				// in case there are duplicate triangles.
+				exp = append(exp[:j], exp[j+1:]...)
+				break
+			}
+		}
+		if !ok {
+			t.Errorf("Triangle T%s not as expected", ts[i])
+		}
+	}
+	var (
+		nn []*Point
+		nd []float64
+	)
+	for _, p := range ps {
+		n, d := p.NearestNeighbor()
+		nn = append(nn, n)
+		nd = append(nd, d)
+	}
+	expN := []*Point{p4, p5, p4, p1, p9, p11, p8, p7, p5, p15, p15, p7, p12, p15, p11}
+	expD := []float64{1.9, 2.326, 2.209, 1.9, 1.879, 2.335, 1.726, 1.726, 1.879, 1.677, 1.464, 1.965, 2.786, 1.953, 1.464}
+	got, want = len(nn), len(expN)
+	if got != want {
+		t.Errorf("got=%d nearest neighbors, want=%d", got, want)
+	}
+	for i := range nn {
+		if !nn[i].Equals(expN[i]) {
+			t.Errorf("got=N%s nearest neighbor, want=N%s", nn[i], expN[i])
+		}
+		if math.Abs(nd[i]-expD[i]) > tol {
+			t.Errorf("got=%f distance, want=%f for point P%s with neighbour N%s", nd[i], expD[i], ps[i], nn[i])
+		}
+	}
+}
+
+func grid(nx, ny int, angle float64) []*Point {
+	s := math.Sin(angle)
+	c := math.Cos(angle)
+	var points []*Point
+	for xi := 0; xi < nx; xi++ {
+		tx := float64(xi)
+		for yi := 0; yi < ny; yi++ {
+			ty := float64(yi)
+			x := tx*c - ty*s
+			y := tx*s + ty*c
+			points = append(points, NewPoint(x, y))
+		}
+	}
+	return points
+}
+
+func TestHierarchicalDelaunayGrid(t *testing.T) {
+	const degrees = math.Pi / 180
+	const n = 10
+	ps := grid(n, n, 10*degrees)
+	d := HierarchicalDelaunay()
+	for _, p := range ps {
+		d.Insert(p)
+	}
+}
+
+func TestHierarchicalDelaunayGridRotated(t *testing.T) {
+	const degrees = math.Pi / 180
+	const n = 10
+	ps := grid(n, n, 60*degrees)
+	d := HierarchicalDelaunay()
+	for _, p := range ps {
+		d.Insert(p)
+	}
+}
+
+func benchmarkHierarchicalDelaunayInsertion(i int, b *testing.B) {
+	ps := make([]*Point, i)
+	for j := 0; j < i; j++ {
+		x := rand.Float64() * 1000
+		y := rand.Float64() * 1000
+		ps[j] = NewPoint(x, y)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		d := HierarchicalDelaunay()
+		for _, p := range ps {
+			d.Insert(p)
+		}
+	}
+}
+
+func BenchmarkHierarchicalDelaunayInsertion50(b *testing.B) {
+	benchmarkHierarchicalDelaunayInsertion(50, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertion100(b *testing.B) {
+	benchmarkHierarchicalDelaunayInsertion(100, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertion150(b *testing.B) {
+	benchmarkHierarchicalDelaunayInsertion(150, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertion200(b *testing.B) {
+	benchmarkHierarchicalDelaunayInsertion(200, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertion250(b *testing.B) {
+	benchmarkHierarchicalDelaunayInsertion(250, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertion300(b *testing.B) {
+	benchmarkHierarchicalDelaunayInsertion(300, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertion350(b *testing.B) {
+	benchmarkHierarchicalDelaunayInsertion(350, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertion400(b *testing.B) {
+	benchmarkHierarchicalDelaunayInsertion(400, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertion450(b *testing.B) {
+	benchmarkHierarchicalDelaunayInsertion(450, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertion500(b *testing.B) {
+	benchmarkHierarchicalDelaunayInsertion(500, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertion550(b *testing.B) {
+	benchmarkHierarchicalDelaunayInsertion(550, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertion600(b *testing.B) {
+	benchmarkHierarchicalDelaunayInsertion(600, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertion650(b *testing.B) {
+	benchmarkHierarchicalDelaunayInsertion(650, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertion700(b *testing.B) {
+	benchmarkHierarchicalDelaunayInsertion(700, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertion750(b *testing.B) {
+	benchmarkHierarchicalDelaunayInsertion(750, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertion800(b *testing.B) {
+	benchmarkHierarchicalDelaunayInsertion(800, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertion850(b *testing.B) {
+	benchmarkHierarchicalDelaunayInsertion(850, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertion900(b *testing.B) {
+	benchmarkHierarchicalDelaunayInsertion(900, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertion950(b *testing.B) {
+	benchmarkHierarchicalDelaunayInsertion(950, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertion1000(b *testing.B) {
+	benchmarkHierarchicalDelaunayInsertion(1000, b)
+}

--- a/fastjet/internal/delaunay/point.go
+++ b/fastjet/internal/delaunay/point.go
@@ -89,13 +89,13 @@ func (p *Point) findNearest() {
 			}
 		case p.Equals(t.C):
 			distA := p.distance(t.A)
-			distC := p.distance(t.C)
-			if distA <= distC {
+			distB := p.distance(t.B)
+			if distA <= distB {
 				dist = distA
 				np = t.A
 			} else {
-				dist = distC
-				np = t.C
+				dist = distB
+				np = t.B
 			}
 		default:
 			panic(fmt.Errorf("delaunay: point P%s not found in T%s", p, t))

--- a/fastjet/internal/delaunay/triangle.go
+++ b/fastjet/internal/delaunay/triangle.go
@@ -159,3 +159,14 @@ func (ts triangles) remove(triangles ...*Triangle) triangles {
 	}
 	return ts
 }
+
+// keepCurrentTriangles returns all triangles that are in the current triangulation.
+func (ts triangles) keepCurrentTriangles() triangles {
+	triangles := make(triangles, 0, len(ts))
+	for _, t := range ts {
+		if t.isInTriangulation {
+			triangles = append(triangles, t)
+		}
+	}
+	return triangles
+}


### PR DESCRIPTION
This PR implements the insertion using the hierarchical delaunay algorithm. 

The benchmark numbers are significantly worse than the version in the first PR without the predicates. The cpu profile shows that swapDelaunay takes up most of the time. That is where the incircle function is called. If possible improving the incircle function would be the best for the performance.