### PR TITLE
xrootd: add encoder

### DIFF
--- a/xrootd/encoder/encoder.go
+++ b/xrootd/encoder/encoder.go
@@ -1,0 +1,144 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package encoder // import "go-hep.org/x/hep/xrootd/encoder"
+
+import (
+	"encoding/binary"
+	"reflect"
+
+	"github.com/pkg/errors"
+	"go-hep.org/x/hep/xrootd/protocol"
+)
+
+// MarshalRequest encodes request body alongside with request and stream ids
+func MarshalRequest(requestID uint16, streamID protocol.StreamID, requestBody interface{}) ([]byte, error) {
+	requestHeader := make([]byte, 4)
+
+	copy(requestHeader, streamID[:])
+	binary.BigEndian.PutUint16(requestHeader[2:], requestID)
+
+	b, err := Marshal(requestBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(requestHeader, b...), nil
+}
+
+// Marshal encodes structure to the bytes
+func Marshal(x interface{}) ([]byte, error) {
+	v := reflect.ValueOf(x)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	dataSize, err := calculateSizeForMarshaling(v)
+	if err != nil {
+		return nil, err
+	}
+
+	data := make([]byte, dataSize)
+	pos := 0
+	for i := 0; i < v.NumField() && err == nil; i++ {
+		field := v.Field(i)
+		fieldSize := 0
+		switch field.Kind() {
+		case reflect.Uint8:
+			fieldSize = 1
+			data[pos] = uint8(field.Uint())
+		case reflect.Uint16:
+			fieldSize = 2
+			binary.BigEndian.PutUint16(data[pos:pos+fieldSize], uint16(field.Uint()))
+		case reflect.Int32:
+			fieldSize = 4
+			binary.BigEndian.PutUint32(data[pos:pos+fieldSize], uint32(field.Int()))
+		case reflect.Int64:
+			fieldSize = 8
+			binary.BigEndian.PutUint64(data[pos:pos+fieldSize], uint64(field.Int()))
+		case reflect.Slice:
+			fieldSize = field.Len()
+			reflect.Copy(reflect.ValueOf(data[pos:pos+fieldSize]), field)
+		case reflect.Array:
+			fieldSize = field.Len()
+			reflect.Copy(reflect.ValueOf(data[pos:pos+fieldSize]), field)
+
+		default:
+			err = errors.Errorf("Cannot encode kind %s", field.Kind())
+		}
+		pos += fieldSize
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// Unmarshal decodes data from byte slice
+func Unmarshal(data []byte, x interface{}) (err error) {
+	v := reflect.ValueOf(x)
+
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	pos := 0
+
+	for i := 0; i < v.NumField() && err == nil; i++ {
+		field := v.Field(i)
+		fieldSize := 0
+		switch field.Kind() {
+		case reflect.Uint8:
+			fieldSize = 1
+			field.SetUint(uint64(data[pos]))
+		case reflect.Uint16:
+			fieldSize = 2
+			var value = binary.BigEndian.Uint16(data[pos : pos+fieldSize])
+			field.SetUint(uint64(value))
+		case reflect.Int32:
+			fieldSize = 4
+			var value = int32(binary.BigEndian.Uint32(data[pos : pos+fieldSize]))
+			field.SetInt(int64(value))
+		case reflect.Int64:
+			fieldSize = 8
+			var value = int64(binary.BigEndian.Uint64(data[pos : pos+fieldSize]))
+			field.SetInt(value)
+		case reflect.Slice:
+			bytes := data[pos:]
+			fieldSize = len(bytes)
+			field.SetBytes(bytes)
+		case reflect.Array:
+			fieldSize = field.Len()
+			reflect.Copy(field, reflect.ValueOf(data[pos:pos+fieldSize]))
+		default:
+			err = errors.Errorf("Cannot decode kind %s", field.Kind())
+		}
+		pos += fieldSize
+	}
+	return
+}
+
+func calculateSizeForMarshaling(v reflect.Value) (size int, err error) {
+	for i := 0; i < v.NumField() && err == nil; i++ {
+		field := v.Field(i)
+		switch field.Kind() {
+		case reflect.Uint8:
+			size++
+		case reflect.Uint16:
+			size += 2
+		case reflect.Int32:
+			size += 4
+		case reflect.Int64:
+			size += 8
+		case reflect.Array:
+			size += field.Len()
+		case reflect.Slice:
+			size += field.Len()
+		default:
+			err = errors.Errorf("Cannot decode kind %s", field.Kind())
+		}
+	}
+	return
+}

--- a/xrootd/encoder/encoder_test.go
+++ b/xrootd/encoder/encoder_test.go
@@ -1,0 +1,107 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package encoder // import "go-hep.org/x/hep/xrootd/encoder"
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go-hep.org/x/hep/xrootd/protocol"
+)
+
+type request struct {
+	Z int64
+	X int32
+	A uint8
+	C uint16
+	D [2]byte
+	Y []byte
+}
+
+type benchmarkRequest struct {
+	X   int32
+	A   uint8
+	A1  uint8
+	A2  uint8
+	A3  uint8
+	A4  int32
+	A5  int32
+	A6  int32
+	A7  int32
+	A8  int32
+	A9  int32
+	A10 int32
+	A11 int32
+	A12 int32
+	A13 int32
+	A14 int32
+	A16 int32
+	C   uint16
+	D   [10]byte
+	Z   [10]byte
+}
+
+type undecodable struct {
+	A float64
+}
+
+func TestMarshalRequest(t *testing.T) {
+	var requestID uint16 = 1337
+	var streamID = protocol.StreamID{42, 37}
+	expected := []byte{42, 37, 5, 57, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 1, 2, 0, 3, 6, 7, 11, 13}
+
+	actual, err := MarshalRequest(requestID, streamID, request{7, 1, 2, 3, protocol.StreamID{6, 7}, []byte{11, 13}})
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestUnmarshal(t *testing.T) {
+	var expected = request{7, 1, 2, 3, protocol.StreamID{6, 7}, []byte{11, 13}}
+
+	var actual = &request{}
+	err := Unmarshal([]byte{0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 1, 2, 0, 3, 6, 7, 11, 13}, actual)
+
+	assert.Equal(t, expected, *actual)
+	assert.NoError(t, err)
+}
+
+func TestMarshalRequest_Undecodable(t *testing.T) {
+	var requestID uint16 = 1337
+	var streamID = protocol.StreamID{42, 37}
+
+	_, err := MarshalRequest(requestID, streamID, undecodable{1})
+
+	assert.Error(t, err)
+}
+
+func TestUnmarshal_Undecodable(t *testing.T) {
+	var actual = &undecodable{}
+
+	err := Unmarshal([]byte{0, 0, 0, 1, 2, 0, 3, 6, 7, 11, 13}, actual)
+
+	assert.Error(t, err)
+}
+
+func BenchmarkMarshal(b *testing.B) {
+	br := benchmarkRequest{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := Marshal(br); err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+func BenchmarkUnMarshal(b *testing.B) {
+	br := benchmarkRequest{}
+	data := make([]byte, 78)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(data, &br); err != nil {
+			b.Error(err)
+		}
+	}
+}

--- a/xrootd/protocol/streamID.go
+++ b/xrootd/protocol/streamID.go
@@ -1,0 +1,7 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package protocol // import "go-hep.org/x/hep/xrootd/protocol"
+
+// StreamID is the binary identifier associated with request stream
+type StreamID [2]byte


### PR DESCRIPTION
Add encoder package which (un)marshals requests/responses to a Go struct.
Specific structs will be added as part of the corresponding request implementation.

Is part of #170, #179. 