### PR TITLE
rootio: update package doc, reference rootio examples

### DIFF
--- a/rootio/doc.go
+++ b/rootio/doc.go
@@ -5,10 +5,26 @@
 // Package rootio provides a pure-go read-access to ROOT files.
 // rootio might, with time, provide write-access too.
 //
-// A typical usage is as follow:
+// A typical usage is as follows:
 //
 //   f, err := rootio.Open("ntup.root")
-//   obj, err := f.Get("tree")
-//   tree := obj.(*rootio.Tree)
-//   fmt.Printf("entries= %v\n", t.Entries())
+//   if err != nil {
+//       log.Fatal(err)
+//   }
+//   defer f.Close()
+//
+//   obj, ok := f.Get("tree")
+//   if !ok {
+//       log.Fatalf("no object called %q in file %s", "tree", f.Name())
+//   }
+//   tree := obj.(rootio.Tree)
+//   fmt.Printf("entries= %v\n", tree.Entries())
+//
+// More complete examples on how to iterate over the content of a Tree can
+// be found in the examples attached to rootio.TreeScanner and rootio.Scanner:
+// https://godoc.org/go-hep.org/x/hep/rootio#pkg-examples
+//
+// Another possibility is to look at:
+// https://godoc.org/go-hep.org/x/hep/rootio/cmd/root-ls,
+// a command that inspects the content of ROOT files.
 package rootio // import "go-hep.org/x/hep/rootio"


### PR DESCRIPTION
The package doc was still refering to the old way to retrieve values
from a rootio.Directory.
Fix that and expand it a bit.

Updates go-hep/hep#112.