### PR TITLE
xrootd: add dirlist request

### DIFF
--- a/xrootd/client/filesystem.go
+++ b/xrootd/client/filesystem.go
@@ -1,0 +1,36 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package client // import "go-hep.org/x/hep/xrootd/client"
+
+import (
+	"context"
+
+	"go-hep.org/x/hep/xrootd/xrdfs"
+	"go-hep.org/x/hep/xrootd/xrdproto/dirlist"
+)
+
+// FS returns a xrdfs.FileSystem which uses this client to make requests.
+func (cli *Client) FS() xrdfs.FileSystem {
+	return &fileSystem{cli}
+}
+
+// fileSystem contains filesystem-related methods of the XRootD protocol.
+type fileSystem struct {
+	c *Client
+}
+
+// Dirlist returns the contents of a directory together with the stat information.
+func (fs *fileSystem) Dirlist(ctx context.Context, path string) ([]xrdfs.EntryStat, error) {
+	var resp dirlist.Response
+	err := fs.c.Send(ctx, &resp, dirlist.NewRequest(path))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Entries, err
+}
+
+var (
+	_ xrdfs.FileSystem = (*fileSystem)(nil)
+)

--- a/xrootd/client/filesystem_mock_test.go
+++ b/xrootd/client/filesystem_mock_test.go
@@ -1,0 +1,173 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package client // import "go-hep.org/x/hep/xrootd/client"
+
+import (
+	"context"
+	"net"
+	"reflect"
+	"testing"
+
+	"go-hep.org/x/hep/xrootd/xrdfs"
+	"go-hep.org/x/hep/xrootd/xrdproto"
+	"go-hep.org/x/hep/xrootd/xrdproto/dirlist"
+)
+
+func TestFileSystem_Dirlist_Mock(t *testing.T) {
+	path := "/tmp/test"
+	response := ".\n0 0 0 0\ntestfile\n0 20 0 10\ntestfile2\n0 21 2 12\x00"
+
+	var want = []xrdfs.EntryStat{
+		{
+			EntryName:   "testfile",
+			EntrySize:   20,
+			Mtime:       10,
+			HasStatInfo: true,
+		},
+		{
+			EntryName:   "testfile2",
+			EntrySize:   21,
+			Mtime:       12,
+			HasStatInfo: true,
+			Flags:       xrdfs.StatIsDir,
+		},
+	}
+
+	var wantRequest = dirlist.Request{
+		Options: dirlist.WithStatInfo,
+		Path:    path,
+	}
+
+	serverFunc := func(cancel func(), conn net.Conn) {
+		data, err := readRequest(conn)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not read request: %v", err)
+		}
+
+		var gotRequest dirlist.Request
+		gotHeader, err := unmarshalRequest(data, &gotRequest)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not unmarshal request: %v", err)
+		}
+
+		if gotHeader.RequestID != dirlist.RequestID {
+			cancel()
+			t.Fatalf("invalid request id was specified:\nwant = %d\ngot = %d\n", dirlist.RequestID, gotHeader.RequestID)
+		}
+
+		if !reflect.DeepEqual(gotRequest, wantRequest) {
+			cancel()
+			t.Fatalf("request info does not match:\ngot = %v\nwant = %v", gotRequest, wantRequest)
+		}
+
+		responseHeader := xrdproto.ResponseHeader{
+			StreamID:   gotHeader.StreamID,
+			DataLength: int32(len(response)),
+		}
+
+		responseData, err := marshalResponse(responseHeader)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not marshal response: %v", err)
+		}
+		responseData = append(responseData, []byte(response)...)
+
+		if err := writeResponse(conn, responseData); err != nil {
+			cancel()
+			t.Fatalf("invalid write: %s", err)
+		}
+	}
+
+	clientFunc := func(cancel func(), client *Client) {
+		fs := client.FS()
+		got, err := fs.Dirlist(context.Background(), path)
+		if err != nil {
+			t.Fatalf("invalid dirlist call: %v", err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("dirlist info does not match:\ngot = %v\nwant = %v", got, want)
+		}
+	}
+
+	testClientWithMockServer(serverFunc, clientFunc)
+}
+
+func TestFileSystem_Dirlist_Mock_WithoutStatInfo(t *testing.T) {
+	path := "/tmp/test"
+	response := "testfile\ntestfile2\x00"
+
+	var want = []xrdfs.EntryStat{
+		{
+			EntryName:   "testfile",
+			HasStatInfo: false,
+		},
+		{
+			EntryName:   "testfile2",
+			HasStatInfo: false,
+		},
+	}
+
+	var wantRequest = dirlist.Request{
+		Options: dirlist.WithStatInfo,
+		Path:    path,
+	}
+
+	serverFunc := func(cancel func(), conn net.Conn) {
+		data, err := readRequest(conn)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not read request: %v", err)
+		}
+
+		var gotRequest dirlist.Request
+		gotHeader, err := unmarshalRequest(data, &gotRequest)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not unmarshal request: %v", err)
+		}
+
+		if gotHeader.RequestID != dirlist.RequestID {
+			cancel()
+			t.Fatalf("invalid request id was specified:\nwant = %d\ngot = %d\n", dirlist.RequestID, gotHeader.RequestID)
+		}
+
+		if !reflect.DeepEqual(gotRequest, wantRequest) {
+			cancel()
+			t.Fatalf("request info does not match:\ngot = %v\nwant = %v", gotRequest, wantRequest)
+		}
+
+		responseHeader := xrdproto.ResponseHeader{
+			StreamID:   gotHeader.StreamID,
+			DataLength: int32(len(response)),
+		}
+
+		responseData, err := marshalResponse(responseHeader)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not marshal response: %v", err)
+		}
+		responseData = append(responseData, []byte(response)...)
+
+		if err := writeResponse(conn, responseData); err != nil {
+			cancel()
+			t.Fatalf("invalid write: %s", err)
+		}
+	}
+
+	clientFunc := func(cancel func(), client *Client) {
+		fs := fileSystem{client}
+		got, err := fs.Dirlist(context.Background(), path)
+		if err != nil {
+			t.Fatalf("invalid dirlist call: %v", err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("dirlist info does not match:\ngot = %v\nwant = %v", got, want)
+		}
+	}
+
+	testClientWithMockServer(serverFunc, clientFunc)
+}

--- a/xrootd/client/filesystem_test.go
+++ b/xrootd/client/filesystem_test.go
@@ -1,0 +1,50 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package client
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"go-hep.org/x/hep/xrootd/xrdfs"
+)
+
+func testFileSystem_Dirlist(t *testing.T, addr string) {
+	var want = []xrdfs.EntryStat{
+		{
+			EntryName:   "file1.txt",
+			HasStatInfo: true,
+			ID:          60129606914,
+			EntrySize:   17,
+			Mtime:       1527753618,
+			Flags:       xrdfs.StatIsReadable | xrdfs.StatIsWritable,
+		},
+	}
+
+	client, err := NewClient(context.Background(), addr, "gopher")
+	if err != nil {
+		t.Fatalf("could not create client: %v", err)
+	}
+	defer client.Close()
+
+	fs := client.FS()
+
+	got, err := fs.Dirlist(context.Background(), "/tmp/dir1")
+	if err != nil {
+		t.Fatalf("invalid protocol call: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("FileSystem.Dirlist()\ngot = %v\nwant = %v", got, want)
+	}
+}
+
+func TestFileSystem_Dirlist(t *testing.T) {
+	for _, addr := range testClientAddrs {
+		t.Run(addr, func(t *testing.T) {
+			testFileSystem_Dirlist(t, addr)
+		})
+	}
+}

--- a/xrootd/xrdfs/fs.go
+++ b/xrootd/xrdfs/fs.go
@@ -1,0 +1,15 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package xrdfs contains structures representing the XRootD-based filesystem.
+package xrdfs
+
+import (
+	"context"
+)
+
+// FileSystem implements access to a collection of named files over XRootD.
+type FileSystem interface {
+	Dirlist(ctx context.Context, path string) ([]EntryStat, error)
+}

--- a/xrootd/xrdfs/stat.go
+++ b/xrootd/xrdfs/stat.go
@@ -1,0 +1,180 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xrdfs // import "go-hep.org/x/hep/xrootd/xrdfs"
+
+import (
+	"bytes"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/pkg/errors"
+	"go-hep.org/x/hep/xrootd/internal/xrdenc"
+)
+
+// StatFlags identifies the entry's attributes.
+type StatFlags int32
+
+const (
+	// StatIsExecutable indicates that entry is either an executable file or a searchable directory.
+	StatIsExecutable StatFlags = 1
+	// StatIsDir indicates that entry is a directory.
+	StatIsDir StatFlags = 2
+	// StatIsOther indicates that entry is neither a file nor a directory.
+	StatIsOther StatFlags = 4
+	// StatIsOffline indicates that the file is not online (i. e., on disk).
+	StatIsOffline StatFlags = 8
+	// StatIsReadable indicates that read access to that entry is allowed.
+	StatIsReadable StatFlags = 16
+	// StatIsWritable indicates that write access to that entry is allowed.
+	StatIsWritable StatFlags = 32
+	// StatIsPOSCPending indicates that the file was created with kXR_posc and has not yet been successfully closed.
+	// kXR_posc is an option of open request indicating that the "Persist On Successful Close" processing is enabled and
+	// the file will be persisted only when it has been explicitly closed.
+	StatIsPOSCPending StatFlags = 64
+)
+
+// EntryStat holds the entry name and the entry stat information.
+type EntryStat struct {
+	EntryName   string    // EntryName is the name of entry.
+	HasStatInfo bool      // HasStatInfo indicates if the following stat information is valid.
+	ID          int64     // ID is the OS-dependent identifier assigned to this entry.
+	EntrySize   int64     // EntrySize is the decimal size of the entry.
+	Flags       StatFlags // Flags identifies the entry's attributes.
+	Mtime       int64     // Mtime is the last modification time in Unix time units.
+}
+
+// Name implements os.FileInfo.
+func (es EntryStat) Name() string {
+	return es.EntryName
+}
+
+// Size implements os.FileInfo.
+func (es EntryStat) Size() int64 {
+	return es.EntrySize
+}
+
+// ModTime implements os.FileInfo.
+func (es EntryStat) ModTime() time.Time {
+	return time.Unix(es.Mtime, 0)
+}
+
+// Sys implements os.FileInfo.
+func (es EntryStat) Sys() interface{} {
+	return nil
+}
+
+// Mode implements os.FileInfo.
+func (es EntryStat) Mode() os.FileMode {
+	var mode os.FileMode
+	if es.IsDir() {
+		mode |= os.ModeDir
+	}
+	if es.IsWritable() {
+		mode |= 0222
+	}
+	if es.IsReadable() {
+		mode |= 0444
+	}
+	return mode
+}
+
+// IsExecutable indicates whether this entry is either an executable file or a searchable directory.
+func (es EntryStat) IsExecutable() bool {
+	return es.Flags&StatIsExecutable != 0
+}
+
+// IsDir indicates whether this entry is a directory.
+func (es EntryStat) IsDir() bool {
+	return es.Flags&StatIsDir != 0
+}
+
+// IsOther indicates whether this entry is neither a file nor a directory.
+func (es EntryStat) IsOther() bool {
+	return es.Flags&StatIsOther != 0
+}
+
+// IsOffline indicates whether this the file is not online (i. e., on disk).
+func (es EntryStat) IsOffline() bool {
+	return es.Flags&StatIsOffline != 0
+}
+
+// IsReadable indicates whether this read access to that entry is allowed.
+func (es EntryStat) IsReadable() bool {
+	return es.Flags&StatIsReadable != 0
+}
+
+// IsWritable indicates whether this write access to that entry is allowed.
+func (es EntryStat) IsWritable() bool {
+	return es.Flags&StatIsWritable != 0
+}
+
+// IsPOSCPending indicates whether this the file was created with kXR_posc and has not yet been successfully closed.
+// kXR_posc is an option of open request indicating that the "Persist On Successful Close" processing is enabled and
+// the file will be persisted only when it has been explicitly closed.
+func (es EntryStat) IsPOSCPending() bool {
+	return es.Flags&StatIsPOSCPending != 0
+}
+
+// MarshalXrd implements xrdproto.Marshaler.
+func (o EntryStat) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
+	if !o.HasStatInfo {
+		return nil
+	}
+
+	idStr := strconv.Itoa(int(o.ID))
+	sizeStr := strconv.Itoa(int(o.EntrySize))
+	flagsStr := strconv.Itoa(int(o.Flags))
+	mtimeStr := strconv.Itoa(int(o.Mtime))
+
+	wBuffer.WriteBytes([]byte(idStr + " " + sizeStr + " " + flagsStr + " " + mtimeStr))
+	return nil
+}
+
+// UnmarshalXrd implements xrdproto.Unmarshaler.
+func (o *EntryStat) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
+	var buf []byte
+	for rBuffer.Len() != 0 {
+		b := rBuffer.ReadU8()
+		if b == '\x00' || b == '\n' {
+			break
+		}
+		buf = append(buf, b)
+	}
+
+	stats := bytes.Split(buf, []byte{' '})
+	if len(stats) < 4 {
+		return errors.Errorf("xrootd: statinfo \"%s\" doesn't have enough fields, expected format is: \"id size flags modtime\"", buf)
+	}
+
+	id, err := strconv.Atoi(string(stats[0]))
+	if err != nil {
+		return err
+	}
+	size, err := strconv.Atoi(string(stats[1]))
+	if err != nil {
+		return err
+	}
+	flags, err := strconv.Atoi(string(stats[2]))
+	if err != nil {
+		return err
+	}
+	mtime, err := strconv.Atoi(string(stats[3]))
+	if err != nil {
+		return err
+	}
+
+	o.HasStatInfo = true
+	o.ID = int64(id)
+	o.EntrySize = int64(size)
+	o.Mtime = int64(mtime)
+	o.Flags = StatFlags(flags)
+
+	return nil
+}
+
+var (
+	_ os.FileInfo = (*EntryStat)(nil)
+)

--- a/xrootd/xrdproto/dirlist/dirlist.go
+++ b/xrootd/xrdproto/dirlist/dirlist.go
@@ -1,0 +1,123 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package dirlist contains the structures describing request and response
+// for dirlist request used to obtain the contents of a directory.
+package dirlist // import "go-hep.org/x/hep/xrootd/xrdproto/dirlist"
+
+import (
+	"bytes"
+
+	"github.com/pkg/errors"
+	"go-hep.org/x/hep/xrootd/internal/xrdenc"
+	"go-hep.org/x/hep/xrootd/xrdfs"
+)
+
+// RequestID is the id of the request, it is sent as part of message.
+// See xrootd protocol specification for details: http://xrootd.org/doc/dev45/XRdv310.pdf, 2.3 Client Request Format.
+const RequestID uint16 = 3004
+
+// Response is a response for the dirlist request,
+// which contains a slice of entries containing the entry name and the entry stat info.
+type Response struct {
+	Entries []xrdfs.EntryStat
+}
+
+// RespID implements xrdproto.Response.RespID
+func (resp *Response) RespID() uint16 { return RequestID }
+
+// MarshalXrd implements xrdproto.Marshaler
+func (o Response) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
+	// TODO: implement
+	panic(errors.New("xrootd: MarshalXrd is not implemented"))
+	return nil
+}
+
+// UnmarshalXrd implements xrdproto.Unmarshaler
+// When stat information is supported by the server, the format is
+//  ".\n"
+//  "0 0 0 0\n"
+//  "dirname\n"
+//  "id size flags modtime\n"
+//  ...
+//  0
+// Otherwise, the format is the following:
+//  "dirname\n"
+//  ...
+//  0
+// See xrootd protocol specification, page 45 for further details.
+func (o *Response) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
+	if rBuffer.Len() == 0 {
+		return nil
+	}
+
+	data := bytes.TrimRight(rBuffer.Bytes(), "\x00")
+	lines := bytes.Split(data, []byte{'\n'})
+
+	if !bytes.HasPrefix(data, []byte(".\n0 0 0 0\n")) {
+		// That means that the server doesn't support returning stat information.
+		o.Entries = make([]xrdfs.EntryStat, len(lines))
+		for i, v := range lines {
+			o.Entries[i] = xrdfs.EntryStat{EntryName: string(v)}
+		}
+		return nil
+	}
+
+	if len(lines)%2 != 0 {
+		return errors.Errorf("xrootd: wrong response size for the dirlist request: want even number of lines, got %d", len(lines))
+	}
+
+	lines = lines[2:]
+	o.Entries = make([]xrdfs.EntryStat, len(lines)/2)
+
+	for i := 0; i < len(lines); i += 2 {
+		var rbuf = xrdenc.NewRBuffer(lines[i+1])
+		err := o.Entries[i/2].UnmarshalXrd(rbuf)
+		if err != nil {
+			return err
+		}
+		o.Entries[i/2].EntryName = string(lines[i])
+	}
+
+	return nil
+}
+
+// Request holds the dirlist request parameters.
+type Request struct {
+	_       [15]byte
+	Options RequestOptions
+	Path    string
+}
+
+// RequestOptions specifies what should be returned as part of response.
+type RequestOptions byte
+
+const (
+	None         RequestOptions = 0 // None specifies that no addition information except entry names is required.
+	WithStatInfo RequestOptions = 2 // WithStatInfo specifies that stat information for every entry is required.
+)
+
+// NewRequest forms a Request according to provided path.
+func NewRequest(path string) *Request {
+	return &Request{Options: WithStatInfo, Path: path}
+}
+
+// ReqID implements xrdproto.Request.ReqID
+func (req *Request) ReqID() uint16 { return RequestID }
+
+// MarshalXrd implements xrdproto.Marshaler
+func (o Request) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
+	wBuffer.Next(15)
+	wBuffer.WriteU8(byte(o.Options))
+	wBuffer.WriteStr(o.Path)
+	return nil
+}
+
+// UnmarshalXrd implements xrdproto.Unmarshaler
+func (o *Request) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
+	rBuffer.Skip(15)
+	o.Options = RequestOptions(rBuffer.ReadU8())
+	o.Path = rBuffer.ReadStr()
+	return nil
+}

--- a/xrootd/xrdproto/signing.go
+++ b/xrootd/xrdproto/signing.go
@@ -4,7 +4,10 @@
 
 package xrdproto // import "go-hep.org/x/hep/xrootd/xrdproto"
 
-import "go-hep.org/x/hep/xrootd/internal/xrdenc"
+import (
+	"go-hep.org/x/hep/xrootd/internal/xrdenc"
+	"go-hep.org/x/hep/xrootd/xrdproto/dirlist"
+)
 
 // RequestLevel is the security requirement that the associated request is to have.
 type RequestLevel byte
@@ -102,6 +105,7 @@ func NewSignRequirements(level SecurityLevel, overrides []SecurityOverride) Sign
 	}
 	if level >= Pedantic {
 		// TODO: set requirements
+		sr.requirements[dirlist.RequestID] = SignNeeded
 	}
 
 	for _, override := range overrides {


### PR DESCRIPTION
Updates go-hep/hep#170.

I'm not sure about testing via `fs.Dirlist(context.Background(), "/tmp/.xrootd")`, since response may change. Probably we need to create some permanent directory on the remote server for test purposes?