### PR TITLE
xrootd: add close request

### DIFF
--- a/xrootd/client/file.go
+++ b/xrootd/client/file.go
@@ -4,7 +4,12 @@
 
 package client // import "go-hep.org/x/hep/xrootd/client"
 
-import "go-hep.org/x/hep/xrootd/xrdfs"
+import (
+	"context"
+
+	"go-hep.org/x/hep/xrootd/xrdfs"
+	"go-hep.org/x/hep/xrootd/xrdproto/xrdclose"
+)
 
 // File implements access to a content and meta information of file over XRootD.
 type file struct {
@@ -28,6 +33,19 @@ func (f file) Info() *xrdfs.EntryStat {
 // Handle returns the file handle.
 func (f file) Handle() xrdfs.FileHandle {
 	return f.handle
+}
+
+// Close closes the file.
+func (f file) Close(ctx context.Context) error {
+	_, err := f.fs.c.call(ctx, &xrdclose.Request{Handle: f.handle})
+	return err
+}
+
+// CloseVerify closes the file and checks whether the file has the provided size.
+// A zero size suppresses the verification.
+func (f file) CloseVerify(ctx context.Context, size int64) error {
+	_, err := f.fs.c.call(ctx, &xrdclose.Request{Handle: f.handle, Size: size})
+	return err
 }
 
 var (

--- a/xrootd/client/file_mock_test.go
+++ b/xrootd/client/file_mock_test.go
@@ -1,0 +1,73 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package client // import "go-hep.org/x/hep/xrootd/client"
+
+import (
+	"context"
+	"net"
+	"reflect"
+	"testing"
+
+	"go-hep.org/x/hep/xrootd/xrdfs"
+	"go-hep.org/x/hep/xrootd/xrdproto"
+	"go-hep.org/x/hep/xrootd/xrdproto/xrdclose"
+)
+
+func TestFile_Close_Mock(t *testing.T) {
+	handle := xrdfs.FileHandle{1, 2, 3, 4}
+	wantRequest := xrdclose.Request{Handle: handle}
+
+	serverFunc := func(cancel func(), conn net.Conn) {
+		data, err := readRequest(conn)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not read request: %v", err)
+		}
+
+		var gotRequest xrdclose.Request
+		gotHeader, err := unmarshalRequest(data, &gotRequest)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not unmarshal request: %v", err)
+		}
+
+		if gotHeader.RequestID != wantRequest.ReqID() {
+			cancel()
+			t.Fatalf("invalid request id was specified:\nwant = %d\ngot = %d\n", wantRequest.ReqID(), gotHeader.RequestID)
+		}
+
+		if !reflect.DeepEqual(gotRequest, wantRequest) {
+			cancel()
+			t.Fatalf("request info does not match:\ngot = %v\nwant = %v", gotRequest, wantRequest)
+		}
+
+		responseHeader := xrdproto.ResponseHeader{
+			StreamID:   gotHeader.StreamID,
+			DataLength: 0,
+		}
+
+		responseData, err := marshalResponse(responseHeader)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not marshal response header: %v", err)
+		}
+
+		if err := writeResponse(conn, responseData); err != nil {
+			cancel()
+			t.Fatalf("invalid write: %s", err)
+		}
+	}
+
+	clientFunc := func(cancel func(), client *Client) {
+		file := file{fs: client.FS().(*fileSystem), handle: handle}
+
+		err := file.Close(context.Background())
+		if err != nil {
+			t.Fatalf("invalid close call: %v", err)
+		}
+	}
+
+	testClientWithMockServer(serverFunc, clientFunc)
+}

--- a/xrootd/client/file_test.go
+++ b/xrootd/client/file_test.go
@@ -1,0 +1,73 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package client // import "go-hep.org/x/hep/xrootd/client"
+
+import (
+	"context"
+	"testing"
+
+	"go-hep.org/x/hep/xrootd/xrdfs"
+)
+
+func testFile_Close(t *testing.T, addr string) {
+	client, err := NewClient(context.Background(), addr, "gopher")
+	if err != nil {
+		t.Fatalf("could not create client: %v", err)
+	}
+	defer client.Close()
+
+	fs := client.FS()
+
+	file, err := fs.Open(context.Background(), "/tmp/dir1/file1.txt", xrdfs.OpenModeOtherRead, xrdfs.OpenOptionsNone)
+	if err != nil {
+		t.Fatalf("invalid open call: %v", err)
+	}
+
+	err = file.Close(context.Background())
+	if err != nil {
+		t.Fatalf("invalid close call: %v", err)
+	}
+}
+
+func TestFile_Close(t *testing.T) {
+	for _, addr := range testClientAddrs {
+		t.Run(addr, func(t *testing.T) {
+			testFile_Close(t, addr)
+		})
+	}
+}
+
+func testFile_CloseVerify(t *testing.T, addr string) {
+	client, err := NewClient(context.Background(), addr, "gopher")
+	if err != nil {
+		t.Fatalf("could not create client: %v", err)
+	}
+	defer client.Close()
+
+	fs := client.FS()
+
+	file, err := fs.Open(context.Background(), "/tmp/test.txt", xrdfs.OpenModeOwnerWrite, xrdfs.OpenOptionsOpenUpdate|xrdfs.OpenOptionsOpenAppend)
+	if err != nil {
+		t.Fatalf("invalid open call: %v", err)
+	}
+
+	// TODO: Remove these 2 lines when XRootD server will follow protocol specification and fail such requests.
+	// See https://github.com/xrootd/xrootd/issues/727.
+	defer file.Close(context.Background())
+	t.Skip("Skipping test because the XRootD C++ server doesn't fail request when the wrong size is passed.")
+
+	err = file.CloseVerify(context.Background(), 14)
+	if err == nil {
+		t.Fatal("close call should fail when the wrong size is passed")
+	}
+}
+
+func TestFile_CloseVerify(t *testing.T) {
+	for _, addr := range testClientAddrs {
+		t.Run(addr, func(t *testing.T) {
+			testFile_CloseVerify(t, addr)
+		})
+	}
+}

--- a/xrootd/client/filesystem_mock_test.go
+++ b/xrootd/client/filesystem_mock_test.go
@@ -242,8 +242,9 @@ func testFileSystem_Open_Mock(t *testing.T, wantFileHandle xrdfs.FileHandle, wan
 		fs := client.FS()
 		gotFile, err := fs.Open(context.Background(), path, xrdfs.OpenModeOtherRead, xrdfs.OpenOptionsOpenRead)
 		if err != nil {
-			t.Fatalf("invalid dirlist call: %v", err)
+			t.Fatalf("invalid open call: %v", err)
 		}
+		// FIXME: consider calling defer gotFile.Close(context.Background()).
 
 		if !reflect.DeepEqual(gotFile.Handle(), wantFileHandle) {
 			t.Errorf("Filesystem.Open()\ngotFile.Handle() = %v\nwantFileHandle = %v", gotFile.Handle(), wantFileHandle)

--- a/xrootd/client/filesystem_test.go
+++ b/xrootd/client/filesystem_test.go
@@ -62,6 +62,7 @@ func testFileSystem_Open(t *testing.T, addr string, options xrdfs.OpenOptions, w
 	if err != nil {
 		t.Fatalf("invalid open call: %v", err)
 	}
+	defer gotFile.Close(context.Background())
 
 	if !reflect.DeepEqual(gotFile.Handle(), wantFileHandle) {
 		t.Errorf("Filesystem.Open()\ngotFile.Handle() = %v\nwantFileHandle = %v", gotFile.Handle(), wantFileHandle)

--- a/xrootd/xrdfs/file.go
+++ b/xrootd/xrdfs/file.go
@@ -5,6 +5,8 @@
 package xrdfs
 
 import (
+	"context"
+
 	"go-hep.org/x/hep/xrootd/internal/xrdenc"
 )
 
@@ -17,6 +19,11 @@ type File interface {
 	Info() *EntryStat
 	// Handle returns the file handle.
 	Handle() FileHandle
+	// Close closes the file.
+	Close(ctx context.Context) error
+	// CloseVerify closes the file and checks whether the file has the provided size.
+	// A zero size suppresses the verification.
+	CloseVerify(ctx context.Context, size int64) error
 }
 
 // FileHandle is the file handle, which should be treated as opaque data.

--- a/xrootd/xrdproto/signing.go
+++ b/xrootd/xrdproto/signing.go
@@ -8,6 +8,7 @@ import (
 	"go-hep.org/x/hep/xrootd/internal/xrdenc"
 	"go-hep.org/x/hep/xrootd/xrdproto/dirlist"
 	"go-hep.org/x/hep/xrootd/xrdproto/open"
+	"go-hep.org/x/hep/xrootd/xrdproto/xrdclose"
 )
 
 // RequestLevel is the security requirement that the associated request is to have.
@@ -105,10 +106,12 @@ func NewSignRequirements(level SecurityLevel, overrides []SecurityOverride) Sign
 	}
 	if level >= Intense {
 		// TODO: set requirements
+		sr.requirements[xrdclose.RequestID] = SignNeeded
 		sr.requirements[open.RequestID] = SignNeeded
 	}
 	if level >= Pedantic {
 		// TODO: set requirements
+		sr.requirements[xrdclose.RequestID] = SignNeeded
 		sr.requirements[dirlist.RequestID] = SignNeeded
 		sr.requirements[open.RequestID] = SignNeeded
 	}

--- a/xrootd/xrdproto/xrdclose/xrdclose.go
+++ b/xrootd/xrdproto/xrdclose/xrdclose.go
@@ -1,0 +1,47 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package xrdclose contains the structures describing request and response for close request.
+// See xrootd protocol specification (http://xrootd.org/doc/dev45/XRdv310.pdf, p. 41) for details.
+package xrdclose // import "go-hep.org/x/hep/xrootd/xrdproto/xrdclose"
+
+import (
+	"go-hep.org/x/hep/xrootd/internal/xrdenc"
+	"go-hep.org/x/hep/xrootd/xrdfs"
+)
+
+// RequestID is the id of the request, it is sent as part of message.
+// See xrootd protocol specification for details: http://xrootd.org/doc/dev45/XRdv310.pdf, 2.3 Client Request Format.
+const RequestID uint16 = 3003
+
+// Request holds close request parameters, such as
+// the file handle and the size, in bytes, that the file
+// is to have. The close operation fails and the file
+// is erased if it is not of the indicated size. A size of 0
+// suppresses the check.
+type Request struct {
+	Handle xrdfs.FileHandle
+	Size   int64
+	_      [4]byte
+	_      int32
+}
+
+// MarshalXrd implements xrdproto.Marshaler
+func (o Request) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
+	wBuffer.WriteBytes(o.Handle[:])
+	wBuffer.WriteI64(o.Size)
+	wBuffer.Next(8)
+	return nil
+}
+
+// UnmarshalXrd implements xrdproto.Unmarshaler
+func (o *Request) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
+	rBuffer.ReadBytes(o.Handle[:])
+	o.Size = rBuffer.ReadI64()
+	rBuffer.Skip(8)
+	return nil
+}
+
+// ReqID implements xrdproto.Request.ReqID
+func (req *Request) ReqID() uint16 { return RequestID }


### PR DESCRIPTION
Updates go-hep/hep#170.

Note that `TestFile_CloseVerify` test is skipped.
From the [specs, p. 41](http://xrootd.org/doc/dev45/XRdv310.pdf):
>fsize the size, in bytes, that the file is to have. The close operation fails and the
file is erased if it is not of the indicated size. An fsize of zero suppresses the
check

As far as I understand, `close operation fails` means that response will contain the error, however, the response is `ok` when I provide wrong `fsize`.

I'm going to fill an issue to clarify this behavior. :)