### PR TITLE
all, rootio: make Directory.Get return an error instead of a boolean

### DIFF
--- a/cmd/root2npy/main.go
+++ b/cmd/root2npy/main.go
@@ -159,9 +159,9 @@ func main() {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get(*tname)
-	if !ok {
-		log.Fatalf("no object named %q in file %q", *tname, *fname)
+	obj, err := f.Get(*tname)
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	tree, ok := obj.(rootio.Tree)

--- a/hbook/rootcnv/root_test.go
+++ b/hbook/rootcnv/root_test.go
@@ -23,9 +23,9 @@ func ExampleH1D() {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("h1d")
-	if !ok {
-		log.Fatalf("no such histo %q\n", "h1d")
+	obj, err := f.Get("h1d")
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	root := obj.(*rootio.H1D)
@@ -53,9 +53,9 @@ func ExampleH2D() {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("h2d")
-	if !ok {
-		log.Fatalf("no such histo %q\n", "h2d")
+	obj, err := f.Get("h2d")
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	root := obj.(*rootio.H2D)
@@ -89,9 +89,9 @@ func ExampleS2D() {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tgae")
-	if !ok {
-		log.Fatalf("no such graph %q\n", "tgae")
+	obj, err := f.Get("tgae")
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	root := obj.(rootio.GraphErrors)
@@ -243,9 +243,9 @@ END YODA_HISTO1D
 `),
 		},
 	} {
-		obj, ok := f.Get(test.name)
-		if !ok {
-			t.Errorf("%s: no key %q", test.name, test.name)
+		obj, err := f.Get(test.name)
+		if err != nil {
+			t.Errorf("%s: error: %v", test.name, err)
 			continue
 		}
 		rhisto := obj.(yodacnv.Marshaler)
@@ -336,9 +336,9 @@ END YODA_HISTO2D
 `),
 		},
 	} {
-		obj, ok := f.Get(test.name)
-		if !ok {
-			t.Errorf("%s: no key %q", test.name, test.name)
+		obj, err := f.Get(test.name)
+		if err != nil {
+			t.Errorf("%s: error: %v", test.name, err)
 			continue
 		}
 		rhisto := obj.(yodacnv.Marshaler)

--- a/rootio/cmd/root-gen-datareader/main.go
+++ b/rootio/cmd/root-gen-datareader/main.go
@@ -94,9 +94,9 @@ func main() {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get(*treeName)
-	if !ok {
-		log.Fatalf("no tree %q", *treeName)
+	obj, err := f.Get(*treeName)
+	if err != nil {
+		log.Fatal(err)
 	}
 	tree := obj.(rootio.Tree)
 	printf("entries: %v\n", tree.Entries())

--- a/rootio/cmd/root-srv/server/plots.go
+++ b/rootio/cmd/root-srv/server/plots.go
@@ -6,7 +6,6 @@ package server
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"image/color"
 	"log"
@@ -23,12 +22,10 @@ import (
 	"go-hep.org/x/hep/rootio"
 )
 
-var errNotExist = errors.New("server: object does not exist")
-
 func walk(f rootio.Directory, path []string) (rootio.Object, error) {
-	o, ok := f.Get(path[0])
-	if !ok {
-		return nil, errNotExist
+	o, err := f.Get(path[0])
+	if err != nil {
+		return nil, err
 	}
 	if dir, ok := o.(rootio.Directory); ok {
 		return walk(dir, path[1:])

--- a/rootio/dir.go
+++ b/rootio/dir.go
@@ -167,21 +167,21 @@ func (dir *tdirectory) Title() string {
 //     foo   : get object named foo in memory
 //             if object is not in memory, try with highest cycle from file
 //     foo;1 : get cycle 1 of foo on file
-func (dir *tdirectory) Get(namecycle string) (Object, bool) {
+func (dir *tdirectory) Get(namecycle string) (Object, error) {
 	name, cycle := decodeNameCycle(namecycle)
 	for i := range dir.keys {
 		k := &dir.keys[i]
 		if k.Name() == name {
 			if cycle != 9999 {
 				if k.cycle == cycle {
-					return k.Value().(Object), true
+					return k.Value().(Object), nil
 				}
 				continue
 			}
-			return k.Value().(Object), true
+			return k.Value().(Object), nil
 		}
 	}
-	return nil, false
+	return nil, noKeyError{key: namecycle, obj: dir}
 }
 
 func (dir *tdirectory) Keys() []Key {

--- a/rootio/doc.go
+++ b/rootio/doc.go
@@ -13,9 +13,9 @@
 //   }
 //   defer f.Close()
 //
-//   obj, ok := f.Get("tree")
-//   if !ok {
-//       log.Fatalf("no object called %q in file %s", "tree", f.Name())
+//   obj, err := f.Get("tree")
+//   if err != nil {
+//       log.Fatal(err)
 //   }
 //   tree := obj.(rootio.Tree)
 //   fmt.Printf("entries= %v\n", tree.Entries())

--- a/rootio/file.go
+++ b/rootio/file.go
@@ -319,7 +319,7 @@ func (f *File) StreamerInfo() []StreamerInfo {
 //     foo   : get object named foo in memory
 //             if object is not in memory, try with highest cycle from file
 //     foo;1 : get cycle 1 of foo on file
-func (f *File) Get(namecycle string) (Object, bool) {
+func (f *File) Get(namecycle string) (Object, error) {
 	return f.dir.Get(namecycle)
 }
 

--- a/rootio/file_test.go
+++ b/rootio/file_test.go
@@ -42,9 +42,9 @@ func TestFileDirectory(t *testing.T) {
 		{"tree_nope;1", false},
 		{"tree_nope;9999", false},
 	} {
-		_, ok := f.Get(table.name)
-		if ok != table.want {
-			t.Fatalf("%s: got key (%v). want=%v", table.name, ok, table.want)
+		_, err := f.Get(table.name)
+		if (err == nil) != table.want {
+			t.Fatalf("%s: got key (err=%v). want=%v", table.name, err, table.want)
 		}
 	}
 
@@ -55,9 +55,9 @@ func TestFileDirectory(t *testing.T) {
 		{"tree", "TTree"},
 		{"tree;1", "TTree"},
 	} {
-		k, ok := f.Get(table.name)
-		if !ok {
-			t.Fatalf("%s: expected key to exist! (got %v)", table.name, ok)
+		k, err := f.Get(table.name)
+		if err != nil {
+			t.Fatalf("%s: expected key to exist! (got %v)", table.name, err)
 		}
 
 		if k.Class() != table.want {
@@ -72,9 +72,9 @@ func TestFileDirectory(t *testing.T) {
 		{"tree", "tree"},
 		{"tree;1", "tree"},
 	} {
-		o, ok := f.Get(table.name)
-		if !ok {
-			t.Fatalf("%s: expected key to exist! (got %v)", table.name, ok)
+		o, err := f.Get(table.name)
+		if err != nil {
+			t.Fatalf("%s: expected key to exist! (got %v)", table.name, err)
 		}
 
 		k := o.(Named)
@@ -90,9 +90,9 @@ func TestFileDirectory(t *testing.T) {
 		{"tree", "my tree title"},
 		{"tree;1", "my tree title"},
 	} {
-		o, ok := f.Get(table.name)
-		if !ok {
-			t.Fatalf("%s: expected key to exist! (got %v)", table.name, ok)
+		o, err := f.Get(table.name)
+		if err != nil {
+			t.Fatalf("%s: expected key to exist! (got %v)", table.name, err)
 		}
 
 		k := o.(Named)

--- a/rootio/graph_test.go
+++ b/rootio/graph_test.go
@@ -19,9 +19,9 @@ func ExampleGraph() {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tg")
-	if !ok {
-		log.Fatalf("could not get 'tg'")
+	obj, err := f.Get("tg")
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	g := obj.(rootio.Graph)
@@ -50,9 +50,9 @@ func ExampleGraphErrors() {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tge")
-	if !ok {
-		log.Fatalf("could not get 'tge'")
+	obj, err := f.Get("tge")
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	g := obj.(rootio.GraphErrors)
@@ -83,9 +83,9 @@ func ExampleGraphErrors_asymmErrors() {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tgae")
-	if !ok {
-		log.Fatalf("could not get 'tgae'")
+	obj, err := f.Get("tgae")
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	g := obj.(rootio.GraphErrors)
@@ -116,9 +116,9 @@ func TestGraph(t *testing.T) {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tg")
-	if !ok {
-		t.Fatalf("could not get 'tg'")
+	obj, err := f.Get("tg")
+	if err != nil {
+		t.Fatal(err)
 	}
 	g, ok := obj.(rootio.Graph)
 	if !ok {
@@ -147,9 +147,9 @@ func TestGraphErrors(t *testing.T) {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tge")
-	if !ok {
-		t.Fatalf("could not get 'tge'")
+	obj, err := f.Get("tge")
+	if err != nil {
+		t.Fatal(err)
 	}
 	g, ok := obj.(rootio.GraphErrors)
 	if !ok {
@@ -192,9 +192,9 @@ func TestGraphAsymmErrors(t *testing.T) {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tgae")
-	if !ok {
-		t.Fatalf("could not get 'tgae'")
+	obj, err := f.Get("tgae")
+	if err != nil {
+		t.Fatal(err)
 	}
 	g, ok := obj.(rootio.GraphErrors)
 	if !ok {

--- a/rootio/key.go
+++ b/rootio/key.go
@@ -12,6 +12,16 @@ import (
 	"time"
 )
 
+// noKeyError is the error returned when a rootio.Key could not be found.
+type noKeyError struct {
+	key string
+	obj Named
+}
+
+func (err noKeyError) Error() string {
+	return fmt.Sprintf("rootio: %s: could not find key %q", err.obj.Name(), err.key)
+}
+
 // Key is a key (a label) in a ROOT file
 //
 //  The Key class includes functions to book space on a file,

--- a/rootio/rootio.go
+++ b/rootio/rootio.go
@@ -113,7 +113,7 @@ type Directory interface {
 	//     foo   : get object named foo in memory
 	//             if object is not in memory, try with highest cycle from file
 	//     foo;1 : get cycle 1 of foo on file
-	Get(namecycle string) (Object, bool)
+	Get(namecycle string) (Object, error)
 	Keys() []Key
 }
 

--- a/rootio/scanner_example_test.go
+++ b/rootio/scanner_example_test.go
@@ -22,9 +22,9 @@ func ExampleTreeScanner() {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tree")
-	if !ok {
-		log.Fatalf("no object %q in file %q", "tree", f.Name())
+	obj, err := f.Get("tree")
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	tree := obj.(rootio.Tree)
@@ -84,9 +84,9 @@ func ExampleTreeScanner_withVars() {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tree")
-	if !ok {
-		log.Fatalf("no object %q in file %q", "tree", f.Name())
+	obj, err := f.Get("tree")
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	tree := obj.(rootio.Tree)
@@ -156,9 +156,9 @@ func ExampleScanner_withStruct() {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tree")
-	if !ok {
-		log.Fatalf("no object %q in file %q", "tree", f.Name())
+	obj, err := f.Get("tree")
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	tree := obj.(rootio.Tree)
@@ -218,9 +218,9 @@ func ExampleScanner_withVars() {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tree")
-	if !ok {
-		log.Fatalf("no object %q in file %q", "tree", f.Name())
+	obj, err := f.Get("tree")
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	tree := obj.(rootio.Tree)

--- a/rootio/scanner_test.go
+++ b/rootio/scanner_test.go
@@ -41,9 +41,9 @@ func TestTreeScannerStruct(t *testing.T) {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tree")
-	if !ok {
-		t.Fatalf("could not retrieve tree [tree]")
+	obj, err := f.Get("tree")
+	if err != nil {
+		t.Fatal(err)
 	}
 	tree := obj.(Tree)
 
@@ -118,9 +118,9 @@ func TestScannerStruct(t *testing.T) {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tree")
-	if !ok {
-		t.Fatalf("could not retrieve tree [tree]")
+	obj, err := f.Get("tree")
+	if err != nil {
+		t.Fatal(err)
 	}
 	tree := obj.(Tree)
 
@@ -196,9 +196,9 @@ func TestScannerVars(t *testing.T) {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tree")
-	if !ok {
-		t.Fatalf("could not retrieve tree [tree]")
+	obj, err := f.Get("tree")
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	tree := obj.(Tree)
@@ -286,9 +286,9 @@ func TestTreeScannerVarsMultipleTimes(t *testing.T) {
 		t.Skip(err)
 	}
 
-	obj, ok := f.Get("mini")
-	if !ok {
-		t.Fatalf("no mini")
+	obj, err := f.Get("mini")
+	if err != nil {
+		t.Fatal(err)
 	}
 	tree := obj.(Tree)
 
@@ -320,9 +320,9 @@ func TestTreeScannerVars(t *testing.T) {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tree")
-	if !ok {
-		t.Fatalf("could not retrieve tree [tree]")
+	obj, err := f.Get("tree")
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	tree := obj.(Tree)
@@ -431,9 +431,9 @@ func TestScannerVarsMultipleTimes(t *testing.T) {
 		t.Skip(err)
 	}
 
-	obj, ok := f.Get("mini")
-	if !ok {
-		t.Fatalf("no mini")
+	obj, err := f.Get("mini")
+	if err != nil {
+		t.Fatal(err)
 	}
 	tree := obj.(Tree)
 
@@ -465,9 +465,9 @@ func TestTreeScannerStructWithCounterLeaf(t *testing.T) {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tree")
-	if !ok {
-		t.Fatalf("could not retrieve tree [tree]")
+	obj, err := f.Get("tree")
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	tree := obj.(Tree)
@@ -514,9 +514,9 @@ func TestScannerStructWithCounterLeaf(t *testing.T) {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tree")
-	if !ok {
-		t.Fatalf("could not retrieve tree [tree]")
+	obj, err := f.Get("tree")
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	tree := obj.(Tree)
@@ -563,9 +563,9 @@ func TestTreeScannerVarsWithCounterLeaf(t *testing.T) {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tree")
-	if !ok {
-		t.Fatalf("could not retrieve tree [tree]")
+	obj, err := f.Get("tree")
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	tree := obj.(Tree)
@@ -608,9 +608,9 @@ func TestScannerVarsWithCounterLeaf(t *testing.T) {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tree")
-	if !ok {
-		t.Fatalf("could not retrieve tree [tree]")
+	obj, err := f.Get("tree")
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	tree := obj.(Tree)
@@ -653,9 +653,9 @@ func BenchmarkTreeScannerStruct(b *testing.B) {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tree")
-	if !ok {
-		b.Fatalf("could not retrieve tree [tree]")
+	obj, err := f.Get("tree")
+	if err != nil {
+		b.Fatal(err)
 	}
 	tree := obj.(Tree)
 
@@ -691,9 +691,9 @@ func BenchmarkScannerStruct(b *testing.B) {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tree")
-	if !ok {
-		b.Fatalf("could not retrieve tree [tree]")
+	obj, err := f.Get("tree")
+	if err != nil {
+		b.Fatal(err)
 	}
 	tree := obj.(Tree)
 
@@ -729,9 +729,9 @@ func BenchmarkTreeScannerVars(b *testing.B) {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tree")
-	if !ok {
-		b.Fatalf("could not retrieve tree [tree]")
+	obj, err := f.Get("tree")
+	if err != nil {
+		b.Fatal(err)
 	}
 
 	tree := obj.(Tree)
@@ -769,9 +769,9 @@ func BenchmarkScannerVars(b *testing.B) {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tree")
-	if !ok {
-		b.Fatalf("could not retrieve tree [tree]")
+	obj, err := f.Get("tree")
+	if err != nil {
+		b.Fatal(err)
 	}
 
 	tree := obj.(Tree)
@@ -808,9 +808,9 @@ func BenchmarkTreeScannerVarsBigFileScalar(b *testing.B) {
 		b.Skip(err)
 	}
 
-	obj, ok := f.Get("mini")
-	if !ok {
-		b.Fatalf("no mini")
+	obj, err := f.Get("mini")
+	if err != nil {
+		b.Fatal(err)
 	}
 	tree := obj.(Tree)
 
@@ -842,9 +842,9 @@ func BenchmarkScannerVarsBigFileScalar(b *testing.B) {
 		b.Skip(err)
 	}
 
-	obj, ok := f.Get("mini")
-	if !ok {
-		b.Fatalf("no mini")
+	obj, err := f.Get("mini")
+	if err != nil {
+		b.Fatal(err)
 	}
 	tree := obj.(Tree)
 
@@ -876,9 +876,9 @@ func BenchmarkTreeScannerVarsBigFileSlice(b *testing.B) {
 		b.Skip(err)
 	}
 
-	obj, ok := f.Get("mini")
-	if !ok {
-		b.Fatalf("no mini")
+	obj, err := f.Get("mini")
+	if err != nil {
+		b.Fatal(err)
 	}
 	tree := obj.(Tree)
 
@@ -910,9 +910,9 @@ func BenchmarkScannerVarsBigFileSlice(b *testing.B) {
 		b.Skip(err)
 	}
 
-	obj, ok := f.Get("mini")
-	if !ok {
-		b.Fatalf("no mini")
+	obj, err := f.Get("mini")
+	if err != nil {
+		b.Fatal(err)
 	}
 	tree := obj.(Tree)
 

--- a/rootio/tree_test.go
+++ b/rootio/tree_test.go
@@ -18,9 +18,9 @@ func TestFlatTree(t *testing.T) {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tree")
-	if !ok {
-		t.Fatalf("could not retrieve tree [tree]")
+	obj, err := f.Get("tree")
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	tree := obj.(Tree)
@@ -206,9 +206,9 @@ func testEventTree(t *testing.T, name, fname string) {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tree")
-	if !ok {
-		t.Errorf("%s: could not retrieve tree [tree]", name)
+	obj, err := f.Get("tree")
+	if err != nil {
+		t.Errorf("%s: %v", name, err)
 		return
 	}
 
@@ -289,9 +289,9 @@ func TestSimpleTree(t *testing.T) {
 	}
 	defer f.Close()
 
-	obj, ok := f.Get("tree")
-	if !ok {
-		t.Fatalf("could not retrieve tree [tree]")
+	obj, err := f.Get("tree")
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	tree := obj.(Tree)


### PR DESCRIPTION
This CL modifies:
 `Directory.Get(namecycle string) (Object, bool)`

to:
 `Directory.Get(namecycle string) (Object, error)`

this allows to capture the context at the call site and thus reduces
code duplication when handling the error.