### PR TITLE
xrootd/client: first import

### DIFF
--- a/xrootd/client/client.go
+++ b/xrootd/client/client.go
@@ -1,0 +1,175 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Package client implements the XRootD client following protocol from http://xrootd.org.
+
+The NewClient function connects to a server:
+
+	ctx := context.Background()
+
+	client, err := NewClient(ctx, *Addr)
+	if err != nil {
+		// handle error
+	}
+
+	// ...
+
+	if err := client.Close(); err != nil {
+		// handle error
+	}
+*/
+package client // import "go-hep.org/x/hep/xrootd/client"
+
+import (
+	"context"
+	"io"
+	"net"
+
+	"go-hep.org/x/hep/xrootd/encoder"
+	"go-hep.org/x/hep/xrootd/mux"
+	"go-hep.org/x/hep/xrootd/protocol"
+)
+
+// A Client to xrootd server which allows to send requests and receive responses.
+// Concurrent requests are supported.
+// Zero value is invalid, Client should be instantiated using NewClient.
+type Client struct {
+	cancel          context.CancelFunc
+	conn            net.Conn
+	mux             *mux.Mux
+	protocolVersion int32
+}
+
+// NewClient creates a new xrootd client that connects to the given address.
+// When the context expires, a response handling is stopped, however, it is
+// necessary to call Cancel to correctly free resources.
+func NewClient(ctx context.Context, address string) (*Client, error) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "tcp", address)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	client := &Client{cancel, conn, mux.New(), 0}
+
+	go client.consume(ctx)
+
+	if err := client.handshake(ctx); err != nil {
+		client.Close()
+		return nil, err
+	}
+
+	return client, nil
+}
+
+// Close closes the connection. Any blocked operation will be unblocked and return error.
+func (client *Client) Close() error {
+	client.cancel()
+
+	client.mux.Close()
+	return client.conn.Close()
+}
+
+func (client *Client) consume(ctx context.Context) {
+	var header protocol.ResponseHeader
+	var headerBytes = make([]byte, protocol.ResponseHeaderLength)
+
+	for {
+		select {
+		case <-ctx.Done():
+			// TODO: Should wait for active requests to be completed?
+			return
+		default:
+			if _, err := io.ReadFull(client.conn, headerBytes); err != nil {
+				if ctx.Err() != nil {
+					// something happened to the context.
+					// ignore this error.
+					continue
+				}
+				panic(err)
+				// TODO: handle EOF by redirection as specified at http://xrootd.org/doc/dev45/XRdv310.pdf, page 11
+			}
+
+			if err := encoder.Unmarshal(headerBytes, &header); err != nil {
+				if ctx.Err() != nil {
+					// something happened to the context.
+					// ignore this error.
+					continue
+				}
+				panic(err)
+				// TODO: should redirect in case if is not possible to decode a header as well?
+			}
+
+			resp := mux.ServerResponse{Data: make([]byte, header.DataLength)}
+			if _, err := io.ReadFull(client.conn, resp.Data); err != nil {
+				if ctx.Err() != nil {
+					// something happened to the context.
+					// ignore this error.
+					continue
+				}
+				resp.Err = err
+			} else if header.Status != protocol.Ok {
+				resp.Err = header.Error(resp.Data)
+			}
+
+			if err := client.mux.SendData(header.StreamID, resp); err != nil {
+				if ctx.Err() != nil {
+					// something happened to the context.
+					// ignore this error.
+					continue
+				}
+				panic(err)
+				// TODO: should we just ignore responses to unclaimed stream IDs?
+			}
+
+			if header.Status != protocol.OkSoFar {
+				client.mux.Unclaim(header.StreamID)
+			}
+		}
+	}
+}
+
+func (client *Client) send(ctx context.Context, responseChannel mux.DataRecvChan, request []byte) ([]byte, error) {
+	if _, err := client.conn.Write(request); err != nil {
+		return nil, err
+	}
+
+	more := true
+	var resp mux.ServerResponse
+	var data []byte
+
+	for more {
+		select {
+		case resp, more = <-responseChannel:
+			data = append(data, resp.Data...)
+			if resp.Err != nil {
+				return nil, resp.Err
+			}
+		case <-ctx.Done():
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return data, nil
+}
+
+func (client *Client) call(ctx context.Context, requestID uint16, request interface{}) ([]byte, error) {
+	streamID, responseChannel, err := client.mux.Claim()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := encoder.MarshalRequest(requestID, streamID, request)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.send(ctx, responseChannel, data)
+}

--- a/xrootd/client/client_test.go
+++ b/xrootd/client/client_test.go
@@ -1,0 +1,57 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build xrootd_test_with_server
+
+package client // import "go-hep.org/x/hep/xrootd/client"
+
+import (
+	"context"
+	"testing"
+)
+
+var testClientAddrs = []string{"0.0.0.0:9001"}
+
+func TestNewClient(t *testing.T) {
+	for _, addr := range testClientAddrs {
+		t.Run(addr, func(t *testing.T) {
+			testNewClient(t, addr)
+		})
+	}
+}
+
+func testNewClient(t *testing.T, addr string) {
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	client, err := NewClient(ctx, addr)
+	if err != nil {
+		t.Fatalf("could not create client: %v", err)
+	}
+
+	if err := client.Close(); err != nil {
+		t.Fatalf("could not close client: %v", err)
+	}
+}
+
+func BenchmarkNewClient(b *testing.B) {
+	for _, addr := range testClientAddrs {
+		b.Run(addr, func(b *testing.B) {
+			benchmarkNewClient(b, addr)
+		})
+	}
+}
+
+func benchmarkNewClient(b *testing.B, addr string) {
+	for i := 0; i < b.N; i++ {
+		client, err := NewClient(context.Background(), addr)
+		if err != nil {
+			b.Fatalf("could not create client: %v", err)
+		}
+		if err := client.Close(); err != nil {
+			b.Fatalf("could not close client: %v", err)
+		}
+	}
+}

--- a/xrootd/client/cxx_server_test.go
+++ b/xrootd/client/cxx_server_test.go
@@ -1,0 +1,12 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build xrootd_test_with_cxx_server
+
+package client // import "go-hep.org/x/hep/xrootd/client"
+
+func init() {
+	// add a C++ XRootD test server hosted in CC-Lyon.
+	testClientAddrs = append(testClientAddrs, "ccxrootdgotest.in2p3.fr:9001")
+}

--- a/xrootd/client/handshake.go
+++ b/xrootd/client/handshake.go
@@ -1,0 +1,39 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package client // import "go-hep.org/x/hep/xrootd/client"
+
+import (
+	"context"
+
+	"go-hep.org/x/hep/xrootd/encoder"
+	"go-hep.org/x/hep/xrootd/protocol"
+	"go-hep.org/x/hep/xrootd/protocol/handshake"
+)
+
+func (client *Client) handshake(ctx context.Context) error {
+	responseChannel, err := client.mux.ClaimWithID(protocol.StreamID{0, 0})
+	if err != nil {
+		return err
+	}
+
+	requestBytes, err := encoder.Marshal(handshake.NewRequest())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.send(ctx, responseChannel, requestBytes)
+	if err != nil {
+		return err
+	}
+
+	var result handshake.Response
+	if err = encoder.Unmarshal(resp, &result); err != nil {
+		return err
+	}
+
+	client.protocolVersion = result.ProtocolVersion
+
+	return nil
+}

--- a/xrootd/protocol/handshake/handshake.go
+++ b/xrootd/protocol/handshake/handshake.go
@@ -1,0 +1,39 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package handshake contains the structures describing request and response
+// for handshake request (see XRootD specification).
+package handshake // import "go-hep.org/x/hep/xrootd/protocol/handshake"
+
+// ServerType is the general server type kept for compatibility
+// with 2.0 protocol version (see xrootd protocol specification v3.1.0, p. 5).
+type ServerType int32
+
+const (
+	// LoadBalancingServer indicates whether this is a load-balancing server.
+	LoadBalancingServer ServerType = iota
+	// DataServer indicates whether this is a data server.
+	DataServer ServerType = iota
+)
+
+// Response is a response for the handshake request,
+// which contains protocol version and server type.
+type Response struct {
+	ProtocolVersion int32
+	ServerType      ServerType
+}
+
+// Request holds the handshake request parameters.
+type Request struct {
+	Reserved1 int32
+	Reserved2 int32
+	Reserved3 int32
+	Reserved4 int32
+	Reserved5 int32
+}
+
+// NewRequest forms a Request that comply with the XRootD protocol v3.1.0.
+func NewRequest() Request {
+	return Request{0, 0, 0, 4, 2012}
+}

--- a/xrootd/protocol/protocol.go
+++ b/xrootd/protocol/protocol.go
@@ -1,0 +1,65 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package protocol contains the XRootD protocol specific types.
+package protocol // import "go-hep.org/x/hep/xrootd/protocol"
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// ResponseStatus is the status code indicating how the request completed.
+type ResponseStatus uint16
+
+const (
+	// Ok indicates that request fully completed and no addition responses will be forthcoming.
+	Ok ResponseStatus = 0
+	// OkSoFar indicates that server provides partial response and client should be prepared
+	// to receive additional responses on same stream.
+	OkSoFar ResponseStatus = 4000
+	// Error indicates that an error occurred during request handling.
+	// Error code and error message are sent as part of response (see xrootd protocol specification v3.1.0, p. 27).
+	Error ResponseStatus = 4003
+)
+
+// ServerError is the error returned by the XRootD server as part of response to the request.
+type ServerError struct {
+	Code    int32
+	Message string
+}
+
+func (err ServerError) Error() string {
+	return fmt.Sprintf("xrootd: error %d: %s", err.Code, err.Message)
+}
+
+// StreamID is the binary identifier associated with a request stream.
+type StreamID [2]byte
+
+// ResponseHeaderLength is the length of the ResponseHeader in bytes.
+const ResponseHeaderLength = 2 + 2 + 4
+
+// ResponseHeader is the header that precedes all responses (see xrootd protocol specification).
+type ResponseHeader struct {
+	StreamID   StreamID
+	Status     ResponseStatus
+	DataLength int32
+}
+
+// Error returns an error received from the server or nil if request hasn't failed.
+func (hdr ResponseHeader) Error(data []byte) error {
+	if hdr.Status == Error {
+		// 4 bytes for error code and at least 1 byte for message (in case it is null-terminated empty string)
+		if len(data) < 5 {
+			return errors.New("xrootd: an server error occurred, but code and message were not provided")
+		}
+		code := int32(binary.BigEndian.Uint32(data[0:4]))
+		message := string(data[4 : len(data)-1]) // Skip \0 character at the end
+
+		return ServerError{code, message}
+	}
+	return nil
+}

--- a/xrootd/protocol/streamID.go
+++ b/xrootd/protocol/streamID.go
@@ -1,7 +1,0 @@
-// Copyright 2018 The go-hep Authors.  All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-package protocol // import "go-hep.org/x/hep/xrootd/protocol"
-
-// StreamID is the binary identifier associated with a request stream
-type StreamID [2]byte


### PR DESCRIPTION
Add client package which allows to send requests and receive responses from XRootD server.
Add handshake request which performs an initial handshake.

Benchmark result is 150 ms/op which equals 2 * ping to the XRootD server.

Is part of https://github.com/go-hep/hep/issues/170.
I have extracted the client-related part from https://github.com/go-hep/hep/pull/179 to make it easier to review core component.

Specific requests will come as separated PR if it's ok and makes the review process easier. :)