### PR TITLE
xrootd: add krb5 auth

### DIFF
--- a/xrootd/xrdproto/auth/auth.go
+++ b/xrootd/xrdproto/auth/auth.go
@@ -20,14 +20,6 @@ type Request struct {
 	Credentials string
 }
 
-// UnixType indicates that unix authentication protocol is used.
-var UnixType = [4]byte{'u', 'n', 'i', 'x'}
-
-// NewUnixRequest forms a Request according to provided parameters using unix authentication.
-func NewUnixRequest(username, groupname string) *Request {
-	return &Request{Type: UnixType, Credentials: "unix\000" + username + " " + groupname + "\000"}
-}
-
 // ReqID implements xrdproto.Request.ReqID.
 func (req *Request) ReqID() uint16 { return RequestID }
 
@@ -48,4 +40,10 @@ func (o *Request) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
 	rBuffer.ReadBytes(o.Type[:])
 	o.Credentials = rBuffer.ReadStr()
 	return nil
+}
+
+// Auther is the interface that must be implemented by a security provider.
+type Auther interface {
+	Provider() string                          // Provider returns the name of the security provider.
+	Request(params []string) (*Request, error) // Request forms an authorization Request according to passed parameters.
 }

--- a/xrootd/xrdproto/auth/krb5/krb5.go
+++ b/xrootd/xrdproto/auth/krb5/krb5.go
@@ -1,0 +1,135 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package krb5 contains the implementation of krb5 (Kerberos) security provider.
+package krb5
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"go-hep.org/x/hep/xrootd/xrdproto/auth"
+	"gopkg.in/jcmturner/gokrb5.v5/client"
+	"gopkg.in/jcmturner/gokrb5.v5/config"
+	"gopkg.in/jcmturner/gokrb5.v5/credentials"
+	"gopkg.in/jcmturner/gokrb5.v5/crypto"
+	"gopkg.in/jcmturner/gokrb5.v5/messages"
+	"gopkg.in/jcmturner/gokrb5.v5/types"
+)
+
+// Default is a Kerberos 5 client configured from cached credentials.
+// If the credentials could not be correctly configured, Default will be nil.
+var Default auth.Auther
+
+func init() {
+	v, err := WithCredCache()
+	if err == nil {
+		Default = v
+	}
+}
+
+// Auth implements krb5 (Kerberos) security provider.
+type Auth struct {
+	client *client.Client
+}
+
+// WithPassword creates a new Auth configured from the provided user, realm and password.
+func WithPassword(user, realm, password string) (*Auth, error) {
+	krb := client.NewClientWithPassword(user, realm, password)
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return nil, errors.WithMessage(err, "auth/krb5: could not load kerberos-5 configuration")
+	}
+
+	krb.WithConfig(cfg)
+
+	err = krb.Login()
+	if err != nil {
+		return nil, errors.WithMessage(err, "auth/krb5: could not login")
+	}
+
+	return &Auth{client: &krb}, nil
+}
+
+// WithCredCache creates a new Auth configured from cached credentials.
+func WithCredCache() (*Auth, error) {
+	cred, err := credentials.LoadCCache(cachePath())
+	if err != nil {
+		return nil, errors.WithMessage(err, "auth/krb5: could not load kerberos-5 cached credentials")
+	}
+
+	krb, err := client.NewClientFromCCache(cred)
+	if err != nil {
+		return nil, errors.WithMessage(err, "auth/krb5: could not create kerberos-5 client from cached credentials")
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return nil, errors.WithMessage(err, "auth/krb5: could not load kerberos-5 configuration")
+	}
+
+	krb.WithConfig(cfg)
+
+	return &Auth{client: &krb}, nil
+}
+
+// WithClient creates a new Auth using the provided krb5 client.
+func WithClient(client *client.Client) *Auth {
+	return &Auth{client: client}
+
+}
+
+// Provider implements auth.Auther
+func (*Auth) Provider() string {
+	return "krb5"
+}
+
+// Type indicates that krb5 (Kerberos) authentication protocol is used.
+var Type = [4]byte{'k', 'r', 'b', '5'}
+
+// Request implements auth.Auther
+func (a *Auth) Request(params []string) (*auth.Request, error) {
+	if len(params) == 0 {
+		return nil, errors.New("auth/krb5: want at least 1 parameter, got 0")
+	}
+	serviceName := string(params[0])
+	if strings.Contains(serviceName, "@") {
+		// Service name from the XRootD server may be in the following format: "xrootd/server.example.com@example.com"
+		// While gokrb5 expects server name in that format: "xrootd/server.example.com".
+		// The "@example.com" part (realm) will be guessed from the instance name "server.example.com".
+		index := strings.Index(serviceName, "@")
+		serviceName = serviceName[:index]
+	}
+	tkt, key, err := a.client.GetServiceTicket(serviceName)
+	if err != nil {
+		return nil, errors.WithMessage(err, "auth/krb5: could not retrieve kerberos service ticket")
+	}
+	authenticator, err := types.NewAuthenticator(a.client.Credentials.Realm, a.client.Credentials.CName)
+	if err != nil {
+		return nil, errors.WithMessage(err, "auth/krb5: could not create kerberos authenticator")
+	}
+	etype, err := crypto.GetEtype(key.KeyType)
+	if err != nil {
+		return nil, errors.WithMessage(err, "auth/krb5: could not retrieve crypto key type")
+	}
+	err = authenticator.GenerateSeqNumberAndSubKey(key.KeyType, etype.GetKeyByteSize())
+	if err != nil {
+		return nil, errors.WithMessage(err, "auth/krb5: could not generate sequence number or sub key")
+	}
+	APReq, err := messages.NewAPReq(tkt, key, authenticator)
+	if err != nil {
+		return nil, errors.WithMessage(err, "auth/krb5: could not generate AP request")
+	}
+	request, err := APReq.Marshal()
+	if err != nil {
+		return nil, errors.WithMessage(err, "auth/krb5: could not marshal AP request")
+	}
+
+	return &auth.Request{Type: Type, Credentials: "krb5\000" + string(request)}, nil
+}
+
+var (
+	_ auth.Auther = (*Auth)(nil)
+)

--- a/xrootd/xrdproto/auth/krb5/krb5_unix.go
+++ b/xrootd/xrdproto/auth/krb5/krb5_unix.go
@@ -1,0 +1,38 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//+build !windows
+
+package krb5
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+)
+
+// FIXME(sbinet): may be overwritten by $KRB5_CONFIG
+// FIXME(sbinet): Linux puts it at:     /etc/krb5.conf
+//                others may put it at: /etc/krb5/krb5.conf
+
+const configPath = "/etc/krb5.conf"
+
+func cachePath() string {
+	if v := os.Getenv("KRB5CCNAME"); v != "" {
+		if strings.HasPrefix(v, "FILE:") {
+			v = string(v[len("FILE:"):])
+		}
+		return v
+	}
+
+	usr, err := user.Current()
+	if err != nil {
+		return ""
+	}
+
+	v := filepath.Join(os.TempDir(), fmt.Sprintf("krb5cc_%s", usr.Uid))
+	return v
+}

--- a/xrootd/xrdproto/auth/krb5/krb5_windows.go
+++ b/xrootd/xrdproto/auth/krb5/krb5_windows.go
@@ -1,0 +1,37 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//+build windows
+
+package krb5
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+)
+
+const configPath = `c:\winnt\krb5.ini`
+
+func cachePath() string {
+	// FIXME: ask people for the popular windows krb5 client and use its cache path.
+	// MIT krb5 lacks fresh windows builds IIUC.
+	// As for now, hope that either KRB5CCNAME or %TEMP%\krb5cc_{uid} will work.
+	if v := os.Getenv("KRB5CCNAME"); v != "" {
+		if strings.HasPrefix(v, "FILE:") {
+			v = string(v[len("FILE:"):])
+		}
+		return v
+	}
+
+	usr, err := user.Current()
+	if err != nil {
+		return ""
+	}
+
+	v := filepath.Join(os.TempDir(), fmt.Sprintf("krb5cc_%s", usr.Uid))
+	return v
+}

--- a/xrootd/xrdproto/auth/unix/lookupgid_unix.go
+++ b/xrootd/xrdproto/auth/unix/lookupgid_unix.go
@@ -4,7 +4,7 @@
 
 //+build !windows
 
-package client // import "go-hep.org/x/hep/xrootd/client"
+package unix // import "go-hep.org/x/hep/xrootd/xrdproto/auth/unix"
 
 import (
 	"os/user"

--- a/xrootd/xrdproto/auth/unix/lookupgid_windows.go
+++ b/xrootd/xrdproto/auth/unix/lookupgid_windows.go
@@ -4,7 +4,7 @@
 
 //+build windows
 
-package client // import "go-hep.org/x/hep/xrootd/client"
+package unix // import "go-hep.org/x/hep/xrootd/xrdproto/auth/unix"
 
 import (
 	"os/user"

--- a/xrootd/xrdproto/auth/unix/unix.go
+++ b/xrootd/xrdproto/auth/unix/unix.go
@@ -1,0 +1,51 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package unix contains the implementation of unix security provider.
+package unix // import "go-hep.org/x/hep/xrootd/xrdproto/auth/unix"
+
+import (
+	"os/user"
+
+	"go-hep.org/x/hep/xrootd/xrdproto/auth"
+)
+
+// Default is an unix security provider configured from current username and group.
+// If the credentials could not be correctly configured, Default will be nil.
+var Default auth.Auther
+
+func init() {
+	u, err := user.Current()
+	if err != nil {
+		return
+	}
+	g, err := lookupGroupID(u)
+	if err != nil {
+		return
+	}
+	Default = &Auth{User: u.Username, Group: g}
+}
+
+// Auth implements unix security provider.
+type Auth struct {
+	User  string
+	Group string
+}
+
+// Provider implements auth.Auther
+func (*Auth) Provider() string {
+	return "unix"
+}
+
+// Type indicates that unix authentication protocol is used.
+var Type = [4]byte{'u', 'n', 'i', 'x'}
+
+// Request implements auth.Auther
+func (a *Auth) Request(params []string) (*auth.Request, error) {
+	return &auth.Request{Type: Type, Credentials: "unix\000" + a.User + " " + a.Group + "\000"}, nil
+}
+
+var (
+	_ auth.Auther = (*Auth)(nil)
+)


### PR DESCRIPTION
@sbinet, could you please give this a try?

I have managed to install and configure Kerberos and that PR works locally with my config. However, yours may differ and it would be cool to test that before polishing it. :)

For the tests, edit the `xrootd/client/auth.go:26` and following lines. That enables Kerberos auth with the provided parameters to all usages of the client, so you can test it against `xrd-cp` for example. :)

I think that we'll receive in the `Client` configured and logged-in client to the Kerberos, so it will allow a user to fully customize the creation of the client.

Another possibility is to introduce `xrootd/auth/krb5` and depend on `gokrb5` only from that package, requiring only basic interface from the `Client` side. Something like:
```go
type KerberosAuth interface {
    Authenticate(serviceName string) ([]byte, error)
}
```

This way it will be optional to install the `xrootd/auth/krb5` and `gokrb5` package since the `Client` will not depend on them.

What do you think?

Updates go-hep/hep#170.
Updates go-hep/hep#250.