### PR TITLE
fastjet:  protect against parton-level events where pt can be zero for some partons, giving rapidity=infinity

### DIFF
--- a/fastjet/jet.go
+++ b/fastjet/jet.go
@@ -10,11 +10,11 @@ import (
 	"go-hep.org/x/hep/fmom"
 )
 
-// // Used to protect against parton-level events where pt can be zero
-// // for some partons, giving rapidity=infinity. KtJet fails in those cases.
-// const (
-// 	MaxRap = 1e5
-// )
+const (
+	// Used to protect against parton-level events where pt can be zero
+	// for some partons, giving rapidity=infinity. KtJet fails in those cases.
+	MaxRap = 1e5
+)
 
 // UserInfo holds extra user information in a Jet
 type UserInfo interface{}
@@ -47,7 +47,22 @@ func (jet *Jet) setupCache() {
 	pt := jet.Pt()
 	jet.pt2 = pt * pt
 
-	jet.rap = 0.5 * math.Log((jet.E()+jet.Pz())/(jet.E()-jet.Pz()))
+	var rap float64
+	if jet.E() == math.Abs(jet.Pz()) && jet.Pt2() == 0 {
+		rap = MaxRap + math.Abs(jet.Pz())
+		if jet.Pz() < 0 {
+			rap = -rap
+		}
+	} else {
+		m := jet.M()
+		m2 := math.Max(0, m*m) // effective mass - force non-tachyonic mass
+		e := jet.E() + math.Abs(jet.Pz())
+		rap = 0.5 * math.Log((jet.Pt2()+m2)/(e*e))
+		if jet.Pz() > 0 {
+			rap = -rap
+		}
+	}
+	jet.rap = rap
 	jet.phi = jet.PxPyPzE.Phi()
 }
 
@@ -61,22 +76,6 @@ func (jet *Jet) Phi() float64 {
 
 func (jet *Jet) Rapidity() float64 {
 	return jet.rap
-	/*
-		var rap float64
-		if jet.E() == math.Abs(jet.Pz()) && jet.Pt2() == 0 {
-			rap = MaxRap + math.Abs(jet.Pz())
-		} else {
-			m := jet.M()
-			m2 := math.Max(0, m*m) // effective mass - force non-tachyonic mass
-			e := jet.E() + math.Abs(jet.Pz())
-			rap = 0.5 * math.Log((jet.Pt2()+m2)/(e*e))
-		}
-
-		if jet.Pz() > 0 {
-			rap = -rap
-		}
-		return rap
-	*/
 }
 
 // Constituents returns the list of constituents for this jet.


### PR DESCRIPTION
Fixes go-hep/hep#97