### PR TITLE
xrootd: add stat request

### DIFF
--- a/xrootd/client/filesystem_test.go
+++ b/xrootd/client/filesystem_test.go
@@ -228,3 +228,71 @@ func TestFileSystem_Truncate(t *testing.T) {
 		})
 	}
 }
+
+func testFileSystem_Stat(t *testing.T, addr string) {
+	want := xrdfs.EntryStat{
+		HasStatInfo: true,
+		ID:          60129606914,
+		EntrySize:   0,
+		Mtime:       1528218208,
+		Flags:       xrdfs.StatIsWritable | xrdfs.StatIsReadable,
+	}
+
+	client, err := NewClient(context.Background(), addr, "gopher")
+	if err != nil {
+		t.Fatalf("could not create client: %v", err)
+	}
+	defer client.Close()
+
+	fs := client.FS()
+
+	got, err := fs.Stat(context.Background(), "/tmp/dir1/file1.txt")
+	if err != nil {
+		t.Fatalf("invalid stat call: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Filesystem.Open()\ngot = %v\nwant = %v", got, want)
+	}
+}
+
+func TestFileSystem_Stat(t *testing.T) {
+	for _, addr := range testClientAddrs {
+		t.Run(addr, func(t *testing.T) {
+			testFileSystem_Stat(t, addr)
+		})
+	}
+}
+
+func testFileSystem_VirtualStat(t *testing.T, addr string) {
+	want := xrdfs.VirtualFSStat{
+		NumberRW:      1,
+		FreeRW:        365,
+		UtilizationRW: 23,
+	}
+
+	client, err := NewClient(context.Background(), addr, "gopher")
+	if err != nil {
+		t.Fatalf("could not create client: %v", err)
+	}
+	defer client.Close()
+
+	fs := client.FS()
+
+	got, err := fs.VirtualStat(context.Background(), "/tmp/dir1/file1.txt")
+	if err != nil {
+		t.Fatalf("invalid stat call: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Filesystem.Open()\ngot = %v\nwant = %v", got, want)
+	}
+}
+
+func TestFileSystem_VirtualStat(t *testing.T) {
+	for _, addr := range testClientAddrs {
+		t.Run(addr, func(t *testing.T) {
+			testFileSystem_VirtualStat(t, addr)
+		})
+	}
+}

--- a/xrootd/xrdfs/file.go
+++ b/xrootd/xrdfs/file.go
@@ -35,6 +35,12 @@ type File interface {
 	io.WriterAt
 	// Truncate changes the size of the file.
 	Truncate(ctx context.Context, size int64) error
+	// Stat fetches the stat info of this file from the XRootD server.
+	// Note that Stat re-fetches value returned by the Info, so after the call to Stat
+	// calls to Info may return different value than before.
+	Stat(ctx context.Context) (EntryStat, error)
+	// StatVirtualFS fetches the virtual stat info of this file from the XRootD server.
+	StatVirtualFS(ctx context.Context) (VirtualFSStat, error)
 }
 
 // FileHandle is the file handle, which should be treated as opaque data.

--- a/xrootd/xrdfs/fs.go
+++ b/xrootd/xrdfs/fs.go
@@ -15,6 +15,8 @@ type FileSystem interface {
 	Open(ctx context.Context, path string, mode OpenMode, options OpenOptions) (File, error)
 	RemoveFile(ctx context.Context, path string) error
 	Truncate(ctx context.Context, path string, size int64) error
+	Stat(ctx context.Context, path string) (EntryStat, error)
+	VirtualStat(ctx context.Context, path string) (VirtualFSStat, error)
 }
 
 // OpenMode is the mode in which path is to be opened.

--- a/xrootd/xrdproto/signing.go
+++ b/xrootd/xrdproto/signing.go
@@ -10,6 +10,7 @@ import (
 	"go-hep.org/x/hep/xrootd/xrdproto/open"
 	"go-hep.org/x/hep/xrootd/xrdproto/read"
 	"go-hep.org/x/hep/xrootd/xrdproto/rm"
+	"go-hep.org/x/hep/xrootd/xrdproto/stat"
 	"go-hep.org/x/hep/xrootd/xrdproto/truncate"
 	"go-hep.org/x/hep/xrootd/xrdproto/write"
 	"go-hep.org/x/hep/xrootd/xrdproto/xrdclose"
@@ -129,6 +130,7 @@ func NewSignRequirements(level SecurityLevel, overrides []SecurityOverride) Sign
 		sr.requirements[truncate.RequestID] = SignNeeded
 		sr.requirements[write.RequestID] = SignNeeded
 		sr.requirements[rm.RequestID] = SignNeeded
+		sr.requirements[stat.RequestID] = SignNeeded
 	}
 
 	for _, override := range overrides {

--- a/xrootd/xrdproto/stat/stat.go
+++ b/xrootd/xrdproto/stat/stat.go
@@ -1,0 +1,76 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package stat contains the structures describing request and response for stat request.
+// See xrootd protocol specification (http://xrootd.org/doc/dev45/XRdv310.pdf, p. 113) for details.
+package stat // import "go-hep.org/x/hep/xrootd/xrdproto/stat"
+
+import (
+	"go-hep.org/x/hep/xrootd/internal/xrdenc"
+	"go-hep.org/x/hep/xrootd/xrdfs"
+)
+
+// RequestID is the id of the request, it is sent as part of message.
+// See xrootd protocol specification for details: http://xrootd.org/doc/dev45/XRdv310.pdf, 2.3 Client Request Format.
+const RequestID uint16 = 3017
+
+// DefaultResponse is a response for the stat request which contains stat information such as:
+// the OS-dependent identifier, the size of the data, the entry attributes and the modification time.
+type DefaultResponse struct {
+	xrdfs.EntryStat
+}
+
+// VirtualFSResponse is a response for the stat request
+// which contains virtual file system stat information such as:
+// nrw - the number of nodes that can provide read/write access,
+// frw - the size of the largest contiguous area of r/w free space,
+// urw - the percent utilization of the partition represented by frw,
+// nstg - the number of nodes that can provide staging access,
+// fstg - the size of the largest contiguous area of staging free space,
+// ustg - the percent utilization of the partition represebted by fstg,
+type VirtualFSResponse struct {
+	xrdfs.VirtualFSStat
+}
+
+// RespID implements xrdproto.Response.RespID
+func (resp *VirtualFSResponse) RespID() uint16 { return RequestID }
+
+// RespID implements xrdproto.Response.RespID
+func (resp *DefaultResponse) RespID() uint16 { return RequestID }
+
+// Options are stat processing options.
+type Options uint8
+
+const (
+	OptionsVFS Options = 1 // OptionsVFS indicates that virtual file system information is requested.
+)
+
+// Request holds open request parameters.
+type Request struct {
+	Options    Options
+	_          [11]uint8
+	FileHandle xrdfs.FileHandle
+	Path       string
+}
+
+// MarshalXrd implements xrdproto.Marshaler
+func (o Request) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
+	wBuffer.WriteU8(uint8(o.Options))
+	wBuffer.Next(11)
+	wBuffer.WriteBytes(o.FileHandle[:])
+	wBuffer.WriteStr(o.Path)
+	return nil
+}
+
+// UnmarshalXrd implements xrdproto.Unmarshaler
+func (o *Request) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
+	o.Options = Options(rBuffer.ReadU8())
+	rBuffer.Skip(11)
+	rBuffer.ReadBytes(o.FileHandle[:])
+	o.Path = rBuffer.ReadStr()
+	return nil
+}
+
+// ReqID implements xrdproto.Request.ReqID
+func (req *Request) ReqID() uint16 { return RequestID }


### PR DESCRIPTION
Note that TestFile_FetchVirtualStatInfo is failing with an error: `xrootd: error 3001: Required argument not present`. I think that it's because it is called with `handle` instead of `path` (`FileSystem` calls it with `path` and it works correctly),

Can you take a look at [specs for kXR_stat](http://xrootd.org/doc/dev45/XRdv310.htm#_Toc464248850), please?
Especially:
>Notes
>...
>4)      kXR_stat - kXR_vfs requests need not specify an existing filesystem object. The specified path is used as a path prefix in order to filter out servers and partitions that could not be used to hold objects whose path starts with the specified path prefix.

I think that since there is no mention of `handle` it's not obvious that `kXR_stat` *requires* `path` to be passed and doesn't work when only `handle` is present.

Am I right? I'm a bit in doubt since I'm not very good at English and `requests need not specify an existing filesystem object`  gives a hint that `handle` would not work.

I'll fill an issue if you too think that documentation is not clear on that topic.