### PR TITLE
rootio: handle large TKey blobs

### DIFF
--- a/rootio/compress.go
+++ b/rootio/compress.go
@@ -4,6 +4,14 @@
 
 package rootio
 
+import (
+	"compress/zlib"
+	"io"
+
+	"github.com/pierrec/lz4"
+	"github.com/ulikunitz/xz"
+)
+
 func rootCompressAlg(buf [rootHDRSIZE]byte) compressAlgType {
 	switch {
 	case buf[0] == 'Z' && buf[1] == 'L':
@@ -17,4 +25,62 @@ func rootCompressAlg(buf [rootHDRSIZE]byte) compressAlgType {
 	default:
 		return kUndefinedCompressionAlgorithm
 	}
+}
+
+func decompress(r io.Reader, buf []byte) error {
+	var (
+		beg    = 0
+		end    = 0
+		buflen = len(buf)
+	)
+	for end < buflen {
+		var hdr [rootHDRSIZE]byte
+		_, err := io.ReadFull(r, hdr[:])
+		if err != nil {
+			return err
+		}
+
+		srcsz := (int64(hdr[3]) | int64(hdr[4])<<8 | int64(hdr[5])<<16)
+		tgtsz := int64(hdr[6]) | int64(hdr[7])<<8 | int64(hdr[8])<<16
+		end += int(tgtsz)
+		lr := io.LimitReader(r, srcsz)
+		switch rootCompressAlg(hdr) {
+		case kZLIB:
+			rc, err := zlib.NewReader(lr)
+			if err != nil {
+				return err
+			}
+			defer rc.Close()
+			_, err = io.ReadFull(rc, buf[beg:end])
+			if err != nil {
+				return err
+			}
+		case kLZ4:
+			src := make([]byte, srcsz)
+			_, err = io.ReadFull(lr, src)
+			if err != nil {
+				return err
+			}
+			const chksum = 8
+			// FIXME: we skip the 32b checksum. use it!
+			_, err = lz4.UncompressBlock(src[chksum:], buf[beg:end], 0)
+			if err != nil {
+				return err
+			}
+		case kLZMA:
+			rc, err := xz.NewReader(lr)
+			if err != nil {
+				return err
+			}
+			_, err = io.ReadFull(rc, buf[beg:end])
+			if err != nil {
+				return err
+			}
+		default:
+			panic("rootio: unknown compression algorithm")
+		}
+		beg = end
+	}
+
+	return nil
 }


### PR DESCRIPTION
TKeys with large payloads are split into multiple 16*1024*1024 bytes
chunks.

This CL adds support for this case.