### PR TITLE
Rootio xrd stat support

### DIFF
--- a/xrootd/xrdfs/file.go
+++ b/xrootd/xrdfs/file.go
@@ -13,32 +13,43 @@ import (
 
 // File implements access to a content and meta information of file over XRootD.
 type File interface {
+	io.ReaderAt
+	io.WriterAt
+
 	// Compression returns the compression info.
 	Compression() *FileCompression
+
 	// Info returns the cached stat info.
 	// Note that it may return nil if info was not yet fetched and info may be not up-to-date.
 	Info() *EntryStat
+
 	// Handle returns the file handle.
 	Handle() FileHandle
+
 	// Close closes the file.
 	Close(ctx context.Context) error
+
 	// CloseVerify closes the file and checks whether the file has the provided size.
 	// A zero size suppresses the verification.
 	CloseVerify(ctx context.Context, size int64) error
+
 	// Sync commits all pending writes to an open file.
 	Sync(ctx context.Context) error
+
 	// ReadAtContext reads len(p) bytes into p starting at offset off.
 	ReadAtContext(ctx context.Context, p []byte, off int64) (n int, err error)
-	io.ReaderAt
+
 	// WriteAtContext writes len(p) bytes from p to the file at offset off.
 	WriteAtContext(ctx context.Context, p []byte, off int64) error
-	io.WriterAt
+
 	// Truncate changes the size of the file.
 	Truncate(ctx context.Context, size int64) error
+
 	// Stat fetches the stat info of this file from the XRootD server.
 	// Note that Stat re-fetches value returned by the Info, so after the call to Stat
 	// calls to Info may return different value than before.
 	Stat(ctx context.Context) (EntryStat, error)
+
 	// StatVirtualFS fetches the virtual stat info of this file from the XRootD server.
 	StatVirtualFS(ctx context.Context) (VirtualFSStat, error)
 }


### PR DESCRIPTION
This CL adds:

- an `os.File.Name`-like method to `xrdfs.File`
- the according implementation for `xrootd/client.file`
- proper computation of the `rootio.xrdFile` size, using `kXR_stat`.