### PR TITLE
rootio, hbook/rootcnv: introduce H1 and H2 interfaces

### DIFF
--- a/hbook/rootcnv/root.go
+++ b/hbook/rootcnv/root.go
@@ -12,8 +12,8 @@ import (
 )
 
 // H1D creates a new H1D from a TH1x.
-func H1D(r yodacnv.Marshaler) (*hbook.H1D, error) {
-	raw, err := r.MarshalYODA()
+func H1D(h1 rootio.H1) (*hbook.H1D, error) {
+	raw, err := h1.(yodacnv.Marshaler).MarshalYODA()
 	if err != nil {
 		return nil, err
 	}
@@ -26,8 +26,8 @@ func H1D(r yodacnv.Marshaler) (*hbook.H1D, error) {
 }
 
 // H2D creates a new H2D from a TH2x.
-func H2D(r yodacnv.Marshaler) (*hbook.H2D, error) {
-	raw, err := r.MarshalYODA()
+func H2D(h2 rootio.H2) (*hbook.H2D, error) {
+	raw, err := h2.(yodacnv.Marshaler).MarshalYODA()
 	if err != nil {
 		return nil, err
 	}

--- a/hbook/rootcnv/root_test.go
+++ b/hbook/rootcnv/root_test.go
@@ -248,7 +248,7 @@ END YODA_HISTO1D
 			t.Errorf("%s: error: %v", test.name, err)
 			continue
 		}
-		rhisto := obj.(yodacnv.Marshaler)
+		rhisto := obj.(rootio.H1)
 
 		h, err := rootcnv.H1D(rhisto)
 		if err != nil {
@@ -341,7 +341,7 @@ END YODA_HISTO2D
 			t.Errorf("%s: error: %v", test.name, err)
 			continue
 		}
-		rhisto := obj.(yodacnv.Marshaler)
+		rhisto := obj.(rootio.H2)
 
 		h, err := rootcnv.H2D(rhisto)
 		if err != nil {

--- a/rootio/cmd/root-print/main.go
+++ b/rootio/cmd/root-print/main.go
@@ -33,7 +33,6 @@ import (
 	"strings"
 
 	"go-hep.org/x/hep/hbook/rootcnv"
-	"go-hep.org/x/hep/hbook/yodacnv"
 	"go-hep.org/x/hep/hplot"
 	"go-hep.org/x/hep/rootio"
 	"gonum.org/v1/plot/plotutil"
@@ -163,8 +162,8 @@ func printObject(f *rootio.File, obj rootio.Object) error {
 	}
 
 	switch o := obj.(type) {
-	case *rootio.H1D, *rootio.H1F, *rootio.H1I:
-		h, err := rootcnv.H1D(o.(yodacnv.Marshaler))
+	case rootio.H1:
+		h, err := rootcnv.H1D(o)
 		if err != nil {
 			return err
 		}
@@ -179,8 +178,8 @@ func printObject(f *rootio.File, obj rootio.Object) error {
 
 		p.Add(hh)
 
-	case *rootio.H2D, *rootio.H2F, *rootio.H2I:
-		h, err := rootcnv.H2D(o.(yodacnv.Marshaler))
+	case rootio.H2:
+		h, err := rootcnv.H2D(o)
 		if err != nil {
 			return err
 		}
@@ -231,10 +230,10 @@ func printObject(f *rootio.File, obj rootio.Object) error {
 
 func filter(obj rootio.Object) bool {
 	switch obj.(type) {
-	case *rootio.H1D, *rootio.H1F, *rootio.H1I:
+	case rootio.H1:
 		return true
 
-	case *rootio.H2D, *rootio.H2F, *rootio.H2I:
+	case rootio.H2:
 		return true
 
 	case rootio.Graph, rootio.GraphErrors:

--- a/rootio/cmd/root-srv/server/plots.go
+++ b/rootio/cmd/root-srv/server/plots.go
@@ -17,7 +17,6 @@ import (
 
 	"go-hep.org/x/hep/hbook"
 	"go-hep.org/x/hep/hbook/rootcnv"
-	"go-hep.org/x/hep/hbook/yodacnv"
 	"go-hep.org/x/hep/hplot"
 	"go-hep.org/x/hep/rootio"
 )
@@ -56,7 +55,7 @@ func (srv *server) plotH1Handle(w http.ResponseWriter, r *http.Request) error {
 		return fmt.Errorf("could not find %q in file %q: %v", filepath.Join(toks[1:]...), fname, err)
 	}
 
-	robj, ok := obj.(yodacnv.Marshaler)
+	robj, ok := obj.(rootio.H1)
 	if !ok {
 		return fmt.Errorf("object %q could not be converted to hbook.H1D", toks[1])
 	}
@@ -69,7 +68,7 @@ func (srv *server) plotH1Handle(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return err
 	}
-	plot.Title.Text = obj.(rootio.Named).Title()
+	plot.Title.Text = robj.Title()
 
 	h, err := hplot.NewH1D(h1d)
 	if err != nil {
@@ -106,7 +105,7 @@ func (srv *server) plotH2Handle(w http.ResponseWriter, r *http.Request) error {
 		return fmt.Errorf("could not find %q in file %q: %v", filepath.Join(toks[1:]...), fname, err)
 	}
 
-	robj, ok := obj.(yodacnv.Marshaler)
+	robj, ok := obj.(rootio.H2)
 	if !ok {
 		return fmt.Errorf("object %q could not be converted to hbook.H1D", toks[1])
 	}
@@ -119,7 +118,7 @@ func (srv *server) plotH2Handle(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return err
 	}
-	plot.Title.Text = obj.(rootio.Named).Title()
+	plot.Title.Text = robj.Title()
 
 	h := hplot.NewH2D(h2d, nil)
 	h.Infos.Style = hplot.HInfoSummary

--- a/rootio/gen-code.go
+++ b/rootio/gen-code.go
@@ -524,6 +524,8 @@ type {{.Name}} struct {
 	arr {{.Type}}
 }
 
+func (*{{.Name}}) isH1() {}
+
 // Class returns the ROOT class name.
 func (*{{.Name}}) Class() string {
 	return "T{{.Name}}"
@@ -719,9 +721,12 @@ func init() {
 	Factory.add("*rootio.{{.Name}}", f)
 }
 
-var _ Object = (*{{.Name}})(nil)
-var _ Named = (*{{.Name}})(nil)
-var _ ROOTUnmarshaler = (*{{.Name}})(nil)
+var (
+	_ Object          = (*{{.Name}})(nil)
+	_ Named           = (*{{.Name}})(nil)
+	_ H1              = (*{{.Name}})(nil)
+	_ ROOTUnmarshaler = (*{{.Name}})(nil)
+)
 `
 
 const h2Tmpl = `// {{.Name}} implements ROOT T{{.Name}}
@@ -729,6 +734,8 @@ type {{.Name}} struct {
 	th2
 	arr {{.Type}}
 }
+
+func (*{{.Name}}) isH2() {}
 
 // Class returns the ROOT class name.
 func (*{{.Name}}) Class() string {
@@ -1007,7 +1014,10 @@ func init() {
 	Factory.add("*rootio.{{.Name}}", f)
 }
 
-var _ Object = (*{{.Name}})(nil)
-var _ Named = (*{{.Name}})(nil)
-var _ ROOTUnmarshaler = (*{{.Name}})(nil)
+var (
+	_ Object          = (*{{.Name}})(nil)
+	_ Named           = (*{{.Name}})(nil)
+	_ H2              = (*{{.Name}})(nil)
+	_ ROOTUnmarshaler = (*{{.Name}})(nil)
+)
 `

--- a/rootio/h1_gen.go
+++ b/rootio/h1_gen.go
@@ -19,6 +19,8 @@ type H1F struct {
 	arr ArrayF
 }
 
+func (*H1F) isH1() {}
+
 // Class returns the ROOT class name.
 func (*H1F) Class() string {
 	return "TH1F"
@@ -214,15 +216,20 @@ func init() {
 	Factory.add("*rootio.H1F", f)
 }
 
-var _ Object = (*H1F)(nil)
-var _ Named = (*H1F)(nil)
-var _ ROOTUnmarshaler = (*H1F)(nil)
+var (
+	_ Object          = (*H1F)(nil)
+	_ Named           = (*H1F)(nil)
+	_ H1              = (*H1F)(nil)
+	_ ROOTUnmarshaler = (*H1F)(nil)
+)
 
 // H1D implements ROOT TH1D
 type H1D struct {
 	th1
 	arr ArrayD
 }
+
+func (*H1D) isH1() {}
 
 // Class returns the ROOT class name.
 func (*H1D) Class() string {
@@ -419,15 +426,20 @@ func init() {
 	Factory.add("*rootio.H1D", f)
 }
 
-var _ Object = (*H1D)(nil)
-var _ Named = (*H1D)(nil)
-var _ ROOTUnmarshaler = (*H1D)(nil)
+var (
+	_ Object          = (*H1D)(nil)
+	_ Named           = (*H1D)(nil)
+	_ H1              = (*H1D)(nil)
+	_ ROOTUnmarshaler = (*H1D)(nil)
+)
 
 // H1I implements ROOT TH1I
 type H1I struct {
 	th1
 	arr ArrayI
 }
+
+func (*H1I) isH1() {}
 
 // Class returns the ROOT class name.
 func (*H1I) Class() string {
@@ -624,6 +636,9 @@ func init() {
 	Factory.add("*rootio.H1I", f)
 }
 
-var _ Object = (*H1I)(nil)
-var _ Named = (*H1I)(nil)
-var _ ROOTUnmarshaler = (*H1I)(nil)
+var (
+	_ Object          = (*H1I)(nil)
+	_ Named           = (*H1I)(nil)
+	_ H1              = (*H1I)(nil)
+	_ ROOTUnmarshaler = (*H1I)(nil)
+)

--- a/rootio/h2_gen.go
+++ b/rootio/h2_gen.go
@@ -19,6 +19,8 @@ type H2F struct {
 	arr ArrayF
 }
 
+func (*H2F) isH2() {}
+
 // Class returns the ROOT class name.
 func (*H2F) Class() string {
 	return "TH2F"
@@ -296,15 +298,20 @@ func init() {
 	Factory.add("*rootio.H2F", f)
 }
 
-var _ Object = (*H2F)(nil)
-var _ Named = (*H2F)(nil)
-var _ ROOTUnmarshaler = (*H2F)(nil)
+var (
+	_ Object          = (*H2F)(nil)
+	_ Named           = (*H2F)(nil)
+	_ H2              = (*H2F)(nil)
+	_ ROOTUnmarshaler = (*H2F)(nil)
+)
 
 // H2D implements ROOT TH2D
 type H2D struct {
 	th2
 	arr ArrayD
 }
+
+func (*H2D) isH2() {}
 
 // Class returns the ROOT class name.
 func (*H2D) Class() string {
@@ -583,15 +590,20 @@ func init() {
 	Factory.add("*rootio.H2D", f)
 }
 
-var _ Object = (*H2D)(nil)
-var _ Named = (*H2D)(nil)
-var _ ROOTUnmarshaler = (*H2D)(nil)
+var (
+	_ Object          = (*H2D)(nil)
+	_ Named           = (*H2D)(nil)
+	_ H2              = (*H2D)(nil)
+	_ ROOTUnmarshaler = (*H2D)(nil)
+)
 
 // H2I implements ROOT TH2I
 type H2I struct {
 	th2
 	arr ArrayI
 }
+
+func (*H2I) isH2() {}
 
 // Class returns the ROOT class name.
 func (*H2I) Class() string {
@@ -870,6 +882,9 @@ func init() {
 	Factory.add("*rootio.H2I", f)
 }
 
-var _ Object = (*H2I)(nil)
-var _ Named = (*H2I)(nil)
-var _ ROOTUnmarshaler = (*H2I)(nil)
+var (
+	_ Object          = (*H2I)(nil)
+	_ Named           = (*H2I)(nil)
+	_ H2              = (*H2I)(nil)
+	_ ROOTUnmarshaler = (*H2I)(nil)
+)

--- a/rootio/rootio.go
+++ b/rootio/rootio.go
@@ -219,6 +219,52 @@ type Axis interface {
 	BinWidth(int) float64
 }
 
+// H1 is a 1-dim ROOT histogram
+type H1 interface {
+	Named
+
+	isH1()
+
+	// Entries returns the number of entries for this histogram.
+	Entries() float64
+	// SumW returns the total sum of weights
+	SumW() float64
+	// SumW2 returns the total sum of squares of weights
+	SumW2() float64
+	// SumWX returns the total sum of weights*x
+	SumWX() float64
+	// SumWX2 returns the total sum of weights*x*x
+	SumWX2() float64
+	// SumW2s returns the array of sum of squares of weights
+	SumW2s() []float64
+}
+
+// H2 is a 2-dim ROOT histogram
+type H2 interface {
+	Named
+
+	isH2()
+
+	// Entries returns the number of entries for this histogram.
+	Entries() float64
+	// SumW returns the total sum of weights
+	SumW() float64
+	// SumW2 returns the total sum of squares of weights
+	SumW2() float64
+	// SumWX returns the total sum of weights*x
+	SumWX() float64
+	// SumWX2 returns the total sum of weights*x*x
+	SumWX2() float64
+	// SumW2s returns the array of sum of squares of weights
+	SumW2s() []float64
+	// SumWY returns the total sum of weights*y
+	SumWY() float64
+	// SumWY2 returns the total sum of weights*y*y
+	SumWY2() float64
+	// SumWXY returns the total sum of weights*x*y
+	SumWXY() float64
+}
+
 // Graph describes a ROOT TGraph
 type Graph interface {
 	Named


### PR DESCRIPTION
This CL introduces 2 new interfaces:
- rootio.H1
- rootio.H2
They describe 1-dim and 2-dim ROOT histograms.
Note that a rootio.H2 is not a rootio.H1.