### PR TITLE
fastjet/internal/heap: implement a min heap for pairs of jets

### DIFF
--- a/fastjet/internal/heap/doc.go
+++ b/fastjet/internal/heap/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2017 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// package heap implements a min-heap for pairs of jets.
+package heap

--- a/fastjet/internal/heap/heap.go
+++ b/fastjet/internal/heap/heap.go
@@ -1,0 +1,118 @@
+// Copyright 2017 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package heap
+
+// pair is an item in the heap. It contains the indices of the two jets to be
+// clustered and their kt distance.
+type pair struct {
+	// jeti and jetj are the indices of the jets to be recombined.
+	jeti, jetj int
+	// dij is the kt distance for the two particles.
+	dij float64
+}
+
+// Heap contains a slice of items and the last index.
+type Heap struct {
+	n     int // n is the last index of the slice
+	items []pair
+}
+
+// New returns a heap pointer.
+func New() *Heap {
+	h := &Heap{n: 0}
+	h.items = make([]pair, 1)
+	return h
+}
+
+// Push inserts two new clustering candidates and their kt distance.
+func (h *Heap) Push(jeti, jetj int, dij float64) {
+	item := pair{jeti: jeti, jetj: jetj, dij: dij}
+	h.n++
+	if h.n >= len(h.items) {
+		h.items = append(h.items, item)
+	} else {
+		h.items[h.n] = item
+	}
+	h.moveUp(h.n)
+}
+
+// Pop returns the two jets with the smallest distance.
+// It returns -1, -1, 0 if the heap is empty.
+func (h *Heap) Pop() (jeti, jetj int, dij float64) {
+	if h.n == 0 {
+		return -1, -1, 0
+	}
+	item := h.items[1]
+	h.n--
+	if h.n == 0 {
+		return item.jeti, item.jetj, item.dij
+	}
+	h.swap(1, h.n+1)
+	h.moveDown(1)
+	return item.jeti, item.jetj, item.dij
+}
+
+// IsEmpty returns whether a heap is empty.
+func (h *Heap) IsEmpty() bool {
+	return h.n == 0
+}
+
+// moveUp compares an item with its parent and moves it up if it has
+// a smaller distance. It will keep moving up until the parent's distance is smaller
+// or if it reaches the top.
+func (h *Heap) moveUp(i int) {
+	for {
+		parent := int(i / 2)
+		if parent == 0 {
+			return
+		}
+		if h.less(i, parent) {
+			h.swap(i, parent)
+			i = parent
+			continue
+		}
+		return
+	}
+}
+
+// moveDown compares an item to its children and moves it down
+// if one of the children has a smaller distance. It will keep
+// moving down until it reaches a leaf or both children have
+// a bigger distance.
+func (h *Heap) moveDown(i int) {
+	for {
+		left := 2 * i
+		if left > h.n {
+			return
+		}
+		right := 2*i + 1
+		var smallestChild int
+		switch {
+		case left == h.n:
+			smallestChild = left
+		case h.less(left, right):
+			smallestChild = left
+		default:
+			smallestChild = right
+		}
+		if h.less(smallestChild, i) {
+			h.swap(i, smallestChild)
+			i = smallestChild
+			continue
+		}
+		return
+	}
+}
+
+// less returns whether item at index i has a smaller distance
+// than the item at index j.
+func (h *Heap) less(i, j int) bool {
+	return h.items[i].dij < h.items[j].dij
+}
+
+// swap swaps the two items at the indices i and j.
+func (h *Heap) swap(i, j int) {
+	h.items[i], h.items[j] = h.items[j], h.items[i]
+}

--- a/fastjet/internal/heap/heap_test.go
+++ b/fastjet/internal/heap/heap_test.go
@@ -1,0 +1,162 @@
+// Copyright 2017 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package heap
+
+import (
+	"container/heap"
+	"math/rand"
+	"testing"
+)
+
+// FIXME B/op is higher here, than for PQ
+func BenchmarkHeap(b *testing.B) {
+	var items []*pair
+	for i := 0; i < 5000; i++ {
+		jeti := rand.Int()
+		jetj := rand.Int()
+		dij := rand.Float64()
+		items = append(items, &pair{jeti: jeti, jetj: jetj, dij: dij})
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		h := New()
+		for _, item := range items {
+			h.Push(item.jeti, item.jetj, item.dij)
+		}
+		for !h.IsEmpty() {
+			h.Pop()
+		}
+	}
+}
+
+func BenchmarkPQ(b *testing.B) {
+	var items []*pair
+	for i := 0; i < 5000; i++ {
+		jeti := rand.Int()
+		jetj := rand.Int()
+		dij := rand.Float64()
+		items = append(items, &pair{jeti: jeti, jetj: jetj, dij: dij})
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		var pq PQ
+		heap.Init(&pq)
+		for _, item := range items {
+			heap.Push(&pq, item)
+		}
+		for pq.Len() > 0 {
+			heap.Pop(&pq)
+		}
+	}
+}
+
+func TestHeapPush(t *testing.T) {
+	h := New()
+	h.Push(0, 1, 10)
+	h.Push(2, 3, 5)
+	h.Push(4, 5, 8)
+	h.Push(6, 7, 2)
+	want := []struct {
+		jeti, jetj int
+		dij        float64
+	}{
+		{-1, -1, 0},
+		{6, 7, 2},
+		{2, 3, 5},
+		{4, 5, 8},
+		{0, 1, 10},
+	}
+	got := h.items
+	if len(got) != len(want) {
+		t.Errorf("got = %d items, want = %d", len(got), len(want))
+	}
+	for i, pair := range got {
+		if i == 0 {
+			continue
+		}
+		if pair.jeti != want[i].jeti {
+			t.Errorf("h.items[%d].jeti: got = %d, want = %d", i, pair.jeti, want[i].jeti)
+		}
+		if pair.jetj != want[i].jetj {
+			t.Errorf("h.items[%d].jetj: got = %d, want = %d", i, pair.jetj, want[i].jetj)
+		}
+		if pair.dij != want[i].dij {
+			t.Errorf("h.items[%d].dij: got = %f, want = %f", i, pair.dij, want[i].dij)
+		}
+	}
+}
+
+func TestHeapPop(t *testing.T) {
+	pairs := []pair{{}, {jeti: 6, jetj: 7, dij: 2}, {jeti: 2, jetj: 3, dij: 5}, {jeti: 4, jetj: 5, dij: 8},
+		{jeti: 0, jetj: 1, dij: 10}, {jeti: 8, jetj: 9, dij: 6},
+	}
+	h := &Heap{items: pairs, n: 5}
+	want := []struct {
+		jeti, jetj int
+		dij        float64
+	}{
+		{6, 7, 2},
+		{2, 3, 5},
+		{8, 9, 6},
+		{4, 5, 8},
+		{0, 1, 10},
+	}
+	got := make([]struct {
+		jeti, jetj int
+		dij        float64
+	}, len(pairs)-1)
+	for i := 0; !h.IsEmpty(); i++ {
+		if i >= len(got) {
+			t.Fatalf("Heap with n = %d should be empty", h.n)
+		}
+		jeti, jetj, dij := h.Pop()
+		got[i].jeti = jeti
+		got[i].jetj = jetj
+		got[i].dij = dij
+	}
+	if len(got) != len(want) {
+		t.Errorf("got = %d items, want = %d", len(got), len(want))
+	}
+	for i := range got {
+		if want[i].jeti != got[i].jeti {
+			t.Errorf("got[%d].jeti = %d, want[%d].jeti = %d", i, got[i].jeti, i, want[i].jeti)
+		}
+		if want[i].jetj != got[i].jetj {
+			t.Errorf("got[%d].jetj = %d, want[%d].jetj = %d", i, got[i].jetj, i, want[i].jetj)
+		}
+		if want[i].dij != got[i].dij {
+			t.Errorf("got[%d] = %f, want[%d] = %f", i, got[i].dij, i, want[i].dij)
+		}
+	}
+}
+
+// PQ is a priority queue of pairs. It is implemented using the
+// container/heap interface.
+type PQ []*pair
+
+func (pq PQ) Len() int { return len(pq) }
+
+func (pq PQ) Less(i, j int) bool {
+	return pq[i].dij < pq[j].dij
+}
+
+func (pq PQ) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+}
+
+func (pq *PQ) Push(x interface{}) {
+	item := x.(*pair)
+	*pq = append(*pq, item)
+}
+
+func (pq *PQ) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	*pq = old[0 : n-1]
+	return item
+}


### PR DESCRIPTION
This PR implements a min heap that will be used in the delaunay clustering.