### PR TITLE
Rootio tchain scanner

### DIFF
--- a/rootio/tchain_test.go
+++ b/rootio/tchain_test.go
@@ -5,6 +5,9 @@
 package rootio_test
 
 import (
+	"fmt"
+	"io"
+	"reflect"
 	"testing"
 
 	"go-hep.org/x/hep/rootio"
@@ -76,5 +79,95 @@ func TestChain(t *testing.T) {
 				t.Fatalf("titles differ\ngot = %v, want= %v", got, want)
 			}
 		})
+	}
+}
+
+func TestChainScan(t *testing.T) {
+	files := []string{
+		"testdata/chain.1.root",
+		//	"testdata/chain.2.root", // FIXME(sbinet): implement for >1 tree
+	}
+	trees := make([]rootio.Tree, len(files))
+	for i, fname := range files {
+		f, err := rootio.Open(fname)
+		if err != nil {
+			t.Fatalf("could not open ROOT file %q: %v", fname, err)
+		}
+		defer f.Close()
+
+		obj, err := f.Get("tree")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		trees[i] = obj.(rootio.Tree)
+	}
+
+	chain := rootio.Chain(trees...)
+
+	type Data struct {
+		Event struct {
+			Beg       string      `rootio:"Beg"`
+			F64       float64     `rootio:"F64"`
+			ArrF64    [10]float64 `rootio:"ArrayF64"`
+			N         int32       `rootio:"N"`
+			SliF64    []float64   `rootio:"SliceF64"`
+			StdStr    string      `rootio:"StdStr"`
+			StlVecF64 []float64   `rootio:"StlVecF64"`
+			StlVecStr []string    `rootio:"StlVecStr"`
+			End       string      `rootio:"End"`
+		} `rootio:"evt"`
+	}
+
+	want := func(i int64) (data Data) {
+		evt := &data.Event
+		evt.Beg = fmt.Sprintf("beg-%03d", i)
+		evt.F64 = float64(i)
+		for j := range evt.ArrF64 {
+			evt.ArrF64[j] = float64(i)
+		}
+		evt.N = int32(i) % 10
+		evt.SliF64 = make([]float64, evt.N)
+		evt.StdStr = fmt.Sprintf("std-%03d", i)
+		evt.StlVecF64 = make([]float64, int(evt.N))
+		evt.StlVecStr = make([]string, int(evt.N))
+		for ii := 0; ii < int(evt.N); ii++ {
+			evt.SliF64[ii] = float64(i)
+			evt.StlVecF64[ii] = float64(i)
+			evt.StlVecStr[ii] = fmt.Sprintf("vec-%03d", i)
+		}
+		evt.End = fmt.Sprintf("end-%03d", i)
+
+		return data
+	}
+
+	sc, err := rootio.NewTreeScanner(chain, &Data{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sc.Close()
+
+	for sc.Next() {
+		var d1 Data
+		err := sc.Scan(&d1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		i := sc.Entry()
+		if !reflect.DeepEqual(d1, want(i)) {
+			t.Fatalf("entry[%d]:\ngot= %#v\nwant=%#v\n", i, d1, want(i))
+		}
+
+		var d2 Data
+		err = sc.Scan(&d2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(d2, want(i)) {
+			t.Fatalf("entry[%d]:\ngot= %#v\nwant=%#v\n", i, d2, want(i))
+		}
+	}
+	if err := sc.Err(); err != nil && err != io.EOF {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Hello, 
There are many errors in the next proposition, but the idea is to add an argument to the loadEntry method : totalEntries. totalEntries is the total number of entries of the chain. This, i think, will allow to increase the nevbuf (number of entries in the basket) in order to be able to scan a chain containing more than one tree. Is it a way according to you ? 
Thanks  