### PR TITLE
xrootd/client: fix test

### DIFF
--- a/xrootd/client/protocol_mock_test.go
+++ b/xrootd/client/protocol_mock_test.go
@@ -18,24 +18,26 @@ func TestClient_Protocol_WithSecurityInfo(t *testing.T) {
 	var protocolVersion int32 = 0x310
 
 	serverFunc := func(cancel func(), conn net.Conn) {
-		defer cancel()
-
 		data, err := readRequest(conn)
 		if err != nil {
+			cancel()
 			t.Fatalf("could not read request: %v", err)
 		}
 
 		var gotRequest protocol.Request
 		gotHeader, err := unmarshalRequest(data, &gotRequest)
 		if err != nil {
+			cancel()
 			t.Fatalf("could not unmarshal request: %v", err)
 		}
 
 		if gotHeader.RequestID != protocol.RequestID {
+			cancel()
 			t.Fatalf("invalid request id was specified:\nwant = %d\ngot = %d\n", protocol.RequestID, gotHeader.RequestID)
 		}
 
 		if gotRequest.ClientProtocolVersion != protocolVersion {
+			cancel()
 			t.Fatalf("invalid client protocol version was specified:\nwant = %d\ngot = %d\n", protocolVersion, gotRequest.ClientProtocolVersion)
 		}
 
@@ -58,10 +60,12 @@ func TestClient_Protocol_WithSecurityInfo(t *testing.T) {
 
 		response, err := marshalResponse(responseHeader, protocolResponse, protocolSecurityInfo, securityOverride)
 		if err != nil {
+			cancel()
 			t.Fatalf("could not marshal response: %v", err)
 		}
 
 		if err := writeResponse(conn, response); err != nil {
+			cancel()
 			t.Fatalf("invalid write: %s", err)
 		}
 	}


### PR DESCRIPTION
Fix a random test failure introduced in #195.

If cancel() is called before client handled request, then the client
will raise an error indicating that (expected behaviour if we called
Close while some requests were blocked).

In case of test failure, it's safe to call cancel()
before the end of request handling because of the fact that
the actual error message will still be present at top of the log.

