### PR TITLE
xrootd/{client,xrdproto/read}: make ReadAt directly use provided buffer

### DIFF
--- a/xrootd/client/file.go
+++ b/xrootd/client/file.go
@@ -10,6 +10,7 @@ import (
 	"go-hep.org/x/hep/xrootd/xrdfs"
 	"go-hep.org/x/hep/xrootd/xrdproto/read"
 	"go-hep.org/x/hep/xrootd/xrdproto/sync"
+	"go-hep.org/x/hep/xrootd/xrdproto/write"
 	"go-hep.org/x/hep/xrootd/xrdproto/xrdclose"
 )
 
@@ -70,6 +71,21 @@ func (f file) ReadAtContext(ctx context.Context, p []byte, off int64) (n int, er
 // ReadAt reads len(p) bytes into p starting at offset off.
 func (f file) ReadAt(p []byte, off int64) (n int, err error) {
 	return f.ReadAtContext(context.Background(), p, off)
+}
+
+// WriteAtContext writes len(p) bytes from p to the file at offset off.
+func (f file) WriteAtContext(ctx context.Context, p []byte, off int64) error {
+	_, err := f.fs.c.call(ctx, &write.Request{Handle: f.handle, Offset: off, Data: p})
+	return err
+}
+
+// WriteAt writes len(p) bytes from p to the file at offset off.
+func (f file) WriteAt(p []byte, off int64) (n int, err error) {
+	err = f.WriteAtContext(context.Background(), p, off)
+	if err != nil {
+		return 0, err
+	}
+	return len(p), nil
 }
 
 var (

--- a/xrootd/client/file.go
+++ b/xrootd/client/file.go
@@ -59,12 +59,11 @@ func (f file) Sync(ctx context.Context) error {
 
 // ReadAtContext reads len(p) bytes into p starting at offset off.
 func (f file) ReadAtContext(ctx context.Context, p []byte, off int64) (n int, err error) {
-	var resp read.Response
+	resp := read.Response{Data: p}
 	err = f.fs.c.Send(ctx, &resp, &read.Request{Handle: f.handle, Offset: off, Length: int32(len(p))})
 	if err != nil {
 		return 0, err
 	}
-	copy(p, resp.Data)
 	return len(resp.Data), nil
 }
 

--- a/xrootd/client/file_test.go
+++ b/xrootd/client/file_test.go
@@ -6,6 +6,7 @@ package client // import "go-hep.org/x/hep/xrootd/client"
 
 import (
 	"context"
+	"math/rand"
 	"reflect"
 	"testing"
 
@@ -108,6 +109,62 @@ func TestFile_ReadAt(t *testing.T) {
 	for _, addr := range testClientAddrs {
 		t.Run(addr, func(t *testing.T) {
 			testFile_ReadAt(t, addr)
+		})
+	}
+}
+
+func testFile_WriteAt(t *testing.T, addr string) {
+	filePath := "/tmp/test_rw.txt"
+	want := make([]byte, 8*1024)
+	rand.Read(want)
+
+	client, err := NewClient(context.Background(), addr, "gopher")
+	if err != nil {
+		t.Fatalf("could not create client: %v", err)
+	}
+	defer client.Close()
+
+	fs := client.FS()
+	file, err := fs.Open(context.Background(), filePath, xrdfs.OpenModeOwnerWrite, xrdfs.OpenOptionsOpenUpdate|xrdfs.OpenOptionsOpenAppend)
+	if err != nil {
+		t.Fatalf("invalid open call: %v", err)
+	}
+	defer file.Close(context.Background())
+
+	_, err = file.WriteAt(want, 0)
+	if err != nil {
+		t.Fatalf("invalid write call: %v", err)
+	}
+
+	err = file.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("invalid sync call: %v", err)
+	}
+
+	file.Close(context.Background())
+	file, err = fs.Open(context.Background(), filePath, xrdfs.OpenModeOwnerRead, xrdfs.OpenOptionsOpenRead)
+	defer file.Close(context.Background())
+
+	got := make([]uint8, len(want)+10)
+	n, err := file.ReadAt(got, 0)
+	if err != nil {
+		t.Fatalf("invalid read call: %v", err)
+	}
+
+	if n != len(want) {
+		t.Fatalf("read count does not match:\ngot = %v\nwant = %v", n, len(want))
+	}
+
+	if !reflect.DeepEqual(got[:n], want) {
+		t.Fatalf("read data does not match:\ngot = %v\nwant = %v", got[:n], want)
+	}
+
+}
+
+func TestFile_WriteAt(t *testing.T) {
+	for _, addr := range testClientAddrs {
+		t.Run(addr, func(t *testing.T) {
+			testFile_WriteAt(t, addr)
 		})
 	}
 }

--- a/xrootd/xrdfs/file.go
+++ b/xrootd/xrdfs/file.go
@@ -30,6 +30,9 @@ type File interface {
 	// ReadAtContext reads len(p) bytes into p starting at offset off.
 	ReadAtContext(ctx context.Context, p []byte, off int64) (n int, err error)
 	io.ReaderAt
+	// WriteAtContext writes len(p) bytes from p to the file at offset off.
+	WriteAtContext(ctx context.Context, p []byte, off int64) error
+	io.WriterAt
 }
 
 // FileHandle is the file handle, which should be treated as opaque data.

--- a/xrootd/xrdproto/read/read.go
+++ b/xrootd/xrdproto/read/read.go
@@ -29,7 +29,13 @@ func (o Response) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
 
 // UnmarshalXrd implements xrdproto.Unmarshaler
 func (o *Response) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
-	o.Data = append(o.Data, rBuffer.Bytes()...)
+	src := rBuffer.Len()
+	dst := len(o.Data)
+	if src > dst {
+		o.Data = make([]byte, src)
+	}
+	n := copy(o.Data, rBuffer.Bytes())
+	o.Data = o.Data[:n]
 	return nil
 }
 

--- a/xrootd/xrdproto/signing.go
+++ b/xrootd/xrdproto/signing.go
@@ -9,6 +9,7 @@ import (
 	"go-hep.org/x/hep/xrootd/xrdproto/dirlist"
 	"go-hep.org/x/hep/xrootd/xrdproto/open"
 	"go-hep.org/x/hep/xrootd/xrdproto/read"
+	"go-hep.org/x/hep/xrootd/xrdproto/write"
 	"go-hep.org/x/hep/xrootd/xrdproto/xrdclose"
 )
 
@@ -109,6 +110,7 @@ func NewSignRequirements(level SecurityLevel, overrides []SecurityOverride) Sign
 		// TODO: set requirements
 		sr.requirements[xrdclose.RequestID] = SignNeeded
 		sr.requirements[open.RequestID] = SignNeeded
+		sr.requirements[write.RequestID] = SignNeeded
 	}
 	if level >= Pedantic {
 		// TODO: set requirements
@@ -116,6 +118,7 @@ func NewSignRequirements(level SecurityLevel, overrides []SecurityOverride) Sign
 		sr.requirements[dirlist.RequestID] = SignNeeded
 		sr.requirements[open.RequestID] = SignNeeded
 		sr.requirements[read.RequestID] = SignNeeded
+		sr.requirements[write.RequestID] = SignNeeded
 	}
 
 	for _, override := range overrides {

--- a/xrootd/xrdproto/write/write.go
+++ b/xrootd/xrdproto/write/write.go
@@ -1,0 +1,50 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package write contains the structures describing write request.
+// See xrootd protocol specification (http://xrootd.org/doc/dev45/XRdv310.pdf, p. 124) for details.
+package write // import "go-hep.org/x/hep/xrootd/xrdproto/write"
+
+import (
+	"go-hep.org/x/hep/xrootd/internal/xrdenc"
+	"go-hep.org/x/hep/xrootd/xrdfs"
+)
+
+// RequestID is the id of the request, it is sent as part of message.
+// See xrootd protocol specification for details: http://xrootd.org/doc/dev45/XRdv310.pdf, 2.3 Client Request Format.
+const RequestID uint16 = 3019
+
+// Request holds write request parameters.
+type Request struct {
+	Handle xrdfs.FileHandle
+	Offset int64
+	PathID uint8
+	_      [3]uint8
+	Data   []uint8
+}
+
+// MarshalXrd implements xrdproto.Marshaler.
+func (req Request) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
+	wBuffer.WriteBytes(req.Handle[:])
+	wBuffer.WriteI64(req.Offset)
+	wBuffer.WriteU8(req.PathID)
+	wBuffer.Next(3)
+	wBuffer.WriteLen(len(req.Data))
+	wBuffer.WriteBytes(req.Data)
+	return nil
+}
+
+// UnmarshalXrd implements xrdproto.Unmarshaler.
+func (req *Request) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
+	rBuffer.ReadBytes(req.Handle[:])
+	req.Offset = rBuffer.ReadI64()
+	req.PathID = rBuffer.ReadU8()
+	rBuffer.Skip(3)
+	req.Data = make([]uint8, rBuffer.ReadLen())
+	rBuffer.ReadBytes(req.Data)
+	return nil
+}
+
+// ReqID implements xrdproto.Request.ReqID.
+func (req *Request) ReqID() uint16 { return RequestID }


### PR DESCRIPTION
This CL modifies the read.Response unmarshaler to use the provided
buffer if it's big enough.
Otherwise, a new big enough buffer is allocated.