### PR TITLE
rootio: implement naive remote ROOT file over HTTP

### DIFF
--- a/rootio/file.go
+++ b/rootio/file.go
@@ -7,7 +7,6 @@ package rootio
 import (
 	"fmt"
 	"io"
-	"os"
 )
 
 type Reader interface {
@@ -93,7 +92,7 @@ type File struct {
 // returned file can be used for reading; the associated file descriptor
 // has mode os.O_RDONLY.
 func Open(path string) (*File, error) {
-	fd, err := os.Open(path)
+	fd, err := openFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("rootio: unable to open %q (%q)", path, err.Error())
 	}
@@ -323,6 +322,8 @@ func (f *File) Get(namecycle string) (Object, error) {
 	return f.dir.Get(namecycle)
 }
 
-var _ Object = (*File)(nil)
-var _ Named = (*File)(nil)
-var _ Directory = (*File)(nil)
+var (
+	_ Object    = (*File)(nil)
+	_ Named     = (*File)(nil)
+	_ Directory = (*File)(nil)
+)

--- a/rootio/fileplugin.go
+++ b/rootio/fileplugin.go
@@ -1,0 +1,59 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package rootio
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func openFile(path string) (Reader, error) {
+	switch {
+	case strings.HasPrefix(path, "http://"), strings.HasPrefix(path, "https://"):
+		resp, err := http.Get(path)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+
+		f, err := ioutil.TempFile("", "rootio-remote-")
+		if err != nil {
+			return nil, err
+		}
+		_, err = io.Copy(f, resp.Body)
+		if err != nil {
+			f.Close()
+			return nil, err
+		}
+		_, err = f.Seek(0, 0)
+		if err != nil {
+			f.Close()
+			return nil, err
+		}
+		return &tmpFile{f}, nil
+	case strings.HasPrefix(path, "file://"):
+		return os.Open(path)
+	default:
+		return os.Open(path)
+	}
+}
+
+// tmpFile wraps a regular os.File to automatically remove it when closed.
+type tmpFile struct {
+	*os.File
+}
+
+func (f *tmpFile) Close() error {
+	os.Remove(f.File.Name())
+	return f.File.Close()
+}
+
+var (
+	_ Reader = (*tmpFile)(nil)
+	_ Writer = (*tmpFile)(nil)
+)

--- a/rootio/fileplugin_test.go
+++ b/rootio/fileplugin_test.go
@@ -1,0 +1,50 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package rootio
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestTmpFile(t *testing.T) {
+	f, err := ioutil.TempFile("", "rootio-remote-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmp := tmpFile{f}
+	defer tmp.Close()
+
+	const want = "foo\n"
+	_, err = tmp.WriteString(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = tmp.Sync()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := ioutil.ReadFile(tmp.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	str := string(raw)
+	if str != want {
+		t.Fatalf("got=%q. want=%q", str, want)
+	}
+
+	err = tmp.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = os.Stat(tmp.Name())
+	if err == nil {
+		t.Fatalf("file %q should have been removed", tmp.Name())
+	}
+}

--- a/rootio/tree_test.go
+++ b/rootio/tree_test.go
@@ -328,6 +328,51 @@ func TestSimpleTree(t *testing.T) {
 	}
 }
 
+func TestSimpleTreeOverHTTP(t *testing.T) {
+	f, err := Open("https://github.com/go-hep/hep/raw/master/rootio/testdata/simple.root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	obj, err := f.Get("tree")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tree := obj.(Tree)
+	if got, want := tree.Name(), "tree"; got != want {
+		t.Fatalf("tree.Name: got=%q. want=%q", got, want)
+	}
+
+	for _, table := range []struct {
+		test  string
+		value string
+		want  string
+	}{
+		{"Name", tree.Name(), "tree"}, // name when created
+		{"Title", tree.Title(), "fake data"},
+		{"Class", tree.Class(), "TTree"},
+	} {
+		if table.value != table.want {
+			t.Fatalf("%v: got=[%v]. want=[%v]", table.test, table.value, table.want)
+		}
+	}
+
+	entries := tree.Entries()
+	if got, want := entries, int64(4); got != want {
+		t.Fatalf("tree.Entries: got=%v. want=%v", got, want)
+	}
+
+	if got, want := tree.TotBytes(), int64(288); got != want {
+		t.Fatalf("tree.totbytes: got=%v. want=%v", got, want)
+	}
+
+	if got, want := tree.ZipBytes(), int64(288); got != want {
+		t.Fatalf("tree.zipbytes: got=%v. want=%v", got, want)
+	}
+}
+
 func TestTreeWithBasketWithTKeyData(t *testing.T) {
 	f, err := Open("testdata/PhaseSpaceSimulation.root")
 	if err != nil {


### PR DESCRIPTION
This CL implements a naive remote ROOT file handling over HTTP(S).
rootio.Open will seamlessly download the whole ROOT file into a
temporary local file.
This local file will be automatically removed when closed.

Updates go-hep/hep#142.