### PR TITLE
xrootd: implement FilepathRequest interface in corresponding requests

### DIFF
--- a/xrootd/xrdproto/chmod/chmod.go
+++ b/xrootd/xrdproto/chmod/chmod.go
@@ -9,6 +9,7 @@ package chmod // import "go-hep.org/x/hep/xrootd/xrdproto/chmod"
 import (
 	"go-hep.org/x/hep/xrootd/internal/xrdenc"
 	"go-hep.org/x/hep/xrootd/xrdfs"
+	"go-hep.org/x/hep/xrootd/xrdproto"
 )
 
 // RequestID is the id of the request, it is sent as part of message.
@@ -43,3 +44,13 @@ func (req *Request) ReqID() uint16 { return RequestID }
 
 // ShouldSign implements xrdproto.Request.ShouldSign.
 func (req *Request) ShouldSign() bool { return false }
+
+// Opaque implements xrdproto.FilepathRequest.Opaque.
+func (req *Request) Opaque() string {
+	return xrdproto.Opaque(req.Path)
+}
+
+// SetOpaque implements xrdproto.FilepathRequest.SetOpaque.
+func (req *Request) SetOpaque(opaque string) {
+	xrdproto.SetOpaque(&req.Path, opaque)
+}

--- a/xrootd/xrdproto/dirlist/dirlist.go
+++ b/xrootd/xrdproto/dirlist/dirlist.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"go-hep.org/x/hep/xrootd/internal/xrdenc"
 	"go-hep.org/x/hep/xrootd/xrdfs"
+	"go-hep.org/x/hep/xrootd/xrdproto"
 )
 
 // RequestID is the id of the request, it is sent as part of message.
@@ -126,4 +127,14 @@ func (o *Request) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
 	o.Options = RequestOptions(rBuffer.ReadU8())
 	o.Path = rBuffer.ReadStr()
 	return nil
+}
+
+// Opaque implements xrdproto.FilepathRequest.Opaque.
+func (req *Request) Opaque() string {
+	return xrdproto.Opaque(req.Path)
+}
+
+// SetOpaque implements xrdproto.FilepathRequest.SetOpaque.
+func (req *Request) SetOpaque(opaque string) {
+	xrdproto.SetOpaque(&req.Path, opaque)
 }

--- a/xrootd/xrdproto/mkdir/mkdir.go
+++ b/xrootd/xrdproto/mkdir/mkdir.go
@@ -9,6 +9,7 @@ package mkdir // import "go-hep.org/x/hep/xrootd/xrdproto/mkdir"
 import (
 	"go-hep.org/x/hep/xrootd/internal/xrdenc"
 	"go-hep.org/x/hep/xrootd/xrdfs"
+	"go-hep.org/x/hep/xrootd/xrdproto"
 )
 
 // RequestID is the id of the request, it is sent as part of message.
@@ -55,3 +56,13 @@ func (req *Request) ReqID() uint16 { return RequestID }
 
 // ShouldSign implements xrdproto.Request.ShouldSign.
 func (req *Request) ShouldSign() bool { return false }
+
+// Opaque implements xrdproto.FilepathRequest.Opaque.
+func (req *Request) Opaque() string {
+	return xrdproto.Opaque(req.Path)
+}
+
+// SetOpaque implements xrdproto.FilepathRequest.SetOpaque.
+func (req *Request) SetOpaque(opaque string) {
+	xrdproto.SetOpaque(&req.Path, opaque)
+}

--- a/xrootd/xrdproto/mv/mv.go
+++ b/xrootd/xrdproto/mv/mv.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 	"go-hep.org/x/hep/xrootd/internal/xrdenc"
+	"go-hep.org/x/hep/xrootd/xrdproto"
 )
 
 // RequestID is the id of the request, it is sent as part of message.
@@ -59,3 +60,13 @@ func (req *Request) ReqID() uint16 { return RequestID }
 
 // ShouldSign implements xrdproto.Request.ShouldSign.
 func (req *Request) ShouldSign() bool { return false }
+
+// Opaque implements xrdproto.FilepathRequest.Opaque.
+func (req *Request) Opaque() string {
+	return xrdproto.Opaque(req.NewPath)
+}
+
+// SetOpaque implements xrdproto.FilepathRequest.SetOpaque.
+func (req *Request) SetOpaque(opaque string) {
+	xrdproto.SetOpaque(&req.NewPath, opaque)
+}

--- a/xrootd/xrdproto/open/open.go
+++ b/xrootd/xrdproto/open/open.go
@@ -7,8 +7,6 @@
 package open // import "go-hep.org/x/hep/xrootd/xrdproto/open"
 
 import (
-	"strings"
-
 	"go-hep.org/x/hep/xrootd/internal/xrdenc"
 	"go-hep.org/x/hep/xrootd/xrdfs"
 	"go-hep.org/x/hep/xrootd/xrdproto"
@@ -79,18 +77,12 @@ type Request struct {
 
 // Opaque implements xrdproto.FilepathRequest.Opaque.
 func (req *Request) Opaque() string {
-	pos := strings.LastIndex(req.Path, "?")
-	return req.Path[pos+1:]
+	return xrdproto.Opaque(req.Path)
 }
 
 // SetOpaque implements xrdproto.FilepathRequest.SetOpaque.
 func (req *Request) SetOpaque(opaque string) {
-	path := req.Path
-	pos := strings.LastIndex(path, "?")
-	if pos != -1 {
-		path = path[:pos]
-	}
-	req.Path = path + "?" + opaque
+	xrdproto.SetOpaque(&req.Path, opaque)
 }
 
 // NewRequest forms a Request according to provided path, mode, and options.

--- a/xrootd/xrdproto/protocol.go
+++ b/xrootd/xrdproto/protocol.go
@@ -9,6 +9,7 @@ package xrdproto // import "go-hep.org/x/hep/xrootd/xrdproto"
 import (
 	"encoding/binary"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	"go-hep.org/x/hep/xrootd/internal/xrdenc"
@@ -181,4 +182,19 @@ func (o *SecurityOverride) UnmarshalXrd(dec *xrdenc.RBuffer) error {
 	o.RequestIndex = dec.ReadU8()
 	o.RequestLevel = RequestLevel(dec.ReadU8())
 	return nil
+}
+
+// SetOpaque sets opaque data part in the provided path.
+func SetOpaque(path *string, opaque string) {
+	pos := strings.LastIndex(*path, "?")
+	if pos != -1 {
+		*path = (*path)[:pos]
+	}
+	*path = *path + "?" + opaque
+}
+
+// Opaque returns opaque data from provided path.
+func Opaque(path string) string {
+	pos := strings.LastIndex(path, "?")
+	return path[pos+1:]
 }

--- a/xrootd/xrdproto/rm/rm.go
+++ b/xrootd/xrdproto/rm/rm.go
@@ -8,6 +8,7 @@ package rm // import "go-hep.org/x/hep/xrootd/xrdproto/rm"
 
 import (
 	"go-hep.org/x/hep/xrootd/internal/xrdenc"
+	"go-hep.org/x/hep/xrootd/xrdproto"
 )
 
 // RequestID is the id of the request, it is sent as part of message.
@@ -39,3 +40,13 @@ func (req *Request) ReqID() uint16 { return RequestID }
 
 // ShouldSign implements xrdproto.Request.ShouldSign.
 func (req *Request) ShouldSign() bool { return false }
+
+// Opaque implements xrdproto.FilepathRequest.Opaque.
+func (req *Request) Opaque() string {
+	return xrdproto.Opaque(req.Path)
+}
+
+// SetOpaque implements xrdproto.FilepathRequest.SetOpaque.
+func (req *Request) SetOpaque(opaque string) {
+	xrdproto.SetOpaque(&req.Path, opaque)
+}

--- a/xrootd/xrdproto/rmdir/rmdir.go
+++ b/xrootd/xrdproto/rmdir/rmdir.go
@@ -8,6 +8,7 @@ package rmdir // import "go-hep.org/x/hep/xrootd/xrdproto/rmdir"
 
 import (
 	"go-hep.org/x/hep/xrootd/internal/xrdenc"
+	"go-hep.org/x/hep/xrootd/xrdproto"
 )
 
 // RequestID is the id of the request, it is sent as part of message.
@@ -39,3 +40,13 @@ func (req *Request) ReqID() uint16 { return RequestID }
 
 // ShouldSign implements xrdproto.Request.ShouldSign.
 func (req *Request) ShouldSign() bool { return false }
+
+// Opaque implements xrdproto.FilepathRequest.Opaque.
+func (req *Request) Opaque() string {
+	return xrdproto.Opaque(req.Path)
+}
+
+// SetOpaque implements xrdproto.FilepathRequest.SetOpaque.
+func (req *Request) SetOpaque(opaque string) {
+	xrdproto.SetOpaque(&req.Path, opaque)
+}

--- a/xrootd/xrdproto/stat/stat.go
+++ b/xrootd/xrdproto/stat/stat.go
@@ -9,6 +9,7 @@ package stat // import "go-hep.org/x/hep/xrootd/xrdproto/stat"
 import (
 	"go-hep.org/x/hep/xrootd/internal/xrdenc"
 	"go-hep.org/x/hep/xrootd/xrdfs"
+	"go-hep.org/x/hep/xrootd/xrdproto"
 )
 
 // RequestID is the id of the request, it is sent as part of message.
@@ -77,3 +78,13 @@ func (req *Request) ReqID() uint16 { return RequestID }
 
 // ShouldSign implements xrdproto.Request.ShouldSign.
 func (req *Request) ShouldSign() bool { return false }
+
+// Opaque implements xrdproto.FilepathRequest.Opaque.
+func (req *Request) Opaque() string {
+	return xrdproto.Opaque(req.Path)
+}
+
+// SetOpaque implements xrdproto.FilepathRequest.SetOpaque.
+func (req *Request) SetOpaque(opaque string) {
+	xrdproto.SetOpaque(&req.Path, opaque)
+}

--- a/xrootd/xrdproto/truncate/truncate.go
+++ b/xrootd/xrdproto/truncate/truncate.go
@@ -9,6 +9,7 @@ package truncate // import "go-hep.org/x/hep/xrootd/xrdproto/truncate"
 import (
 	"go-hep.org/x/hep/xrootd/internal/xrdenc"
 	"go-hep.org/x/hep/xrootd/xrdfs"
+	"go-hep.org/x/hep/xrootd/xrdproto"
 )
 
 // RequestID is the id of the request, it is sent as part of message.
@@ -47,3 +48,17 @@ func (req *Request) ReqID() uint16 { return RequestID }
 
 // ShouldSign implements xrdproto.Request.ShouldSign.
 func (req *Request) ShouldSign() bool { return false }
+
+// Opaque implements xrdproto.FilepathRequest.Opaque.
+func (req *Request) Opaque() string {
+	return xrdproto.Opaque(req.Path)
+}
+
+// SetOpaque implements xrdproto.FilepathRequest.SetOpaque.
+func (req *Request) SetOpaque(opaque string) {
+	// Opaque is only required if path was specified.
+	if len(req.Path) == 0 {
+		return
+	}
+	xrdproto.SetOpaque(&req.Path, opaque)
+}


### PR DESCRIPTION
This allows any request with a file path to have correct `opaque` after redirection.