### PR TITLE
xrootd: add auth request together with unix auth

### DIFF
--- a/xrootd/client/auth.go
+++ b/xrootd/client/auth.go
@@ -1,0 +1,46 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package client // import "go-hep.org/x/hep/xrootd/client"
+
+import (
+	"bytes"
+	"context"
+	"os/user"
+
+	"github.com/pkg/errors"
+	"go-hep.org/x/hep/xrootd/xrdproto/auth"
+)
+
+func (client *Client) auth(ctx context.Context, securityInformation []byte) error {
+	securityInformation = bytes.TrimLeft(securityInformation, "&")
+	securityProviders := bytes.Split(securityInformation, []byte{'&'})
+
+	var errs []error
+	for _, securityProvider := range securityProviders {
+		securityProvider = bytes.TrimLeft(securityProvider, "P=")
+		if bytes.Equal(securityProvider, auth.UnixType[:]) {
+			u, err := user.Current()
+			if err != nil {
+				errs = append(errs, errors.WithMessage(err, "xrootd: could not authorize using unix"))
+				continue
+			}
+			g, err := lookupGroupID(u)
+			if err != nil {
+				errs = append(errs, errors.WithMessage(err, "xrootd: could not authorize using unix"))
+				continue
+			}
+
+			_, err = client.call(ctx, auth.NewUnixRequest(u.Username, g))
+			if err != nil {
+				errs = append(errs, errors.WithMessage(err, "xrootd: could not authorize using unix"))
+				continue
+			} else {
+				return nil
+			}
+		}
+	}
+
+	return errors.Errorf("xrootd: could not authorize:\n%v", errs)
+}

--- a/xrootd/client/client.go
+++ b/xrootd/client/client.go
@@ -66,11 +66,18 @@ func NewClient(ctx context.Context, address string, username string) (*Client, e
 		return nil, err
 	}
 
-	// TODO: parse security information from Login request and perform an Auth request if needed.
-	_, err = client.Login(ctx, username, "")
+	securityInfo, err := client.Login(ctx, username, "")
 	if err != nil {
 		client.Close()
 		return nil, err
+	}
+
+	if len(securityInfo.SecurityInformation) > 0 {
+		err = client.auth(ctx, securityInfo.SecurityInformation)
+		if err != nil {
+			client.Close()
+			return nil, err
+		}
 	}
 
 	protocolInfo, err := client.Protocol(ctx)

--- a/xrootd/client/lookupgid_unix.go
+++ b/xrootd/client/lookupgid_unix.go
@@ -1,0 +1,19 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//+build !windows
+
+package client // import "go-hep.org/x/hep/xrootd/client"
+
+import (
+	"os/user"
+)
+
+func lookupGroupID(usr *user.User) (string, error) {
+	group, err := user.LookupGroupId(usr.Gid)
+	if err != nil {
+		return "", err
+	}
+	return group.Name, nil
+}

--- a/xrootd/client/lookupgid_windows.go
+++ b/xrootd/client/lookupgid_windows.go
@@ -1,0 +1,16 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//+build windows
+
+package client // import "go-hep.org/x/hep/xrootd/client"
+
+import (
+	"os/user"
+)
+
+func lookupGroupID(usr *user.User) (string, error) {
+	// Since user.LookupGroupId is not implemented under Windows fallback to the username.
+	return usr.Username, nil
+}

--- a/xrootd/xrdproto/auth/auth.go
+++ b/xrootd/xrdproto/auth/auth.go
@@ -1,0 +1,48 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package auth contains the structures describing auth request.
+package auth // import "go-hep.org/x/hep/xrootd/xrdproto/auth"
+
+import (
+	"go-hep.org/x/hep/xrootd/internal/xrdenc"
+)
+
+// RequestID is the id of the request, it is sent as part of message.
+// See xrootd protocol specification for details: http://xrootd.org/doc/dev45/XRdv310.pdf, 2.3 Client Request Format.
+const RequestID uint16 = 3000
+
+// Request holds the auth request parameters.
+type Request struct {
+	_           [12]byte
+	Type        [4]byte
+	Credentials string
+}
+
+// UnixType indicates that unix authentication protocol is used.
+var UnixType = [4]byte{'u', 'n', 'i', 'x'}
+
+// NewUnixRequest forms a Request according to provided parameters using unix authentication.
+func NewUnixRequest(username, groupname string) *Request {
+	return &Request{Type: UnixType, Credentials: "unix\000" + username + " " + groupname + "\000"}
+}
+
+// ReqID implements xrdproto.Request.ReqID.
+func (req *Request) ReqID() uint16 { return RequestID }
+
+// MarshalXrd implements xrdproto.Marshaler.
+func (o Request) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
+	wBuffer.Next(12)
+	wBuffer.WriteBytes(o.Type[:])
+	wBuffer.WriteStr(o.Credentials)
+	return nil
+}
+
+// UnmarshalXrd implements xrdproto.Unmarshaler.
+func (o *Request) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
+	rBuffer.Skip(12)
+	rBuffer.ReadBytes(o.Type[:])
+	o.Credentials = rBuffer.ReadStr()
+	return nil
+}

--- a/xrootd/xrdproto/signing.go
+++ b/xrootd/xrdproto/signing.go
@@ -6,6 +6,7 @@ package xrdproto // import "go-hep.org/x/hep/xrootd/xrdproto"
 
 import (
 	"go-hep.org/x/hep/xrootd/internal/xrdenc"
+	"go-hep.org/x/hep/xrootd/xrdproto/auth"
 	"go-hep.org/x/hep/xrootd/xrdproto/chmod"
 	"go-hep.org/x/hep/xrootd/xrdproto/dirlist"
 	"go-hep.org/x/hep/xrootd/xrdproto/mkdir"
@@ -158,8 +159,7 @@ func NewSignRequirements(level SecurityLevel, overrides []SecurityOverride) Sign
 	}
 
 	for _, override := range overrides {
-		// TODO: use auth.RequestID instead of 3000.
-		requestID := 3000 + uint16(override.RequestIndex)
+		requestID := auth.RequestID + uint16(override.RequestIndex)
 		sr.requirements[requestID] = override.RequestLevel
 	}
 


### PR DESCRIPTION
Updates go-hep/hep#170.
Updates go-hep/hep#250.

I have tested it locally against the XRootD server with such config:

```
ofs.trace all
xrd.trace all
#sec.level all pedantic force
xrootd.seclib /usr/lib/libXrdSec.so
sec.protocol /usr/lib/ unix
sec.protocol /usr/lib/ pwd
sec.protbind * unix pwd
acc.authdb /tmp/Authfile
ofs.authorize 1
```

/tmp/Authfile is:
```
u ematirov /tmp a
u DESKTOP-R8CLF5C\ematirov /tmp a
```

Note that even Windows is supported by **unix** auth. :-P