### PR TITLE
fastjet/internal/delaunay: implement voronoi

### DIFF
--- a/fastjet/internal/delaunay/delaunay_test.go
+++ b/fastjet/internal/delaunay/delaunay_test.go
@@ -639,3 +639,71 @@ func BenchmarkHierarchicalDelaunayInsertionAndRemoval950(b *testing.B) {
 func BenchmarkHierarchicalDelaunayInsertionAndRemoval1000(b *testing.B) {
 	benchmarkHierarchicalDelaunayRemoval(1000, b)
 }
+
+func TestVoronoiCell(t *testing.T) {
+	p := NewPoint(0, 0)
+	p1 := NewPoint(2, 0)
+	p2 := NewPoint(0, 3)
+	p3 := NewPoint(-2, 0)
+	p4 := NewPoint(0, -2)
+	t1 := NewTriangle(p, p1, p2)
+	t2 := NewTriangle(NewPoint(-4, 1), NewPoint(-4, 0), p3)
+	t3 := NewTriangle(p, p2, p3)
+	t4 := NewTriangle(p3, p4, p)
+	t5 := NewTriangle(p4, p1, p)
+	t6 := NewTriangle(p1, p2, NewPoint(5, 5))
+	p.adjacentTriangles = triangles{t1, t3, t4, t5}
+	p1.adjacentTriangles = triangles{t1, t5, t6}
+	p2.adjacentTriangles = triangles{t1, t3, t6}
+	p3.adjacentTriangles = triangles{t2, t3}
+	p4.adjacentTriangles = triangles{t4, t5}
+	d := &Delaunay{root: NewTriangle(NewPoint(-100, -100), NewPoint(100, -100), NewPoint(0, 100))}
+	wantPoints := []*Point{NewPoint(1, 1.5), NewPoint(1, -1), NewPoint(-1, -1), NewPoint(-1, 1.5)}
+	wantArea := 5.0
+	gotPoints, gotArea := d.VoronoiCell(p)
+	if wantArea != gotArea {
+		t.Errorf("area got = %f, want = %f", gotArea, wantArea)
+	}
+	if len(wantPoints) != len(gotPoints) {
+		t.Fatalf("got = %d points, want = %d", len(gotPoints), len(wantPoints))
+	}
+	for i, got := range gotPoints {
+		if !got.Equals(wantPoints[i]) {
+			t.Errorf("vornoi point got = %v, want = %v", got, wantPoints[i])
+		}
+	}
+}
+
+func TestVoronoiCellBorder(t *testing.T) {
+	p := NewPoint(0, 0)
+	p1 := NewPoint(2, 0)
+	p2 := NewPoint(0, 3)
+	p3 := NewPoint(-2, 0)
+	p4 := NewPoint(0, -2)
+	t1 := NewTriangle(p, p1, p2)
+	t2 := NewTriangle(NewPoint(-4, 1), NewPoint(-4, 0), p3)
+	t3 := NewTriangle(p, p2, p3)
+	t4 := NewTriangle(p3, p4, p)
+	t5 := NewTriangle(p4, p1, p)
+	t6 := NewTriangle(p1, p2, NewPoint(5, 5))
+	p.adjacentTriangles = triangles{t1, t3, t4, t5}
+	p1.adjacentTriangles = triangles{t1, t5, t6}
+	p2.adjacentTriangles = triangles{t1, t3, t6}
+	p3.adjacentTriangles = triangles{t2, t3}
+	p4.adjacentTriangles = triangles{t4, t5}
+	d := &Delaunay{root: NewTriangle(NewPoint(-100, 100), NewPoint(100, 100), p4)}
+	wantPoints := []*Point{NewPoint(-1, -1), NewPoint(-1, 1.5), NewPoint(1, 1.5), NewPoint(1, -1)}
+	wantArea := math.Inf(1)
+	gotPoints, gotArea := d.VoronoiCell(p)
+	if wantArea != gotArea {
+		t.Errorf("area got = %f, want = %f", gotArea, wantArea)
+	}
+	if len(wantPoints) != len(gotPoints) {
+		t.Fatalf("got = %d points, want = %d", len(gotPoints), len(wantPoints))
+	}
+	for i, got := range gotPoints {
+		if !got.Equals(wantPoints[i]) {
+			t.Errorf("vornoi point got = %v, want = %v", got, wantPoints[i])
+		}
+	}
+}

--- a/fastjet/internal/delaunay/point.go
+++ b/fastjet/internal/delaunay/point.go
@@ -241,6 +241,31 @@ func (p *Point) surroundingPoints() []*Point {
 	return points
 }
 
+// findClockwiseTriangle finds the next triangle in clockwise order.
+func (p *Point) findClockwiseTriangle(t *Triangle) *Triangle {
+	// points in a triangle are ordered counter clockwise
+	var p2 *Point
+	// find point counterclockwise of p
+	switch {
+	case p.Equals(t.A):
+		p2 = t.B
+	case p.Equals(t.B):
+		p2 = t.C
+	case p.Equals(t.C):
+		p2 = t.A
+	default:
+		panic(fmt.Errorf("delaunay: can't find Point %v in Triangle %v", p, t))
+	}
+	for _, t1 := range p.adjacentTriangles {
+		for _, t2 := range p2.adjacentTriangles {
+			if !t1.Equals(t) && t1.Equals(t2) {
+				return t1
+			}
+		}
+	}
+	panic(fmt.Errorf("delaunay: no clockwise neighbor of Triangle %v around Point %v", t, p))
+}
+
 // inTriangle checks whether the point is in the triangle and whether it is on an edge.
 func (p *Point) inTriangle(t *Triangle) location {
 	o1 := predicates.Orientation(t.A.x, t.A.y, t.B.x, t.B.y, p.x, p.y)
@@ -298,4 +323,16 @@ func (ps points) remove(pts ...*Point) points {
 
 	}
 	return out
+}
+
+// polyArea finds the area of an irregular polygon.
+// The points need to be in clockwise order.
+func (points points) polyArea() float64 {
+	var area float64
+	j := len(points) - 1
+	for i := 0; i < len(points); i++ {
+		area += (points[j].x + points[i].x) * (points[j].y - points[i].y)
+		j = i
+	}
+	return area * 0.5
 }

--- a/fastjet/internal/delaunay/point_test.go
+++ b/fastjet/internal/delaunay/point_test.go
@@ -196,3 +196,52 @@ func TestPointsRemove(t *testing.T) {
 		}
 	}
 }
+
+func TestPolyArea(t *testing.T) {
+	tests := []struct {
+		points points
+		want   float64
+	}{
+		{points{NewPoint(0, 0), NewPoint(0, 1), NewPoint(1, 1), NewPoint(1, 0)}, 1},
+		{points{NewPoint(0, 2), NewPoint(-1, 4), NewPoint(4, 5), NewPoint(5, -1), NewPoint(-2, 0)}, 27},
+	}
+	for i, test := range tests {
+		got := test.points.polyArea()
+		if !floats.EqualWithinAbs(got, test.want, tol) {
+			t.Errorf("test %d: got = %f, want = %f", i, got, test.want)
+		}
+	}
+}
+
+func TestFindClockwiseTriangle(t *testing.T) {
+	p := NewPoint(0, 0)
+	p1 := NewPoint(2, 0)
+	p2 := NewPoint(0, 3)
+	p3 := NewPoint(-2, 0)
+	p4 := NewPoint(0, -2)
+	t1 := NewTriangle(p, p1, p2)
+	t2 := NewTriangle(NewPoint(-4, 1), NewPoint(-4, 0), p3)
+	t3 := NewTriangle(p, p2, p3)
+	t4 := NewTriangle(p3, p4, p)
+	t5 := NewTriangle(p4, p1, p)
+	t6 := NewTriangle(p1, p2, NewPoint(5, 5))
+	p.adjacentTriangles = triangles{t1, t3, t4, t5}
+	p1.adjacentTriangles = triangles{t1, t5, t6}
+	p2.adjacentTriangles = triangles{t1, t3, t6}
+	p3.adjacentTriangles = triangles{t2, t3}
+	p4.adjacentTriangles = triangles{t4, t5}
+	want := []*Triangle{t1, t5, t4, t3}
+	got := make([]*Triangle, len(p.adjacentTriangles))
+	got[0] = p.adjacentTriangles[0]
+	for i := 1; i < len(got); i++ {
+		got[i] = p.findClockwiseTriangle(got[i-1])
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got = %d triangles, want = %d", len(got), len(want))
+	}
+	for i := range got {
+		if !got[i].Equals(want[i]) {
+			t.Errorf("got[%d] = %v, want[%d] = %v", i, got[i], i, want[i])
+		}
+	}
+}

--- a/fastjet/internal/delaunay/triangle_test.go
+++ b/fastjet/internal/delaunay/triangle_test.go
@@ -6,6 +6,8 @@ package delaunay
 
 import (
 	"testing"
+
+	"gonum.org/v1/gonum/floats"
 )
 
 func TestTriangleEquals(t *testing.T) {
@@ -100,6 +102,25 @@ func TestTriangleRemove(t *testing.T) {
 	for i := range got {
 		if !got[i].Equals(want[i]) {
 			t.Errorf("After removing triangle nearest neighbor of points[%d]=%v, got = %v, want = %v", i, points[i], got[i], want[i])
+		}
+	}
+}
+
+func TestTriangleCircumcenter(t *testing.T) {
+	tests := []struct {
+		t     *Triangle
+		wantX float64
+		wantY float64
+	}{
+		{NewTriangle(NewPoint(0, 0), NewPoint(2, 0), NewPoint(0, 2)), 1, 1},
+		{NewTriangle(NewPoint(-1, 4), NewPoint(3, 8), NewPoint(4, 12)), -5.1667, 12.1667},
+		{NewTriangle(NewPoint(6, 9), NewPoint(8, 3), NewPoint(5, 15)), 44.5, 18.5},
+		{NewTriangle(NewPoint(2, 8), NewPoint(3, 7), NewPoint(3, 8)), 2.5, 7.5},
+	}
+	for _, test := range tests {
+		gotX, gotY := test.t.circumcenter()
+		if !floats.EqualWithinAbs(gotX, test.wantX, tol) || !floats.EqualWithinAbs(gotY, test.wantY, tol) {
+			t.Errorf("Circumcenter of %v, got = (%f,%f), want = (%f,%f)", test.t, gotX, gotY, test.wantX, test.wantY)
 		}
 	}
 }


### PR DESCRIPTION
This PR adds several functions to compute the Voronoi Diagram.

To handle the issue #111 I initially started implementing it where Voronoi points on the outside connect to its neighbor. But then after thinking about it more, I changed it to connect to the Circumcenter of the adjacent root triangle, which is just a dummy triangle. Those points are moved to the first and last position in the slice so that they are easy to identify. They might be useful to get a direction of where the line goes towards.  