### PR TITLE
fastjet/internal/delaunay: remove root points from updated & set ID incrementally

### DIFF
--- a/fastjet/internal/delaunay/point.go
+++ b/fastjet/internal/delaunay/point.go
@@ -15,15 +15,17 @@ import (
 //
 // It holds dynamic information about the
 // adjacent triangles, the nearest neighbor and the distance to that neighbor.
+//
+// One should use the Equal method of Point to test whether 2 points are equal.
 type Point struct {
 	x, y              float64   // x and y are the coordinates of the point.
 	adjacentTriangles triangles // adjacentTriangles is a list of triangles containing the point.
 	nearest           *Point
 	dist2             float64 // dist2 is the squared distance to the nearest neighbor.
-	// id is used when points are removed. Copies of the points around the point to
-	// be removed are made. The ID is set incremental in counterclockwise order. It identifies
-	// the original. It is also used to determine whether a Triangle is inside or outside the
-	// polygon formed by all those points.
+	// id is a unique identifier, that is assigned incrementally to a point on insertion.
+	// It is used when points are removed. Copies of the points around the point to be removed are made.
+	// The ID is set incremental in counterclockwise order. It identifies the original. It is also used
+	// to determine whether a Triangle is inside or outside the polygon formed by all those points.
 	id int
 }
 
@@ -44,6 +46,12 @@ func (p *Point) NearestNeighbor() (*Point, float64) {
 // Coordinates returns the x,y coordinates of a Point.
 func (p *Point) Coordinates() (x, y float64) {
 	return p.x, p.y
+}
+
+// ID returns the ID of the point. It is a unique identifier that is incrementally assigned
+// to a point on insertion.
+func (p *Point) ID() int {
+	return p.id
 }
 
 func (p *Point) String() string {
@@ -209,4 +217,27 @@ func (l location) String() string {
 	default:
 		panic(fmt.Errorf("delaunay: unknown location %d", int(l)))
 	}
+}
+
+type points []*Point
+
+// remove removes given points from a slice of points.
+//
+// remove will remove all occurrences of the points.
+func (ps points) remove(pts ...*Point) points {
+	out := make(points, 0, len(ps))
+	for _, p := range ps {
+		keep := true
+		for _, pt := range pts {
+			if p.Equals(pt) {
+				keep = false
+				break
+			}
+		}
+		if keep {
+			out = append(out, p)
+		}
+
+	}
+	return out
 }

--- a/fastjet/internal/delaunay/point_test.go
+++ b/fastjet/internal/delaunay/point_test.go
@@ -115,3 +115,17 @@ func TestInTriangle(t *testing.T) {
 		}
 	}
 }
+
+func TestPointsRemove(t *testing.T) {
+	pts := points{NewPoint(0, 0), NewPoint(1, 1), NewPoint(2, 2), NewPoint(0, 0), NewPoint(3, 3)}
+	want := points{pts[1], pts[2], pts[4]}
+	got := pts.remove(NewPoint(0, 0))
+	if len(got) != len(want) {
+		t.Errorf("got %d points, want %d", len(got), len(want))
+	}
+	for i := range got {
+		if !want[i].Equals(got[i]) {
+			t.Errorf("got[%d] = %v, want[%d] = %v", i, got[i], i, want[i])
+		}
+	}
+}


### PR DESCRIPTION
Added a function to remove the root points from the updatedNearestNeighbor slice from Insert and Remove.
Set the ID incrementally and added a function to access the ID, so that a jet can be mapped from a point.