### PR TITLE
xrootd: add open request

### DIFF
--- a/xrootd/client/file.go
+++ b/xrootd/client/file.go
@@ -1,0 +1,35 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package client // import "go-hep.org/x/hep/xrootd/client"
+
+import "go-hep.org/x/hep/xrootd/xrdfs"
+
+// File implements access to a content and meta information of file over XRootD.
+type file struct {
+	fs          *fileSystem
+	handle      xrdfs.FileHandle
+	compression *xrdfs.FileCompression
+	info        *xrdfs.EntryStat
+}
+
+// Compression returns the compression info.
+func (f file) Compression() *xrdfs.FileCompression {
+	return f.compression
+}
+
+// Info returns the cached stat info.
+// Note that it may return nil if info was not yet fetched and info may be not up-to-date.
+func (f file) Info() *xrdfs.EntryStat {
+	return f.info
+}
+
+// Handle returns the file handle.
+func (f file) Handle() xrdfs.FileHandle {
+	return f.handle
+}
+
+var (
+	_ xrdfs.File = (*file)(nil)
+)

--- a/xrootd/client/filesystem.go
+++ b/xrootd/client/filesystem.go
@@ -9,6 +9,7 @@ import (
 
 	"go-hep.org/x/hep/xrootd/xrdfs"
 	"go-hep.org/x/hep/xrootd/xrdproto/dirlist"
+	"go-hep.org/x/hep/xrootd/xrdproto/open"
 )
 
 // FS returns a xrdfs.FileSystem which uses this client to make requests.
@@ -29,6 +30,16 @@ func (fs *fileSystem) Dirlist(ctx context.Context, path string) ([]xrdfs.EntrySt
 		return nil, err
 	}
 	return resp.Entries, err
+}
+
+// Open returns the file handle for a file together with the compression and the stat info.
+func (fs *fileSystem) Open(ctx context.Context, path string, mode xrdfs.OpenMode, options xrdfs.OpenOptions) (xrdfs.File, error) {
+	var resp open.Response
+	err := fs.c.Send(ctx, &resp, open.NewRequest(path, mode, options))
+	if err != nil {
+		return nil, err
+	}
+	return &file{fs, resp.FileHandle, resp.Compression, resp.Stat}, nil
 }
 
 var (

--- a/xrootd/client/filesystem_mock_test.go
+++ b/xrootd/client/filesystem_mock_test.go
@@ -10,9 +10,11 @@ import (
 	"reflect"
 	"testing"
 
+	"go-hep.org/x/hep/xrootd/internal/xrdenc"
 	"go-hep.org/x/hep/xrootd/xrdfs"
 	"go-hep.org/x/hep/xrootd/xrdproto"
 	"go-hep.org/x/hep/xrootd/xrdproto/dirlist"
+	"go-hep.org/x/hep/xrootd/xrdproto/open"
 )
 
 func TestFileSystem_Dirlist_Mock(t *testing.T) {
@@ -170,4 +172,110 @@ func TestFileSystem_Dirlist_Mock_WithoutStatInfo(t *testing.T) {
 	}
 
 	testClientWithMockServer(serverFunc, clientFunc)
+}
+
+func testFileSystem_Open_Mock(t *testing.T, wantFileHandle xrdfs.FileHandle, wantFileCompression *xrdfs.FileCompression, wantFileInfo *xrdfs.EntryStat) {
+	path := "/tmp/test"
+
+	var wantRequest = open.Request{
+		Path:    path,
+		Mode:    xrdfs.OpenModeOtherRead,
+		Options: xrdfs.OpenOptionsOpenRead,
+	}
+
+	serverFunc := func(cancel func(), conn net.Conn) {
+		data, err := readRequest(conn)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not read request: %v", err)
+		}
+
+		var gotRequest open.Request
+		gotHeader, err := unmarshalRequest(data, &gotRequest)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not unmarshal request: %v", err)
+		}
+
+		if gotHeader.RequestID != wantRequest.ReqID() {
+			cancel()
+			t.Fatalf("invalid request id was specified:\nwant = %d\ngot = %d\n", wantRequest.ReqID(), gotHeader.RequestID)
+		}
+
+		if !reflect.DeepEqual(gotRequest, wantRequest) {
+			cancel()
+			t.Fatalf("request info does not match:\ngot = %v\nwant = %v", gotRequest, wantRequest)
+		}
+
+		response := open.Response{
+			FileHandle:  wantFileHandle,
+			Compression: wantFileCompression,
+			Stat:        wantFileInfo,
+		}
+
+		var wBuffer xrdenc.WBuffer
+		err = response.MarshalXrd(&wBuffer)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not marshal response: %v", err)
+		}
+
+		responseHeader := xrdproto.ResponseHeader{
+			StreamID:   gotHeader.StreamID,
+			DataLength: int32(len(wBuffer.Bytes())),
+		}
+
+		responseData, err := marshalResponse(responseHeader)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not marshal response header: %v", err)
+		}
+		responseData = append(responseData, wBuffer.Bytes()...)
+
+		if err := writeResponse(conn, responseData); err != nil {
+			cancel()
+			t.Fatalf("invalid write: %s", err)
+		}
+	}
+
+	clientFunc := func(cancel func(), client *Client) {
+		fs := client.FS()
+		gotFile, err := fs.Open(context.Background(), path, xrdfs.OpenModeOtherRead, xrdfs.OpenOptionsOpenRead)
+		if err != nil {
+			t.Fatalf("invalid dirlist call: %v", err)
+		}
+
+		if !reflect.DeepEqual(gotFile.Handle(), wantFileHandle) {
+			t.Errorf("Filesystem.Open()\ngotFile.Handle() = %v\nwantFileHandle = %v", gotFile.Handle(), wantFileHandle)
+		}
+
+		if !reflect.DeepEqual(gotFile.Compression(), wantFileCompression) {
+			t.Errorf("Filesystem.Open()\ngotFile.Compression() = %v\nwantFileCompression = %v", gotFile.Compression(), wantFileCompression)
+		}
+		if !reflect.DeepEqual(gotFile.Info(), wantFileInfo) {
+			t.Errorf("Filesystem.Open()\ngotFile.Info() = %v\nwantFileInfo = %v", gotFile.Info(), wantFileInfo)
+		}
+	}
+
+	testClientWithMockServer(serverFunc, clientFunc)
+}
+
+func TestFileSystem_Open_Mock(t *testing.T) {
+	testCases := []struct {
+		name        string
+		handle      xrdfs.FileHandle
+		compression *xrdfs.FileCompression
+		stat        *xrdfs.EntryStat
+	}{
+		{"WithoutCompressionAndStat", xrdfs.FileHandle{0, 0, 0, 0}, nil, nil},
+		{"WithEmptyCompression", xrdfs.FileHandle{0, 0, 0, 0}, &xrdfs.FileCompression{}, nil},
+		{"WithCompression", xrdfs.FileHandle{0, 0, 0, 0}, &xrdfs.FileCompression{10, [4]byte{'t', 'e', 's', 't'}}, nil},
+		{"WithStat", xrdfs.FileHandle{0, 0, 0, 0}, &xrdfs.FileCompression{}, &xrdfs.EntryStat{HasStatInfo: true, EntrySize: 10}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testFileSystem_Open_Mock(t, tc.handle, tc.compression, tc.stat)
+		})
+	}
 }

--- a/xrootd/xrdfs/file.go
+++ b/xrootd/xrdfs/file.go
@@ -1,0 +1,43 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xrdfs
+
+import (
+	"go-hep.org/x/hep/xrootd/internal/xrdenc"
+)
+
+// File implements access to a content and meta information of file over XRootD.
+type File interface {
+	// Compression returns the compression info.
+	Compression() *FileCompression
+	// Info returns the cached stat info.
+	// Note that it may return nil if info was not yet fetched and info may be not up-to-date.
+	Info() *EntryStat
+	// Handle returns the file handle.
+	Handle() FileHandle
+}
+
+// FileHandle is the file handle, which should be treated as opaque data.
+type FileHandle [4]byte
+
+// FileCompression holds the compression parameters such as the page size and the type of compression.
+type FileCompression struct {
+	PageSize int32
+	Type     [4]byte
+}
+
+// MarshalXrd implements xrdproto.Marshaler
+func (o FileCompression) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
+	wBuffer.WriteI32(o.PageSize)
+	wBuffer.WriteBytes(o.Type[:])
+	return nil
+}
+
+// UnmarshalXrd implements xrdproto.Unmarshaler
+func (o *FileCompression) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
+	o.PageSize = rBuffer.ReadI32()
+	rBuffer.ReadBytes(o.Type[:])
+	return nil
+}

--- a/xrootd/xrdfs/fs.go
+++ b/xrootd/xrdfs/fs.go
@@ -12,4 +12,61 @@ import (
 // FileSystem implements access to a collection of named files over XRootD.
 type FileSystem interface {
 	Dirlist(ctx context.Context, path string) ([]EntryStat, error)
+	Open(ctx context.Context, path string, mode OpenMode, options OpenOptions) (File, error)
 }
+
+// OpenMode is the mode in which path is to be opened.
+// The mode is an "or`d" combination of ModeXyz flags.
+type OpenMode uint16
+
+const (
+	OpenModeOwnerRead    OpenMode = 0x100 // OpenModeOwnerRead indicates that owner has read access.
+	OpenModeOwnerWrite   OpenMode = 0x080 // OpenModeOwnerWrite indicates that owner has write access.
+	OpenModeOwnerExecute OpenMode = 0x040 // OpenModeOwnerExecute indicates that owner has execute access.
+
+	OpenModeGroupRead    OpenMode = 0x020 // OpenModeGroupRead indicates that group has read access.
+	OpenModeGroupWrite   OpenMode = 0x010 // OpenModeGroupWrite indicates that group has write access.
+	OpenModeGroupExecute OpenMode = 0x008 // OpenModeGroupExecute indicates that group has execute access.
+
+	OpenModeOtherRead    OpenMode = 0x004 // OpenModeOtherRead indicates that owner has read access.
+	OpenModeOtherWrite   OpenMode = 0x002 // OpenModeOtherWrite indicates that owner has write access.
+	OpenModeOtherExecute OpenMode = 0x001 // OpenModeOtherExecute indicates that owner has execute access.
+)
+
+// OpenOptions are the options to apply when path is opened.
+type OpenOptions uint16
+
+const (
+	// OpenOptionsCompress specifies that file is opened even when compressed.
+	OpenOptionsCompress OpenOptions = 1 << iota
+	// OpenOptionsDelete specifies that file is opened deleting any existing file.
+	OpenOptionsDelete
+	// OpenOptionsForce specifies that file is opened ignoring  file usage rules.
+	OpenOptionsForce
+	// OpenOptionsNew specifies that file is opened only if it does not already exist.
+	OpenOptionsNew
+	// OpenOptionsOpenRead specifies that file is opened only for reading.
+	OpenOptionsOpenRead
+	// OpenOptionsOpenUpdate specifies that file is opened only for reading and writing.
+	OpenOptionsOpenUpdate
+	// OpenOptionsAsync specifies that file is opened for asynchronous i/o.
+	OpenOptionsAsync
+	// OpenOptionsRefresh specifies that cached information on the file's location need to be updated.
+	OpenOptionsRefresh
+	// OpenOptionsMkPath specifies that directory path is created if it does not already exist.
+	OpenOptionsMkPath
+	// OpenOptionsOpenAppend specifies that file is opened only for appending.
+	OpenOptionsOpenAppend
+	// OpenOptionsReturnStatus specifies that file status information should be returned in the response.
+	OpenOptionsReturnStatus
+	// OpenOptionsReplica specifies that file is opened for replica creation.
+	OpenOptionsReplica
+	// OpenOptionsPOSC specifies that Persist On Successful Close (POSC) processing should be enabled.
+	OpenOptionsPOSC
+	// OpenOptionsNoWait specifies that file is opened only if it does not cause a wait.
+	OpenOptionsNoWait
+	// OpenOptionsSequentiallyIO specifies that file will be read or written sequentially.
+	OpenOptionsSequentiallyIO
+	// OpenOptionsNone specifies that file is opened without specific options.
+	OpenOptionsNone OpenOptions = 0
+)

--- a/xrootd/xrdproto/open/open.go
+++ b/xrootd/xrdproto/open/open.go
@@ -1,0 +1,101 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package open contains the structures describing request and response for open request.
+// See xrootd protocol specification (http://xrootd.org/doc/dev45/XRdv310.pdf, p. 63) for details.
+package open // import "go-hep.org/x/hep/xrootd/xrdproto/open"
+
+import (
+	"go-hep.org/x/hep/xrootd/internal/xrdenc"
+	"go-hep.org/x/hep/xrootd/xrdfs"
+)
+
+// RequestID is the id of the request, it is sent as part of message.
+// See xrootd protocol specification for details: http://xrootd.org/doc/dev45/XRdv310.pdf, 2.3 Client Request Format.
+const RequestID uint16 = 3010
+
+// Response is a response for the open request,
+// which contains the file handle, the compression page size,
+// the compression type and the stat information.
+type Response struct {
+	FileHandle  xrdfs.FileHandle
+	Compression *xrdfs.FileCompression
+	Stat        *xrdfs.EntryStat
+}
+
+// MarshalXrd implements xrdproto.Marshaler
+func (o Response) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
+	wBuffer.WriteBytes(o.FileHandle[:])
+	if o.Compression == nil {
+		return nil
+	}
+	if err := o.Compression.MarshalXrd(wBuffer); err != nil {
+		return err
+	}
+
+	if o.Stat == nil {
+		return nil
+	}
+	if err := o.Stat.MarshalXrd(wBuffer); err != nil {
+		return err
+	}
+	return nil
+}
+
+// UnmarshalXrd implements xrdproto.Unmarshaler
+func (o *Response) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
+	rBuffer.ReadBytes(o.FileHandle[:])
+	if rBuffer.Len() == 0 {
+		return nil
+	}
+	o.Compression = &xrdfs.FileCompression{}
+	if err := o.Compression.UnmarshalXrd(rBuffer); err != nil {
+		return err
+	}
+	if rBuffer.Len() == 0 {
+		return nil
+	}
+	o.Stat = &xrdfs.EntryStat{}
+	if err := o.Stat.UnmarshalXrd(rBuffer); err != nil {
+		return err
+	}
+	return nil
+}
+
+// RespID implements xrdproto.Response.RespID
+func (resp *Response) RespID() uint16 { return RequestID }
+
+// Request holds open request parameters.
+type Request struct {
+	Mode    xrdfs.OpenMode
+	Options xrdfs.OpenOptions
+	_       [12]byte
+	Path    string
+}
+
+// NewRequest forms a Request according to provided path, mode, and options.
+func NewRequest(path string, mode xrdfs.OpenMode, options xrdfs.OpenOptions) *Request {
+	return &Request{Mode: mode, Options: options, Path: path}
+}
+
+// MarshalXrd implements xrdproto.Marshaler
+func (o Request) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
+	wBuffer.WriteU16(uint16(o.Mode))
+	wBuffer.WriteU16(uint16(o.Options))
+	wBuffer.Next(12)
+	wBuffer.WriteStr(o.Path)
+	return nil
+}
+
+// UnmarshalXrd implements xrdproto.Unmarshaler
+func (o *Request) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
+	o.Mode = xrdfs.OpenMode(rBuffer.ReadU16())
+	o.Options = xrdfs.OpenOptions(rBuffer.ReadU16())
+	rBuffer.Skip(12)
+	o.Path = rBuffer.ReadStr()
+	return nil
+}
+
+// ReqID implements xrdproto.Request.ReqID
+func (req *Request) ReqID() uint16 { return RequestID }

--- a/xrootd/xrdproto/signing.go
+++ b/xrootd/xrdproto/signing.go
@@ -7,6 +7,7 @@ package xrdproto // import "go-hep.org/x/hep/xrootd/xrdproto"
 import (
 	"go-hep.org/x/hep/xrootd/internal/xrdenc"
 	"go-hep.org/x/hep/xrootd/xrdproto/dirlist"
+	"go-hep.org/x/hep/xrootd/xrdproto/open"
 )
 
 // RequestLevel is the security requirement that the associated request is to have.
@@ -96,16 +97,20 @@ func NewSignRequirements(level SecurityLevel, overrides []SecurityOverride) Sign
 
 	if level >= Compatible {
 		// TODO: set requirements
+		sr.requirements[open.RequestID] = SignLikely
 	}
 	if level >= Standard {
 		// TODO: set requirements
+		sr.requirements[open.RequestID] = SignNeeded
 	}
 	if level >= Intense {
 		// TODO: set requirements
+		sr.requirements[open.RequestID] = SignNeeded
 	}
 	if level >= Pedantic {
 		// TODO: set requirements
 		sr.requirements[dirlist.RequestID] = SignNeeded
+		sr.requirements[open.RequestID] = SignNeeded
 	}
 
 	for _, override := range overrides {


### PR DESCRIPTION
Updates go-hep/hep#170 (haven't included in the commit message since I expect rebases because of https://github.com/go-hep/hep/pull/214 and https://github.com/go-hep/hep/pull/211 and it will pollute issue with each commit)

Note that `open` request isn't added to `signing.go` because it creates a cycle import. Any suggestions on how to deal with that? Probably we can move `signing` to `protocol/signing` to fix that?

Also, note that there is a test workaround due to https://github.com/xrootd/xrootd/issues/721.

Also, I'm unsure about `UnmarshalXrd` in `EntryStat` and `NewEntryStat`. It duplicates logic, but otherwise  call to `UnmarshalXrd` in `dirlist.go`, `(Response) UnmarshalXrd(...)` will be like that:
```go
o.Entries[i/2].UnmarshalXrd(xrdenc.NewRBuffer([]byte(lines[i+1)]))
```