### PR TITLE
cmd/{rio,root}2yoda, cmd/yoda2rio: handle gzipped YODA files

### DIFF
--- a/cmd/rio2yoda/main.go
+++ b/cmd/rio2yoda/main.go
@@ -9,6 +9,7 @@
 //
 //  $> rio2yoda file1.rio file2.rio > out.yoda
 //  $> rio2yoda -o out.yoda file1.rio file2.rio
+//  $> rio2yoda -o out.yodz file1.rio file2.rio
 //  $> rio2yoda -o out.yoda.gz file1.rio file2.rio
 package main
 
@@ -39,6 +40,7 @@ func main() {
 ex:
  $> rio2yoda file1.rio > out.yoda
  $> rio2yoda -o out.yoda file1.rio file2.rio
+ $> rio2yoda -o out.yodz file1.rio file2.rio
  $> rio2yoda -o out.yoda.gz file1.rio file2.rio
  `)
 	}
@@ -66,7 +68,7 @@ ex:
 			}
 		}()
 		out = f
-		if filepath.Ext(*oname) == ".gz" {
+		if ext := filepath.Ext(*oname); ext == ".yodz" || ext == ".gz" {
 			wz := gzip.NewWriter(f)
 			defer func() {
 				err = wz.Close()

--- a/cmd/root2yoda/main.go
+++ b/cmd/root2yoda/main.go
@@ -9,6 +9,7 @@
 //
 //  $> root2yoda file1.root file2.root > out.yoda
 //  $> root2yoda -o out.yoda file1.root file2.root
+//  $> root2yoda -o out.yodz file1.root file2.root
 //  $> root2yoda -o out.yoda.gz file1.root file2.root
 package main // import "go-hep.org/x/hep/cmd/root2yoda"
 
@@ -37,6 +38,7 @@ func main() {
 ex:
  $> root2yoda file1.root file2.root > out.yoda
  $> root2yoda -o out.yoda file1.root file2.root
+ $> root2yoda -o out.yodz file1.root file2.root
  $> root2yoda -o out.yoda.gz file1.root file2.root
 
 options:
@@ -68,7 +70,7 @@ options:
 			}
 		}()
 		out = f
-		if filepath.Ext(*oname) == ".gz" {
+		if ext := filepath.Ext(*oname); ext == ".yodz" || ext == ".gz" {
 			wz := gzip.NewWriter(f)
 			defer func() {
 				err = wz.Close()

--- a/cmd/yoda2rio/main.go
+++ b/cmd/yoda2rio/main.go
@@ -8,6 +8,7 @@
 // Example:
 //
 //  $> yoda2rio rivet.yoda >| rivet.rio
+//  $> yoda2rio rivet.yodz >| rivet.rio
 //  $> yoda2rio rivet.yoda.gz >| rivet.rio
 package main
 
@@ -35,7 +36,8 @@ func main() {
 			`Usage: yoda2rio [options] <file1.yoda> [<file2.yoda> [...]]
 
 ex:
- $> yoda2rio rivet.yoda    >| rivet.rio
+ $> yoda2rio rivet.yoda >| rivet.rio
+ $> yoda2rio rivet.yodz >| rivet.rio
  $> yoda2rio rivet.yoda.gz >| rivet.rio
 `)
 	}
@@ -67,7 +69,7 @@ func convert(w *rio.Writer, fname string) {
 	}
 	defer r.Close()
 
-	if filepath.Ext(fname) == ".gz" {
+	if ext := filepath.Ext(fname); ext == ".yodz" || ext == ".gz" {
 		rz, err := gzip.NewReader(r)
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
This CL adds support for gzipped YODA files.
If the input or output YODA file name ends with ".gz", the appropriate
gzip.Reader or gzip.Writer is inserted in the stack of readers or
writers.