### PR TITLE
xrootd: fix docs

### DIFF
--- a/xrootd/encoder/encoder.go
+++ b/xrootd/encoder/encoder.go
@@ -12,7 +12,7 @@ import (
 	"go-hep.org/x/hep/xrootd/protocol"
 )
 
-// MarshalRequest encodes request body alongside with request and stream ids
+// MarshalRequest encodes request body alongside with request and stream ids.
 func MarshalRequest(requestID uint16, streamID protocol.StreamID, requestBody interface{}) ([]byte, error) {
 	requestHeader := make([]byte, 4)
 


### PR DESCRIPTION
Do not add package docs to the encoder and protocol since they will be
merged to the single package (so, just postpone it to that moment).

Fixes https://github.com/go-hep/hep/issues/192.