### PR TITLE
fastjet/internal/delaunay: implement hierarchical removal

### DIFF
--- a/fastjet/internal/delaunay/delaunay.go
+++ b/fastjet/internal/delaunay/delaunay.go
@@ -26,19 +26,19 @@ type Delaunay struct {
 //
 // The worst case time complexity is O(n*log(n)).
 //
-// The three root points (-2^100,-2^100), (2^100,-2^100) and (0,2^100) can't be in the circumcircle of any three non-collinear points in the
+// The three root points (-2^30,-2^30), (2^30,-2^30) and (0,2^30) can't be in the circumcircle of any three non-collinear points in the
 // triangulation. Additionally all points have to be inside the Triangle formed by these three points.
 // If any of these conditions doesn't apply use the WalkDelaunay function instead.
-// 2^100 = 1.27e30
+// 2^30 = 1,073,741,824
 //
 // To locate a point this algorithm uses a Directed Acyclic Graph with a single root.
 // All triangles in the current triangulation are leaf triangles.
 // To find the triangle which contains the point, the algorithm follows the graph until
 // a leaf is reached.
 func HierarchicalDelaunay() *Delaunay {
-	a := NewPoint(-1<<100, -1<<100)
-	b := NewPoint(1<<100, -1<<100)
-	c := NewPoint(0, 1<<100)
+	a := NewPoint(-1<<30, -1<<30)
+	b := NewPoint(1<<30, -1<<30)
+	c := NewPoint(0, 1<<30)
 	root := NewTriangle(a, b, c)
 	return &Delaunay{
 		root: root,
@@ -87,7 +87,18 @@ func (d *Delaunay) Insert(p *Point) (updatedNearestNeighbor []*Point) {
 // whose nearest neighbor changed due to the removal. The slice may contain
 // duplicates.
 func (d *Delaunay) Remove(p *Point) (updatedNearestNeighbor []*Point) {
-	panic(fmt.Errorf("delaunay: Remove not implemented"))
+	if len(p.adjacentTriangles) < 3 {
+		panic(fmt.Errorf("delaunay: can't remove point %v, not enough adjacent triangles", p))
+	}
+	points := p.surroundingPoints()
+	ts := make([]*Triangle, len(p.adjacentTriangles))
+	copy(ts, p.adjacentTriangles)
+	for _, t := range ts {
+		updtemp := t.remove()
+		updatedNearestNeighbor = append(updatedNearestNeighbor, updtemp...)
+	}
+	updtemp := d.retriangulateAndSew(points, ts)
+	return append(updatedNearestNeighbor, updtemp...)
 }
 
 // locatePointHierarchy locates the point using the delaunay hierarchy.
@@ -360,4 +371,61 @@ func (d *Delaunay) swapEdge(t1, t2 *Triangle) (nt1, nt2 *Triangle, updated []*Po
 	t2.children = append(t2.children, nt1, nt2)
 	d.triangles = append(d.triangles, nt1, nt2)
 	return nt1, nt2, updated
+}
+
+// retriangulateAnd Sew uses the re-triangulate and sew method to find the delaunay triangles
+// inside the polygon formed by the CCW-ordered points. If k = len(points) then it has a
+// worst-time complexity of O(k*log(k)).
+func (d *Delaunay) retriangulateAndSew(points []*Point, parents []*Triangle) (updated []*Point) {
+	nd := HierarchicalDelaunay()
+	// change limits to create a root triangle that's far outside of the original root triangle
+	nd.root.A.x = -1 << 35
+	nd.root.A.y = -1 << 35
+	nd.root.B.x = 1 << 35
+	nd.root.B.y = -1 << 35
+	nd.root.C.y = 1 << 35
+	// make copies of points on polygon and run a delaunay triangulation with them
+	// indices of copies are in counter clockwise order, so that with the help of
+	// areCounterclockwise it can be determined if a point is inside or outside the polygon.
+	// A,B,C are ordered counterclockwise, so if the numbers in A,B,C are counterclockwise it is
+	// inside the polygon.
+	copies := make([]*Point, len(points))
+	for i, p := range points {
+		copies[i] = NewPoint(p.x, p.y)
+		copies[i].id = i
+		nd.Insert(copies[i])
+	}
+	ts := nd.Triangles()
+	triangles := make([]*Triangle, 0, len(ts))
+	for _, t := range ts {
+		a := t.A.id
+		b := t.B.id
+		c := t.C.id
+		// only keep triangles that are inside the polygon
+		// points are inside the polygon if the order of the indices inside the triangle
+		// is counterclockwise
+		if areCounterclockwise(a, b, c) {
+			tr := NewTriangle(points[a], points[b], points[c])
+			updtemp := tr.add()
+			updated = append(updated, updtemp...)
+			triangles = append(triangles, tr)
+		}
+	}
+	d.triangles = append(d.triangles, triangles...)
+	for i := range parents {
+		parents[i].children = append(parents[i].children, triangles...)
+	}
+	return updated
+}
+
+// areCounterclockwise is a helper function for retriangulateAndSew. It returns
+// whether three points are in counterclockwise order.
+// Since the points in triangle are ordered counterclockwise and the indices around
+// the polygon are ordered counterclockwise checking if the indices of A,B,C
+// are counter clockwise is enough.
+func areCounterclockwise(a, b, c int) bool {
+	if b < c {
+		return a < b || c < a
+	}
+	return a < b && c < a
 }

--- a/fastjet/internal/delaunay/delaunay_test.go
+++ b/fastjet/internal/delaunay/delaunay_test.go
@@ -297,3 +297,278 @@ func BenchmarkHierarchicalDelaunayInsertion950(b *testing.B) {
 func BenchmarkHierarchicalDelaunayInsertion1000(b *testing.B) {
 	benchmarkHierarchicalDelaunayInsertion(1000, b)
 }
+
+func TestHierarchicalDelaunayRemovalSmall(t *testing.T) {
+	// NewPoint(x, y)
+	p1 := NewPoint(0, 0)
+	p2 := NewPoint(0, 2)
+	p3 := NewPoint(1, 0)
+	p4 := NewPoint(4, 4)
+	// point to be removed later
+	pE := NewPoint(3, 2)
+	ps := []*Point{
+		p1,
+		p2,
+		p3,
+		pE,
+		p4,
+	}
+	d := HierarchicalDelaunay()
+	for _, p := range ps {
+		d.Insert(p)
+	}
+	d.Remove(pE)
+	exp := []*Triangle{
+		NewTriangle(p1, p2, p3),
+		NewTriangle(p2, p3, p4),
+	}
+	ts := d.Triangles()
+	got, want := len(ts), len(exp)
+	if got != want {
+		t.Errorf("got=%d delaunay triangles, want=%d", got, want)
+	}
+	for i := range ts {
+		ok := false
+		for j := range exp {
+			if ts[i].Equals(exp[j]) {
+				ok = true
+				// remove triangles that have been matched from slice,
+				// in case there are duplicate triangles.
+				exp = append(exp[:j], exp[j+1:]...)
+				break
+			}
+		}
+		if !ok {
+			t.Errorf("Triangle T%s not as expected", ts[i])
+		}
+	}
+	var (
+		nn []*Point
+		nd []float64
+	)
+	for _, p := range ps {
+		if p.Equals(pE) {
+			continue
+		}
+		n, d := p.NearestNeighbor()
+		nn = append(nn, n)
+		nd = append(nd, d)
+	}
+	expN := []*Point{p3, p1, p1, p2}
+	expD := []float64{1.0, 2.0, 1.0, 4.4721}
+	got, want = len(nn), len(expN)
+	if got != want {
+		t.Errorf("got=%d nearest neighbors, want=%d", got, want)
+	}
+	for i := range nn {
+		if !nn[i].Equals(expN[i]) {
+			t.Errorf("got=N%s nearest neighbor, want=N%s", nn[i], expN[i])
+		}
+		if math.Abs(nd[i]-expD[i]) > tol {
+			t.Errorf("got=%f distance, want=%f for point P%s with neighbour N%s", nd[i], expD[i], ps[i], nn[i])
+		}
+	}
+}
+
+func TestHierarchicalDelaunayRemovalMedium(t *testing.T) {
+	// NewPoint(x, y)
+	p1 := NewPoint(-1.5, 3.2)
+	p2 := NewPoint(1.8, 3.3)
+	p3 := NewPoint(-3.7, 1.5)
+	p4 := NewPoint(-1.5, 1.3)
+	p5 := NewPoint(0.8, 1.2)
+	p6 := NewPoint(3.3, 1.5)
+	p7 := NewPoint(-4, -1)
+	p8 := NewPoint(-2.3, -0.7)
+	p9 := NewPoint(0, -0.5)
+	p10 := NewPoint(2, -1.5)
+	p11 := NewPoint(3.7, -0.8)
+	p12 := NewPoint(-3.5, -2.9)
+	p13 := NewPoint(-0.9, -3.9)
+	p14 := NewPoint(2, -3.5)
+	p15 := NewPoint(3.5, -2.25)
+	// points to be removed later
+	pE1 := NewPoint(0, 0)
+	pE2 := NewPoint(-2.3, -0.6)
+	pE3 := NewPoint(2, 1.2)
+	pE4 := NewPoint(-2.8, -0.5)
+	ps := []*Point{p1, p2, p3, p4, p5, p6, pE3, pE4,
+		p9, p10, p11, p12, p13, p14}
+	d := HierarchicalDelaunay()
+	for _, p := range ps {
+		d.Insert(p)
+	}
+	d.Remove(pE4)
+	d.Insert(pE1)
+	d.Remove(pE3)
+	d.Insert(p15)
+	d.Insert(pE2)
+	d.Remove(pE1)
+	d.Insert(p7)
+	d.Insert(p8)
+	d.Remove(pE2)
+	ts := d.Triangles()
+	exp := []*Triangle{
+		NewTriangle(p1, p3, p4),
+		NewTriangle(p1, p4, p5),
+		NewTriangle(p1, p5, p2),
+		NewTriangle(p2, p5, p6),
+		NewTriangle(p3, p4, p8),
+		NewTriangle(p3, p8, p7),
+		NewTriangle(p4, p8, p9),
+		NewTriangle(p4, p9, p5),
+		NewTriangle(p5, p9, p10),
+		NewTriangle(p5, p10, p6),
+		NewTriangle(p6, p10, p11),
+		NewTriangle(p7, p8, p12),
+		NewTriangle(p8, p12, p13),
+		NewTriangle(p8, p13, p9),
+		NewTriangle(p9, p13, p10),
+		NewTriangle(p10, p13, p14),
+		NewTriangle(p10, p14, p15),
+		NewTriangle(p10, p15, p11),
+	}
+	got, want := len(ts), len(exp)
+	if got != want {
+		t.Errorf("got=%d delaunay triangles, want=%d", got, want)
+	}
+	for i := range ts {
+		ok := false
+		for j := range exp {
+			if ts[i].Equals(exp[j]) {
+				ok = true
+				// remove triangles that have been matched from slice,
+				// in case there are duplicate triangles.
+				exp = append(exp[:j], exp[j+1:]...)
+				break
+			}
+		}
+		if !ok {
+			t.Errorf("Triangle T%s not as expected", ts[i])
+		}
+	}
+	var (
+		nn []*Point
+		nd []float64
+	)
+	pts := []*Point{p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15}
+	for _, p := range pts {
+		n, d := p.NearestNeighbor()
+		nn = append(nn, n)
+		nd = append(nd, d)
+	}
+	expN := []*Point{p4, p5, p4, p1, p9, p11, p8, p7, p5, p15, p15, p7, p12, p15, p11}
+	expD := []float64{1.9, 2.326, 2.209, 1.9, 1.879, 2.335, 1.726, 1.726, 1.879, 1.677, 1.464, 1.965, 2.786, 1.953, 1.464}
+	got, want = len(nn), len(expN)
+	if got != want {
+		t.Errorf("got=%d nearest neighbors, want=%d", got, want)
+	}
+	for i := range nn {
+		if !nn[i].Equals(expN[i]) {
+			t.Errorf("got=N%s nearest neighbor, want=N%s", nn[i], expN[i])
+		}
+		if math.Abs(nd[i]-expD[i]) > tol {
+			t.Errorf("got=%f distance, want=%f for point P%s with neighbour N%s", nd[i], expD[i], ps[i], nn[i])
+		}
+	}
+}
+
+func benchmarkHierarchicalDelaunayRemoval(i int, b *testing.B) {
+	ps := make([]*Point, i)
+	for j := 0; j < i; j++ {
+		x := rand.Float64() * 1000
+		y := rand.Float64() * 1000
+		ps[j] = NewPoint(x, y)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		d := HierarchicalDelaunay()
+		for _, p := range ps {
+			d.Insert(p)
+		}
+		for _, p := range ps {
+			d.Remove(p)
+		}
+	}
+}
+
+func BenchmarkHierarchicalDelaunayInsertionAndRemoval50(b *testing.B) {
+	benchmarkHierarchicalDelaunayRemoval(50, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertionAndRemovall00(b *testing.B) {
+	benchmarkHierarchicalDelaunayRemoval(100, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertionAndRemoval150(b *testing.B) {
+	benchmarkHierarchicalDelaunayRemoval(150, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertionAndRemoval200(b *testing.B) {
+	benchmarkHierarchicalDelaunayRemoval(200, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertionAndRemoval250(b *testing.B) {
+	benchmarkHierarchicalDelaunayRemoval(250, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertionAndRemoval300(b *testing.B) {
+	benchmarkHierarchicalDelaunayRemoval(300, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertionAndRemoval350(b *testing.B) {
+	benchmarkHierarchicalDelaunayRemoval(350, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertionAndRemoval400(b *testing.B) {
+	benchmarkHierarchicalDelaunayRemoval(400, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertionAndRemoval450(b *testing.B) {
+	benchmarkHierarchicalDelaunayRemoval(450, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertionAndRemoval500(b *testing.B) {
+	benchmarkHierarchicalDelaunayRemoval(500, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertionAndRemoval550(b *testing.B) {
+	benchmarkHierarchicalDelaunayRemoval(550, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertionAndRemoval600(b *testing.B) {
+	benchmarkHierarchicalDelaunayRemoval(600, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertionAndRemoval650(b *testing.B) {
+	benchmarkHierarchicalDelaunayRemoval(650, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertionAndRemoval700(b *testing.B) {
+	benchmarkHierarchicalDelaunayRemoval(700, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertionAndRemoval750(b *testing.B) {
+	benchmarkHierarchicalDelaunayRemoval(750, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertionAndRemoval800(b *testing.B) {
+	benchmarkHierarchicalDelaunayRemoval(800, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertionAndRemoval850(b *testing.B) {
+	benchmarkHierarchicalDelaunayRemoval(850, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertionAndRemoval900(b *testing.B) {
+	benchmarkHierarchicalDelaunayRemoval(900, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertionAndRemoval950(b *testing.B) {
+	benchmarkHierarchicalDelaunayRemoval(950, b)
+}
+
+func BenchmarkHierarchicalDelaunayInsertionAndRemoval1000(b *testing.B) {
+	benchmarkHierarchicalDelaunayRemoval(1000, b)
+}

--- a/fastjet/internal/delaunay/point.go
+++ b/fastjet/internal/delaunay/point.go
@@ -20,6 +20,11 @@ type Point struct {
 	adjacentTriangles triangles // adjacentTriangles is a list of triangles containing the point.
 	nearest           *Point
 	dist2             float64 // dist2 is the squared distance to the nearest neighbor.
+	// id is used when points are removed. Copies of the points around the point to
+	// be removed are made. The ID is set incremental in counterclockwise order. It identifies
+	// the original. It is also used to determine if a Triangle is inside or outside the
+	// polygon formed by all those points.
+	id int
 }
 
 // NewPoint returns Point for the given x,y coordinates
@@ -109,6 +114,65 @@ func (p *Point) findNearest() {
 	// update p's nearest Neighbor
 	p.dist2 = min
 	p.nearest = newNearest
+}
+
+// surroundingPoints returns the points that surround p in counterclockwise order.
+func (p *Point) surroundingPoints() []*Point {
+	points := make([]*Point, len(p.adjacentTriangles))
+	t := p.adjacentTriangles[0]
+	// j is the index of the previous point
+	j := 1
+	// k is the index of the previous triangle
+	k := 0
+	switch {
+	case p.Equals(t.A):
+		points[0] = t.B
+		points[1] = t.C
+	case p.Equals(t.B):
+		points[0] = t.C
+		points[1] = t.A
+	case p.Equals(t.C):
+		points[0] = t.A
+		points[1] = t.B
+	default:
+		panic(fmt.Errorf("delaunay: point %v not in adjacent triangle %v", p, t))
+	}
+	for i := 0; j < len(points)-1; {
+		if i >= len(p.adjacentTriangles) {
+			panic(fmt.Errorf("delaunay: internal error with adjacent triangles for %v. Can't find counterclockwise neighbor of %v", p, points[j]))
+		}
+		// it needs to find the triangle next to k and not k again
+		if p.adjacentTriangles[i].Equals(p.adjacentTriangles[k]) {
+			i++
+			continue
+		}
+		t = p.adjacentTriangles[i]
+		switch {
+		case points[j].Equals(t.A):
+			j++
+			points[j] = t.B
+			k = i
+			// start the loop over
+			i = 0
+			continue
+		case points[j].Equals(t.B):
+			j++
+			points[j] = t.C
+			k = i
+			// start the loop over
+			i = 0
+			continue
+		case points[j].Equals(t.C):
+			j++
+			points[j] = t.A
+			k = i
+			// start the loop over
+			i = 0
+			continue
+		}
+		i++
+	}
+	return points
 }
 
 // inTriangle checks whether the point is in the triangle and whether it is on an edge.

--- a/fastjet/internal/delaunay/point_test.go
+++ b/fastjet/internal/delaunay/point_test.go
@@ -77,6 +77,23 @@ func TestFindNearest(t *testing.T) {
 	}
 }
 
+func TestSurroundingPoints(t *testing.T) {
+	p := NewPoint(0, 0)
+	points := []*Point{NewPoint(1, 0), NewPoint(0, 1), NewPoint(-1, 0), NewPoint(0, -1)}
+	triangles := []*Triangle{NewTriangle(p, points[0], points[1]), NewTriangle(p, points[1], points[2]), NewTriangle(p, points[2], points[3]), NewTriangle(p, points[3], points[0])}
+	p.adjacentTriangles = triangles
+	want := points
+	got := p.surroundingPoints()
+	if len(got) != len(want) {
+		t.Errorf("SurroundingPoints for %v, got = %d, want = %d", p, len(got), len(want))
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("SurroundingPoints for %v, got[%d] = %v, want[%d] = %v", p, i, got, i, want)
+		}
+	}
+}
+
 func TestInTriangle(t *testing.T) {
 	tests := []struct {
 		x1, y1, x2, y2, x3, y3, x, y float64


### PR DESCRIPTION
This PR implements the removal of points using the hierarchical Delaunay method.
```
BenchmarkHierarchicalDelaunayInsertionAndRemoval50-4                 100
  14990644 ns/op          251160 B/op       9868 allocs/op
BenchmarkHierarchicalDelaunayInsertionAndRemovall00-4                 50
  31802214 ns/op          519887 B/op      20575 allocs/op
BenchmarkHierarchicalDelaunayInsertionAndRemoval150-4                 30
  48335503 ns/op          789009 B/op      31358 allocs/op
BenchmarkHierarchicalDelaunayInsertionAndRemoval200-4                 20
  64054045 ns/op         1036826 B/op      41151 allocs/op
BenchmarkHierarchicalDelaunayInsertionAndRemoval250-4                 20
  85055830 ns/op         1363603 B/op      53742 allocs/op
BenchmarkHierarchicalDelaunayInsertionAndRemoval300-4                 20
 104305825 ns/op         1675167 B/op      65500 allocs/op
BenchmarkHierarchicalDelaunayInsertionAndRemoval350-4                 10
 120606840 ns/op         1938459 B/op      76320 allocs/op
BenchmarkHierarchicalDelaunayInsertionAndRemoval400-4                 10
 135409980 ns/op         2193260 B/op      85809 allocs/op
BenchmarkHierarchicalDelaunayInsertionAndRemoval450-4                 10
 154408850 ns/op         2469645 B/op      96895 allocs/op
BenchmarkHierarchicalDelaunayInsertionAndRemoval500-4                 10
 176309790 ns/op         2826494 B/op     109912 allocs/op
BenchmarkHierarchicalDelaunayInsertionAndRemoval550-4                 10
 194312990 ns/op         3118071 B/op     121538 allocs/op
BenchmarkHierarchicalDelaunayInsertionAndRemoval600-4                  5
 211415760 ns/op         3376384 B/op     131168 allocs/op
BenchmarkHierarchicalDelaunayInsertionAndRemoval650-4                  5
 227013440 ns/op         3677582 B/op     143303 allocs/op
BenchmarkHierarchicalDelaunayInsertionAndRemoval700-4                  5
 244409480 ns/op         3881249 B/op     151959 allocs/op
BenchmarkHierarchicalDelaunayInsertionAndRemoval750-4                  5
 267215280 ns/op         4234763 B/op     165574 allocs/op
BenchmarkHierarchicalDelaunayInsertionAndRemoval800-4                  5
 291017040 ns/op         4478049 B/op     175412 allocs/op
BenchmarkHierarchicalDelaunayInsertionAndRemoval850-4                  5
 299621220 ns/op         4771755 B/op     185219 allocs/op
BenchmarkHierarchicalDelaunayInsertionAndRemoval900-4                  5
 322218840 ns/op         5064040 B/op     197023 allocs/op
BenchmarkHierarchicalDelaunayInsertionAndRemoval950-4                  3
 337693266 ns/op         5316234 B/op     207380 allocs/op
BenchmarkHierarchicalDelaunayInsertionAndRemoval1000-4                 3
 362354366 ns/op         5685093 B/op     221822 allocs/op
```
![image](https://user-images.githubusercontent.com/23250770/29467272-d7308c32-840d-11e7-98d4-59894be7a43e.png)

I had to change the root point coordinates because the predicates were giving wrong results for certain constellations. 