### PR TITLE
rootio: implement scanner for Chain

### DIFF
--- a/rootio/tchain.go
+++ b/rootio/tchain.go
@@ -6,42 +6,79 @@ package rootio
 
 type tchain struct {
 	trees []Tree
+	offs  []int64 // number of entries before this tree
+	tots  []int64 // total number of entries up to this tree
+
+	cur  int   // current tree
+	tree Tree  // current tree
+	off  int64 // current offset
+	tot  int64 // current number of entries
+}
+
+// Chain returns a tchain that is the concatenation of all the input Trees.
+func Chain(trees ...Tree) Tree {
+	if len(trees) == 0 {
+		return &tchain{}
+	}
+	n := len(trees)
+	ch := &tchain{
+		trees: make([]Tree, n),
+		offs:  make([]int64, n),
+		tots:  make([]int64, n),
+		cur:   -1,
+	}
+	var (
+		sum int64
+		off int64
+	)
+	for i := range trees {
+		t := trees[i]
+		n := t.Entries()
+		sum += n
+		ch.trees[i] = t
+		ch.offs[i] = off
+		ch.tots[i] = sum
+		off += n
+	}
+	ch.nextTree()
+	return ch
+}
+
+func (ch *tchain) nextTree() {
+	ch.cur++
+	if ch.cur >= len(ch.trees) {
+		ch.tree = nil
+		return
+	}
+	ch.tree = ch.trees[ch.cur]
+	ch.off = ch.offs[ch.cur]
+	ch.tot = ch.tots[ch.cur]
+	return
 }
 
 // Class returns the ROOT class of the argument.
-func (tchain) Class() string {
+func (*tchain) Class() string {
 	return "TChain"
 }
 
 // Name returns the name of the ROOT objet in the argument.
-func (t tchain) Name() string {
-	if len(t.trees) == 0 {
+func (t *tchain) Name() string {
+	if t.tree == nil {
 		return ""
 	}
-	return t.trees[0].Name()
+	return t.tree.Name()
 }
 
 // Title returns the title of the ROOT object in the argument.
-func (t tchain) Title() string {
-	if len(t.trees) == 0 {
+func (t *tchain) Title() string {
+	if t.tree == nil {
 		return ""
 	}
-	return t.trees[0].Title()
-}
-
-// Chain returns a tchain that is the concatenation of all the input Trees.
-func Chain(trees ...Tree) tchain {
-	if len(trees) == 0 {
-		return tchain{}
-	}
-	var t tchain
-	t.trees = make([]Tree, len(trees))
-	copy(t.trees, trees)
-	return t
+	return t.tree.Title()
 }
 
 // Entries returns the total number of entries.
-func (t tchain) Entries() int64 {
+func (t *tchain) Entries() int64 {
 	var v int64
 	for _, tree := range t.trees {
 		v += tree.Entries()
@@ -50,7 +87,7 @@ func (t tchain) Entries() int64 {
 }
 
 // TotBytes return the total number of bytes before compression.
-func (t tchain) TotBytes() int64 {
+func (t *tchain) TotBytes() int64 {
 	var v int64
 	for _, tree := range t.trees {
 		v += tree.TotBytes()
@@ -59,7 +96,7 @@ func (t tchain) TotBytes() int64 {
 }
 
 // ZipBytes returns the total number of bytes after compression.
-func (t tchain) ZipBytes() int64 {
+func (t *tchain) ZipBytes() int64 {
 	var v int64
 	for _, tree := range t.trees {
 		v += tree.ZipBytes()
@@ -69,43 +106,44 @@ func (t tchain) ZipBytes() int64 {
 }
 
 // Branches returns the list of branches.
-func (t tchain) Branches() []Branch {
-	if len(t.trees) == 0 {
+func (t *tchain) Branches() []Branch {
+	if t.tree == nil {
 		return nil
 	}
-	return t.trees[0].Branches()
+	return t.tree.Branches()
 }
 
 // Branch returns the branch whose name is the argument.
-func (t tchain) Branch(name string) Branch {
-	if len(t.trees) == 0 {
+func (t *tchain) Branch(name string) Branch {
+	if t.tree == nil {
 		return nil
 	}
-	return t.trees[0].Branch(name)
+	return t.tree.Branch(name)
 }
 
 // Leaves returns direct pointers to individual branch leaves.
-func (t tchain) Leaves() []Leaf {
-	if len(t.trees) == 0 {
+func (t *tchain) Leaves() []Leaf {
+	if t.tree == nil {
 		return nil
 	}
-	return t.trees[0].Leaves()
+	return t.tree.Leaves()
 }
 
 // getFile returns the underlying file.
-func (t tchain) getFile() *File {
-	if len(t.trees) == 0 {
+func (t *tchain) getFile() *File {
+	if t.tree == nil {
 		return nil
 	}
-	return t.trees[0].getFile()
+	return t.tree.getFile()
 }
 
 // loadEntry returns an error if there is a problem during the loading.
-func (t tchain) loadEntry(i int64) error {
-	if len(t.trees) == 0 {
+func (t *tchain) loadEntry(i int64) error {
+	if t.tree == nil {
 		return nil
 	}
-	return t.trees[0].loadEntry(i)
+	j := i - t.off
+	return t.tree.loadEntry(j)
 }
 
 var (

--- a/rootio/tchain_test.go
+++ b/rootio/tchain_test.go
@@ -82,10 +82,13 @@ func TestChain(t *testing.T) {
 	}
 }
 
-func TestChainScan(t *testing.T) {
+func TestChainScanStruct(t *testing.T) {
 	files := []string{
 		"testdata/chain.1.root",
-		//	"testdata/chain.2.root", // FIXME(sbinet): implement for >1 tree
+		"testdata/chain.2.root",
+	}
+	var total struct {
+		got, want int64
 	}
 	trees := make([]rootio.Tree, len(files))
 	for i, fname := range files {
@@ -101,6 +104,7 @@ func TestChainScan(t *testing.T) {
 		}
 
 		trees[i] = obj.(rootio.Tree)
+		total.want += trees[i].Entries()
 	}
 
 	chain := rootio.Chain(trees...)
@@ -166,8 +170,14 @@ func TestChainScan(t *testing.T) {
 		if !reflect.DeepEqual(d2, want(i)) {
 			t.Fatalf("entry[%d]:\ngot= %#v\nwant=%#v\n", i, d2, want(i))
 		}
+		total.got++
 	}
+
 	if err := sc.Err(); err != nil && err != io.EOF {
 		t.Fatal(err)
+	}
+
+	if total.got != total.want {
+		t.Fatalf("entries scanned differ: got=%d want=%d", total.got, total.want)
 	}
 }


### PR DESCRIPTION
This CL implements the needed modifications to baseScanner to support
scanning a Chain via NewTreeScanner.

Missing support (code+tests):

 - NewTreeScannerVars
 - NewScannerVars
 - NewScanner

Updates go-hep/hep#44.