### PR TITLE
xrootd/...: rename package protocol into xrdproto

### DIFF
--- a/xrootd/client/handshake.go
+++ b/xrootd/client/handshake.go
@@ -8,12 +8,12 @@ import (
 	"context"
 
 	"go-hep.org/x/hep/xrootd/internal/xrdenc"
-	"go-hep.org/x/hep/xrootd/protocol"
-	"go-hep.org/x/hep/xrootd/protocol/handshake"
+	"go-hep.org/x/hep/xrootd/xrdproto"
+	"go-hep.org/x/hep/xrootd/xrdproto/handshake"
 )
 
 func (client *Client) handshake(ctx context.Context) error {
-	responseChannel, err := client.mux.ClaimWithID(protocol.StreamID{0, 0})
+	responseChannel, err := client.mux.ClaimWithID(xrdproto.StreamID{0, 0})
 	if err != nil {
 		return err
 	}
@@ -31,7 +31,7 @@ func (client *Client) handshake(ctx context.Context) error {
 	}
 
 	var result handshake.Response
-	if err = protocol.Unmarshal(resp, &result); err != nil {
+	if err = xrdproto.Unmarshal(resp, &result); err != nil {
 		return err
 	}
 

--- a/xrootd/client/login.go
+++ b/xrootd/client/login.go
@@ -7,7 +7,7 @@ package client // import "go-hep.org/x/hep/xrootd/client"
 import (
 	"context"
 
-	"go-hep.org/x/hep/xrootd/protocol/login"
+	"go-hep.org/x/hep/xrootd/xrdproto/login"
 )
 
 // Login initializes a server connection using username

--- a/xrootd/client/login_mock_test.go
+++ b/xrootd/client/login_mock_test.go
@@ -11,8 +11,8 @@ import (
 	"reflect"
 	"testing"
 
-	"go-hep.org/x/hep/xrootd/protocol"
-	"go-hep.org/x/hep/xrootd/protocol/login"
+	"go-hep.org/x/hep/xrootd/xrdproto"
+	"go-hep.org/x/hep/xrootd/xrdproto/login"
 )
 
 func TestClient_Login_Mock(t *testing.T) {
@@ -58,7 +58,7 @@ func TestClient_Login_Mock(t *testing.T) {
 			t.Fatalf("request info does not match:\ngot = %v\nwant= %v", gotRequest, wantRequest)
 		}
 
-		responseHeader := protocol.ResponseHeader{
+		responseHeader := xrdproto.ResponseHeader{
 			StreamID:   gotHeader.StreamID,
 			DataLength: login.ResponseLength + int32(len(want.SecurityInformation)),
 		}

--- a/xrootd/client/protocol.go
+++ b/xrootd/client/protocol.go
@@ -7,7 +7,7 @@ package client // import "go-hep.org/x/hep/xrootd/client"
 import (
 	"context"
 
-	"go-hep.org/x/hep/xrootd/protocol/protocol"
+	"go-hep.org/x/hep/xrootd/xrdproto/protocol"
 )
 
 // Protocol obtains the protocol version number, type of the server and security information, such as:

--- a/xrootd/client/protocol_mock_test.go
+++ b/xrootd/client/protocol_mock_test.go
@@ -10,8 +10,8 @@ import (
 	"reflect"
 	"testing"
 
-	xrdproto "go-hep.org/x/hep/xrootd/protocol"
-	"go-hep.org/x/hep/xrootd/protocol/protocol"
+	"go-hep.org/x/hep/xrootd/xrdproto"
+	"go-hep.org/x/hep/xrootd/xrdproto/protocol"
 )
 
 func TestClient_Protocol_WithSecurityInfo(t *testing.T) {

--- a/xrootd/client/protocol_test.go
+++ b/xrootd/client/protocol_test.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"testing"
 
-	"go-hep.org/x/hep/xrootd/protocol/protocol"
+	"go-hep.org/x/hep/xrootd/xrdproto/protocol"
 )
 
 func testClient_Protocol(t *testing.T, addr string) {

--- a/xrootd/internal/mux/mux_test.go
+++ b/xrootd/internal/mux/mux_test.go
@@ -8,13 +8,13 @@ import (
 	"reflect"
 	"testing"
 
-	"go-hep.org/x/hep/xrootd/protocol"
+	"go-hep.org/x/hep/xrootd/xrdproto"
 )
 
 func TestMux_Claim(t *testing.T) {
 	m := New()
 	defer m.Close()
-	claimedIds := map[protocol.StreamID]bool{}
+	claimedIds := map[xrdproto.StreamID]bool{}
 
 	for i := 0; i < streamIDPoolSize; i++ {
 		id, channel, err := m.Claim()
@@ -42,14 +42,14 @@ func TestMux_Claim(t *testing.T) {
 func TestMux_Claim_AfterUnclaim(t *testing.T) {
 	m := New()
 	defer m.Close()
-	claimedIds := map[protocol.StreamID]bool{}
+	claimedIds := map[xrdproto.StreamID]bool{}
 
 	for i := 0; i < streamIDPoolSize; i++ {
 		id, _, _ := m.Claim()
 		claimedIds[id] = true
 	}
 
-	wantID := protocol.StreamID{13, 14}
+	wantID := xrdproto.StreamID{13, 14}
 	m.Unclaim(wantID)
 
 	gotID, channel, err := m.Claim()
@@ -75,7 +75,7 @@ func TestMux_ClaimWithID_WhenIDIsFree(t *testing.T) {
 	m := New()
 	defer m.Close()
 
-	streamID := protocol.StreamID{13, 14}
+	streamID := xrdproto.StreamID{13, 14}
 	channel, err := m.ClaimWithID(streamID)
 
 	if err != nil {
@@ -92,7 +92,7 @@ func TestMux_ClaimWithID_WhenIDIsFree(t *testing.T) {
 func TestMux_ClaimWithID_WhenIDIsTakenByClaimWithID(t *testing.T) {
 	m := New()
 	defer m.Close()
-	streamID := protocol.StreamID{13, 14}
+	streamID := xrdproto.StreamID{13, 14}
 	m.ClaimWithID(streamID)
 
 	_, err := m.ClaimWithID(streamID)
@@ -121,7 +121,7 @@ func TestMux_ClaimWithID_WhenIDIsTakenByClaim(t *testing.T) {
 func TestMux_Claim_WhenIDIsTakenByClaimWithID(t *testing.T) {
 	m := New()
 	defer m.Close()
-	takenID := protocol.StreamID{0, 0}
+	takenID := xrdproto.StreamID{0, 0}
 	m.ClaimWithID(takenID)
 
 	id, channel, err := m.Claim()
@@ -145,7 +145,7 @@ func TestMux_Claim_WhenIDIsTakenByClaimWithID(t *testing.T) {
 func TestMux_SendData_WhenIDIsTaken(t *testing.T) {
 	m := New()
 	defer m.Close()
-	takenID := protocol.StreamID{0, 0}
+	takenID := xrdproto.StreamID{0, 0}
 	want := ServerResponse{}
 	var got ServerResponse
 
@@ -168,7 +168,7 @@ func TestMux_SendData_WhenIDIsTaken(t *testing.T) {
 func TestMux_SendData_WhenIDIsNotTaken(t *testing.T) {
 	m := New()
 	defer m.Close()
-	notTakenID := protocol.StreamID{0, 0}
+	notTakenID := xrdproto.StreamID{0, 0}
 
 	err := m.SendData(notTakenID, ServerResponse{})
 
@@ -186,7 +186,7 @@ func TestMux_Close_WhenAlreadyClosed(t *testing.T) {
 func TestMux_Unclaim_WhenNotClaimed(t *testing.T) {
 	m := New()
 	defer m.Close()
-	m.Unclaim(protocol.StreamID{0, 0})
+	m.Unclaim(xrdproto.StreamID{0, 0})
 }
 
 func TestMux_Claim_WhenClosed(t *testing.T) {
@@ -201,7 +201,7 @@ func TestMux_Claim_WhenClosed(t *testing.T) {
 func TestMux_ClaimWithID_WhenClosed(t *testing.T) {
 	m := New()
 	m.Close()
-	_, err := m.ClaimWithID(protocol.StreamID{0, 0})
+	_, err := m.ClaimWithID(xrdproto.StreamID{0, 0})
 	if err == nil {
 		t.Fatal("should not be able to ClaimWithID when mux is closed")
 	}

--- a/xrootd/xrdproto/gen-marshal.go
+++ b/xrootd/xrdproto/gen-marshal.go
@@ -107,7 +107,7 @@ func (g *Generator) Generate(typeName string) {
 }
 
 func (g *Generator) genMarshalXrd(t types.Type, typeName string) {
-	g.printf(`// MarshalXrd implements xrootd/protocol.Marshaler
+	g.printf(`// MarshalXrd implements xrdproto.Marshaler
 func (o %[1]s) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
 `,
 		typeName,
@@ -204,7 +204,7 @@ func (g *Generator) genMarshalType(t types.Type, n string) {
 }
 
 func (g *Generator) genUnmarshalXrd(t types.Type, typeName string) {
-	g.printf(`// UnmarshalXrd implements xrootd/protocol.Unmarshaler
+	g.printf(`// UnmarshalXrd implements xrdproto.Unmarshaler
 func (o *%[1]s) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
 `,
 		typeName,

--- a/xrootd/xrdproto/handshake/handshake.go
+++ b/xrootd/xrdproto/handshake/handshake.go
@@ -4,31 +4,31 @@
 
 // Package handshake contains the structures describing request and response
 // for handshake request (see XRootD specification).
-package handshake // import "go-hep.org/x/hep/xrootd/protocol/handshake"
+package handshake // import "go-hep.org/x/hep/xrootd/xrdproto/handshake"
 
 import (
 	"go-hep.org/x/hep/xrootd/internal/xrdenc"
-	"go-hep.org/x/hep/xrootd/protocol"
+	"go-hep.org/x/hep/xrootd/xrdproto"
 )
 
 // Response is a response for the handshake request,
 // which contains protocol version and server type.
 type Response struct {
 	ProtocolVersion int32
-	ServerType      protocol.ServerType
+	ServerType      xrdproto.ServerType
 }
 
-// MarshalXrd implements xrootd/protocol.Marshaler
+// MarshalXrd implements xrdproto.Marshaler
 func (o Response) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
 	wBuffer.WriteI32(o.ProtocolVersion)
 	wBuffer.WriteI32(int32(o.ServerType))
 	return nil
 }
 
-// UnmarshalXrd implements xrootd/protocol.Unmarshaler
+// UnmarshalXrd implements xrdproto.Unmarshaler
 func (o *Response) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
 	o.ProtocolVersion = rBuffer.ReadI32()
-	o.ServerType = protocol.ServerType(rBuffer.ReadI32())
+	o.ServerType = xrdproto.ServerType(rBuffer.ReadI32())
 	return nil
 }
 
@@ -46,7 +46,7 @@ func NewRequest() Request {
 	return Request{0, 0, 0, 4, 2012}
 }
 
-// MarshalXrd implements xrootd/protocol.Marshaler
+// MarshalXrd implements xrdproto.Marshaler
 func (o Request) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
 	wBuffer.WriteI32(o.Reserved1)
 	wBuffer.WriteI32(o.Reserved2)
@@ -56,7 +56,7 @@ func (o Request) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
 	return nil
 }
 
-// UnmarshalXrd implements xrootd/protocol.Unmarshaler
+// UnmarshalXrd implements xrdproto.Unmarshaler
 func (o *Request) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
 	o.Reserved1 = rBuffer.ReadI32()
 	o.Reserved2 = rBuffer.ReadI32()

--- a/xrootd/xrdproto/login/login.go
+++ b/xrootd/xrdproto/login/login.go
@@ -10,7 +10,7 @@
 // defines the available authentication protocols together with some additional parameters.
 // See XRootD protocol specification, page 127 for further information
 // about the format of the SecurityInformation.
-package login // import "go-hep.org/x/hep/xrootd/protocol/login"
+package login // import "go-hep.org/x/hep/xrootd/xrdproto/login"
 
 import (
 	"os"
@@ -31,17 +31,17 @@ type Response struct {
 	SecurityInformation []byte
 }
 
-// RespID implements protocol.Response.RespID
+// RespID implements xrdproto.Response.RespID
 func (resp *Response) RespID() uint16 { return RequestID }
 
-// MarshalXrd implements xrootd/protocol.Marshaler
+// MarshalXrd implements xrdproto.Marshaler
 func (o Response) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
 	wBuffer.WriteBytes(o.SessionID[:])
 	wBuffer.WriteBytes(o.SecurityInformation)
 	return nil
 }
 
-// UnmarshalXrd implements xrootd/protocol.Unmarshaler
+// UnmarshalXrd implements xrdproto.Unmarshaler
 func (o *Response) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
 	rBuffer.ReadBytes(o.SessionID[:])
 	o.SecurityInformation = append(o.SecurityInformation, rBuffer.Bytes()...)
@@ -75,10 +75,10 @@ func NewRequest(username, token string) *Request {
 	}
 }
 
-// ReqID implements protocol.Request.ReqID
+// ReqID implements xrdproto.Request.ReqID
 func (req *Request) ReqID() uint16 { return RequestID }
 
-// MarshalXrd implements xrootd/protocol.Marshaler
+// MarshalXrd implements xrdproto.Marshaler
 func (o Request) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
 	wBuffer.WriteI32(o.Pid)
 	wBuffer.WriteBytes(o.Username[:])
@@ -91,7 +91,7 @@ func (o Request) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
 	return nil
 }
 
-// UnmarshalXrd implements xrootd/protocol.Unmarshaler
+// UnmarshalXrd implements xrdproto.Unmarshaler
 func (o *Request) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
 	o.Pid = rBuffer.ReadI32()
 	rBuffer.ReadBytes(o.Username[:])

--- a/xrootd/xrdproto/marshaling.go
+++ b/xrootd/xrdproto/marshaling.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package protocol // import "go-hep.org/x/hep/xrootd/protocol"
+package xrdproto // import "go-hep.org/x/hep/xrootd/xrdproto"
 
 import (
 	"encoding/binary"

--- a/xrootd/xrdproto/marshaling_test.go
+++ b/xrootd/xrdproto/marshaling_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package protocol // import "go-hep.org/x/hep/xrootd/protocol"
+package xrdproto // import "go-hep.org/x/hep/xrootd/xrdproto"
 
 import (
 	"reflect"

--- a/xrootd/xrdproto/protocol.go
+++ b/xrootd/xrdproto/protocol.go
@@ -4,7 +4,7 @@
 
 // Package protocol contains the XRootD protocol specific types
 // and methods to handle them, such as marshalling and unmarshalling requests.
-package protocol // import "go-hep.org/x/hep/xrootd/protocol"
+package xrdproto // import "go-hep.org/x/hep/xrootd/xrdproto"
 
 import (
 	"encoding/binary"
@@ -51,7 +51,7 @@ type ResponseHeader struct {
 	DataLength int32
 }
 
-// MarshalXrd implements xrootd/protocol.Marshaler
+// MarshalXrd implements xrdproto.Marshaler
 func (o ResponseHeader) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
 	wBuffer.WriteBytes(o.StreamID[:])
 	wBuffer.WriteU16(uint16(o.Status))
@@ -59,7 +59,7 @@ func (o ResponseHeader) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
 	return nil
 }
 
-// UnmarshalXrd implements xrootd/protocol.Unmarshaler
+// UnmarshalXrd implements xrdproto.Unmarshaler
 func (o *ResponseHeader) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
 	rBuffer.ReadBytes(o.StreamID[:])
 	o.Status = ResponseStatus(rBuffer.ReadU16())

--- a/xrootd/xrdproto/protocol/protocol.go
+++ b/xrootd/xrdproto/protocol/protocol.go
@@ -15,11 +15,11 @@
 // and the number of following security overrides, if any.
 //
 // 3) A list of SecurityOverride - alterations needed to the specified predefined security level.
-package protocol // import "go-hep.org/x/hep/xrootd/protocol/protocol"
+package protocol // import "go-hep.org/x/hep/xrootd/xrdproto/protocol"
 
 import (
 	"go-hep.org/x/hep/xrootd/internal/xrdenc"
-	"go-hep.org/x/hep/xrootd/protocol"
+	"go-hep.org/x/hep/xrootd/xrdproto"
 )
 
 // RequestID is the id of the request, it is sent as part of message.
@@ -75,10 +75,10 @@ func NewRequest(protocolVersion int32, withSecurityRequirements bool) *Request {
 	return &Request{ClientProtocolVersion: protocolVersion, Options: options}
 }
 
-// ReqID implements protocol.Request.ReqID
+// ReqID implements xrdproto.Request.ReqID
 func (req *Request) ReqID() uint16 { return RequestID }
 
-// MarshalXrd implements xrootd/protocol.Marshaler
+// MarshalXrd implements xrdproto.Marshaler
 func (o Request) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
 	wBuffer.WriteI32(o.ClientProtocolVersion)
 	wBuffer.WriteU8(byte(o.Options))
@@ -86,7 +86,7 @@ func (o Request) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
 	return nil
 }
 
-// UnmarshalXrd implements xrootd/protocol.Unmarshaler
+// UnmarshalXrd implements xrdproto.Unmarshaler
 func (o *Request) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
 	o.ClientProtocolVersion = rBuffer.ReadI32()
 	o.Options = RequestOptions(rBuffer.ReadU8())
@@ -103,8 +103,8 @@ type Response struct {
 	_                     byte
 	SecurityVersion       byte
 	SecurityOptions       SecurityOptions
-	SecurityLevel         protocol.SecurityLevel
-	SecurityOverrides     []protocol.SecurityOverride
+	SecurityLevel         xrdproto.SecurityLevel
+	SecurityOverrides     []xrdproto.SecurityOverride
 }
 
 // IsManager indicates whether this server has manager role.
@@ -138,7 +138,7 @@ func (resp *Response) ForceSecurity() bool {
 	return resp.SecurityOptions&ForceSecurity != 0
 }
 
-// MarshalXrd implements xrootd/protocol.Marshaler
+// MarshalXrd implements xrdproto.Marshaler
 func (o Response) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
 	wBuffer.WriteI32(o.BinaryProtocolVersion)
 	wBuffer.WriteI32(int32(o.Flags))
@@ -160,7 +160,7 @@ func (o Response) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
 	return nil
 }
 
-// UnmarshalXrd implements xrootd/protocol.Unmarshaler
+// UnmarshalXrd implements xrdproto.Unmarshaler
 func (o *Response) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
 	o.BinaryProtocolVersion = rBuffer.ReadI32()
 	o.Flags = Flags(rBuffer.ReadI32())
@@ -172,8 +172,8 @@ func (o *Response) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
 	rBuffer.Skip(1)
 	o.SecurityVersion = rBuffer.ReadU8()
 	o.SecurityOptions = SecurityOptions(rBuffer.ReadU8())
-	o.SecurityLevel = protocol.SecurityLevel(rBuffer.ReadU8())
-	o.SecurityOverrides = make([]protocol.SecurityOverride, rBuffer.ReadU8())
+	o.SecurityLevel = xrdproto.SecurityLevel(rBuffer.ReadU8())
+	o.SecurityOverrides = make([]xrdproto.SecurityOverride, rBuffer.ReadU8())
 	for i := 0; i < len(o.SecurityOverrides); i++ {
 		err := o.SecurityOverrides[i].UnmarshalXrd(rBuffer)
 		if err != nil {
@@ -183,5 +183,5 @@ func (o *Response) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
 	return nil
 }
 
-// RespID implements protocol.Response.RespID
+// RespID implements xrdproto.Response.RespID
 func (resp *Response) RespID() uint16 { return RequestID }

--- a/xrootd/xrdproto/signing.go
+++ b/xrootd/xrdproto/signing.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package protocol // import "go-hep.org/x/hep/xrootd/protocol"
+package xrdproto // import "go-hep.org/x/hep/xrootd/xrdproto"
 
 import "go-hep.org/x/hep/xrootd/internal/xrdenc"
 
@@ -46,14 +46,14 @@ type SecurityOverride struct {
 	RequestLevel RequestLevel
 }
 
-// MarshalXrd implements xrootd/protocol.Marshaler
+// MarshalXrd implements xrdproto.Marshaler
 func (o SecurityOverride) MarshalXrd(enc *xrdenc.WBuffer) error {
 	enc.WriteU8(o.RequestIndex)
 	enc.WriteU8(byte(o.RequestLevel))
 	return nil
 }
 
-// UnmarshalXrd implements xrootd/protocol.Unmarshaler
+// UnmarshalXrd implements xrdproto.Unmarshaler
 func (o *SecurityOverride) UnmarshalXrd(dec *xrdenc.RBuffer) error {
 	o.RequestIndex = dec.ReadU8()
 	o.RequestLevel = RequestLevel(dec.ReadU8())


### PR DESCRIPTION
mechanically produced with:

```
mkdir pkg
gomvpkg -from go-hep.org/x/hep/xrootd/protocol/login -to go-hep.org/x/hep/xrootd/pkg/login -vcs_mv_cmd "git mv {{.Src}} {{.Dst}}"
gomvpkg -from go-hep.org/x/hep/xrootd/protocol/handshake -to go-hep.org/x/hep/xrootd/pkg/handshake -vcs_mv_cmd "git mv {{.Src}} {{.Dst}}"
gomvpkg -from go-hep.org/x/hep/xrootd/protocol/protocol -to go-hep.org/x/hep/xrootd/pkg/protocol -vcs_mv_cmd "git mv {{.Src}} {{.Dst}}"
gomvpkg -from go-hep.org/x/hep/xrootd/protocol -to go-hep.org/x/hep/xrootd/xrdproto -vcs_mv_cmd "git mv {{.Src}} {{.Dst}}"
gomvpkg -from go-hep.org/x/hep/xrootd/pkg/protocol -to go-hep.org/x/hep/xrootd/xrdproto/protocol -vcs_mv_cmd "git mv {{.Src}} {{.Dst}}"
gomvpkg -from go-hep.org/x/hep/xrootd/pkg/handshake -to go-hep.org/x/hep/xrootd/xrdproto/handshake -vcs_mv_cmd "git mv {{.Src}} {{.Dst}}"
gomvpkg -from go-hep.org/x/hep/xrootd/pkg/login -to go-hep.org/x/hep/xrootd/xrdproto/login -vcs_mv_cmd "git mv {{.Src}} {{.Dst}}"
```