### PR TITLE
xrootd/internal/mux: make channels unbuffered in both Claim{,WithID}

### DIFF
--- a/xrootd/internal/mux/mux.go
+++ b/xrootd/internal/mux/mux.go
@@ -145,7 +145,7 @@ func (m *Mux) ClaimWithID(id protocol.StreamID) (DataRecvChan, error) {
 	if m.closed {
 		return nil, errors.New("mux: ClaimWithID was called on closed Mux")
 	}
-	ch := make(chan ServerResponse, 1)
+	ch := make(chan ServerResponse)
 
 	if _, claimed := m.dataWaiters[id]; claimed {
 		return nil, errors.Errorf("mux: channel with id %s is already claimed", id)


### PR DESCRIPTION
In one of the previous PRs, it was decided that channels will be unbuffered since making them buffered doesn't make much sense. However accidentally in `ClaimWithID ` channel remained to be buffered, this PR fixes that.