### PR TITLE
xrootd: add read request (without read-ahead usage)

### DIFF
--- a/xrootd/client/file_mock_test.go
+++ b/xrootd/client/file_mock_test.go
@@ -12,6 +12,7 @@ import (
 
 	"go-hep.org/x/hep/xrootd/xrdfs"
 	"go-hep.org/x/hep/xrootd/xrdproto"
+	"go-hep.org/x/hep/xrootd/xrdproto/read"
 	"go-hep.org/x/hep/xrootd/xrdproto/sync"
 	"go-hep.org/x/hep/xrootd/xrdproto/xrdclose"
 )
@@ -124,6 +125,96 @@ func TestFile_Sync_Mock(t *testing.T) {
 		err := file.Sync(context.Background())
 		if err != nil {
 			t.Fatalf("invalid sync call: %v", err)
+		}
+	}
+
+	testClientWithMockServer(serverFunc, clientFunc)
+}
+
+func TestFile_ReadAt_Mock(t *testing.T) {
+	handle := xrdfs.FileHandle{1, 2, 3, 4}
+	want := []byte("Hello XRootD.\n")
+	askLength := int32(len(want) + 4)
+
+	wantRequest := read.Request{Handle: handle, Offset: 1, Length: askLength}
+
+	serverFunc := func(cancel func(), conn net.Conn) {
+		data, err := readRequest(conn)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not read request: %v", err)
+		}
+
+		var gotRequest read.Request
+		gotHeader, err := unmarshalRequest(data, &gotRequest)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not unmarshal request: %v", err)
+		}
+
+		if gotHeader.RequestID != wantRequest.ReqID() {
+			cancel()
+			t.Fatalf("invalid request id was specified:\nwant = %d\ngot = %d\n", wantRequest.ReqID(), gotHeader.RequestID)
+		}
+
+		if !reflect.DeepEqual(gotRequest, wantRequest) {
+			cancel()
+			t.Fatalf("request info does not match:\ngot = %v\nwant = %v", gotRequest, wantRequest)
+		}
+
+		responseHeader := xrdproto.ResponseHeader{
+			StreamID:   gotHeader.StreamID,
+			DataLength: 5,
+			Status:     xrdproto.OkSoFar,
+		}
+
+		responseData, err := marshalResponse(responseHeader)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not marshal response header: %v", err)
+		}
+
+		responseData = append(responseData, want[:5]...)
+
+		if err := writeResponse(conn, responseData); err != nil {
+			cancel()
+			t.Fatalf("invalid write: %s", err)
+		}
+
+		responseHeader = xrdproto.ResponseHeader{
+			StreamID:   gotHeader.StreamID,
+			DataLength: int32(len(want) - 5),
+			Status:     xrdproto.Ok,
+		}
+
+		responseData, err = marshalResponse(responseHeader)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not marshal response header: %v", err)
+		}
+
+		responseData = append(responseData, want[5:]...)
+
+		if err := writeResponse(conn, responseData); err != nil {
+			cancel()
+			t.Fatalf("invalid write: %s", err)
+		}
+	}
+
+	clientFunc := func(cancel func(), client *Client) {
+		file := file{fs: client.FS().(*fileSystem), handle: handle}
+		got := make([]uint8, askLength)
+
+		n, err := file.ReadAt(got, 1)
+		if err != nil {
+			t.Fatalf("invalid read call: %v", err)
+		}
+		if n != len(want) {
+			t.Fatalf("read count does not match:\ngot = %v\nwant = %v", n, len(want))
+		}
+
+		if !reflect.DeepEqual(got[:n], want) {
+			t.Fatalf("read data does not match:\ngot = %v\nwant = %v", got[:n], want)
 		}
 	}
 

--- a/xrootd/xrdfs/file.go
+++ b/xrootd/xrdfs/file.go
@@ -6,6 +6,7 @@ package xrdfs
 
 import (
 	"context"
+	"io"
 
 	"go-hep.org/x/hep/xrootd/internal/xrdenc"
 )
@@ -26,6 +27,9 @@ type File interface {
 	CloseVerify(ctx context.Context, size int64) error
 	// Sync commits all pending writes to an open file.
 	Sync(ctx context.Context) error
+	// ReadAtContext reads len(p) bytes into p starting at offset off.
+	ReadAtContext(ctx context.Context, p []byte, off int64) (n int, err error)
+	io.ReaderAt
 }
 
 // FileHandle is the file handle, which should be treated as opaque data.

--- a/xrootd/xrdproto/read/read.go
+++ b/xrootd/xrdproto/read/read.go
@@ -1,0 +1,141 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package read contains the structures describing request and response for read request.
+// See xrootd protocol specification (http://xrootd.org/doc/dev45/XRdv310.pdf, p. 99) for details.
+package read // import "go-hep.org/x/hep/xrootd/xrdproto/read"
+
+import (
+	"github.com/pkg/errors"
+	"go-hep.org/x/hep/xrootd/internal/xrdenc"
+	"go-hep.org/x/hep/xrootd/xrdfs"
+)
+
+// RequestID is the id of the request, it is sent as part of message.
+// See xrootd protocol specification for details: http://xrootd.org/doc/dev45/XRdv310.pdf, 2.3 Client Request Format.
+const RequestID uint16 = 3013
+
+// Response is a response for the read request, which contains the read data.
+type Response struct {
+	Data []uint8
+}
+
+// MarshalXrd implements xrdproto.Marshaler
+func (o Response) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
+	wBuffer.WriteBytes(o.Data)
+	return nil
+}
+
+// UnmarshalXrd implements xrdproto.Unmarshaler
+func (o *Response) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
+	o.Data = append(o.Data, rBuffer.Bytes()...)
+	return nil
+}
+
+// RespID implements xrdproto.Response.RespID
+func (resp *Response) RespID() uint16 { return RequestID }
+
+// Request holds read request parameters.
+type Request struct {
+	Handle       xrdfs.FileHandle
+	Offset       int64
+	Length       int32
+	OptionalArgs *OptionalArgs
+}
+
+// Request holds optional read request parameters.
+type OptionalArgs struct {
+	// PathID is the path id returned by bind request.
+	// The response data is sent to this path, if possible.
+	PathID uint8
+	_      [7]uint8
+	// ReadAhead is the slice of the pre-read requests.
+	ReadAheads []ReadAhead
+}
+
+// MarshalXrd implements xrdproto.Marshaler
+func (o OptionalArgs) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
+	alen := len(o.ReadAheads)*16 + 8
+	wBuffer.WriteLen(alen)
+	wBuffer.WriteU8(o.PathID)
+	wBuffer.Next(7)
+	for _, x := range o.ReadAheads {
+		err := x.MarshalXrd(wBuffer)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalXrd implements xrdproto.Unmarshaler
+func (o *OptionalArgs) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
+	alen := rBuffer.ReadLen()
+	o.PathID = rBuffer.ReadU8()
+	rBuffer.Skip(7)
+	if alen < 8 || (alen-8)%16 != 0 {
+		return errors.Errorf("xrootd: invalid alen is specified: should be greater or equal to 8"+
+			"and (alen - 8) should be dividable by 16, got: %v", alen)
+	}
+	o.ReadAheads = make([]ReadAhead, (alen-8)/16)
+	for i := 0; i < len(o.ReadAheads); i++ {
+		err := o.ReadAheads[i].UnmarshalXrd(rBuffer)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReadAhead is the pre-read request. It is considered only a hint
+// and can be used to schedule the pre-reading of data that will be asked
+// in the very near future.
+type ReadAhead struct {
+	Handle xrdfs.FileHandle
+	Length int32
+	Offset int64
+}
+
+// MarshalXrd implements xrdproto.Marshaler
+func (o ReadAhead) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
+	wBuffer.WriteBytes(o.Handle[:])
+	wBuffer.WriteI32(o.Length)
+	wBuffer.WriteI64(o.Offset)
+	return nil
+}
+
+// UnmarshalXrd implements xrdproto.Unmarshaler
+func (o *ReadAhead) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
+	rBuffer.ReadBytes(o.Handle[:])
+	o.Length = rBuffer.ReadI32()
+	o.Offset = rBuffer.ReadI64()
+	return nil
+}
+
+// ReqID implements xrdproto.Request.ReqID
+func (req *Request) ReqID() uint16 { return RequestID }
+
+// MarshalXrd implements xrdproto.Marshaler
+func (o Request) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
+	wBuffer.WriteBytes(o.Handle[:])
+	wBuffer.WriteI64(o.Offset)
+	wBuffer.WriteI32(o.Length)
+	if o.OptionalArgs == nil {
+		wBuffer.WriteLen(0)
+		return nil
+	}
+	return o.OptionalArgs.MarshalXrd(wBuffer)
+}
+
+// UnmarshalXrd implements xrdproto.Unmarshaler
+func (o *Request) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
+	rBuffer.ReadBytes(o.Handle[:])
+	o.Offset = rBuffer.ReadI64()
+	o.Length = rBuffer.ReadI32()
+	alen := rBuffer.ReadLen()
+	if alen == 0 {
+		return nil
+	}
+	return o.OptionalArgs.UnmarshalXrd(rBuffer)
+}

--- a/xrootd/xrdproto/signing.go
+++ b/xrootd/xrdproto/signing.go
@@ -8,6 +8,7 @@ import (
 	"go-hep.org/x/hep/xrootd/internal/xrdenc"
 	"go-hep.org/x/hep/xrootd/xrdproto/dirlist"
 	"go-hep.org/x/hep/xrootd/xrdproto/open"
+	"go-hep.org/x/hep/xrootd/xrdproto/read"
 	"go-hep.org/x/hep/xrootd/xrdproto/xrdclose"
 )
 
@@ -114,6 +115,7 @@ func NewSignRequirements(level SecurityLevel, overrides []SecurityOverride) Sign
 		sr.requirements[xrdclose.RequestID] = SignNeeded
 		sr.requirements[dirlist.RequestID] = SignNeeded
 		sr.requirements[open.RequestID] = SignNeeded
+		sr.requirements[read.RequestID] = SignNeeded
 	}
 
 	for _, override := range overrides {


### PR DESCRIPTION
Updates go-hep/hep#170.

I would like to implement [io.ReaderAt](https://golang.org/pkg/io/#ReaderAt) (and probably `io.Reader`) interface but I'm not sure about naming of methods that take a `context` as a parameter.

And basically it will be like:
```go
func (f file) ReadAt(p []byte, off int64) (n int, err error) {
        return f.ReadAtWithContext(context.Background(), p, off)
}
```

What do you think? Should we implement such methods? Any suggestions about naming?