### PR TITLE
xrootd/{cmd/xrootd-fuse,xrdfuse}: first import

### DIFF
--- a/xrootd/cmd/xrootd-fuse/main.go
+++ b/xrootd/cmd/xrootd-fuse/main.go
@@ -1,0 +1,95 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Command xrootd-fuse mounts the directory contents of a remote xrootd server to a local directory.
+//
+// Usage:
+//
+//  $> xrootd-fuse [OPTIONS] <remote-dir> <local-dir>
+//
+// Example:
+//
+//  $> xrootd-fuse root://server.example.com/some/dir /mnt
+//  $> xrootd-fuse -v root://server.example.com/some/dir /mnt
+//
+// Options:
+//   -v	enable verbose mode
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
+	"go-hep.org/x/hep/xrootd/client"
+	"go-hep.org/x/hep/xrootd/xrdfuse"
+	"go-hep.org/x/hep/xrootd/xrdio"
+)
+
+func init() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, `xrootd-fuse mounts the directory contents of a remote xrootd server to a local directory.
+
+Usage:
+
+ $> xrootd-fuse [OPTIONS] <remote-dir> <local-dir>
+
+Example:
+
+ $> xrootd-fuse root://server.example.com/some/dir /mnt
+ $> xrootd-fuse -v root://server.example.com/some/dir /mnt
+
+Options:
+`)
+		flag.PrintDefaults()
+	}
+}
+
+func main() {
+	log.SetPrefix("xrootd-fuse: ")
+	log.SetFlags(0)
+
+	verbose := flag.Bool("v", false, "enable verbose mode")
+
+	flag.Parse()
+
+	if flag.NArg() != 2 {
+		flag.Usage()
+		log.Fatalf("missing directory operands")
+	}
+
+	url, err := xrdio.Parse(flag.Arg(0))
+
+	c, err := client.NewClient(context.Background(), url.Addr, url.User)
+	if err != nil {
+		log.Fatalf("could not create client: %v", err)
+	}
+
+	fs := xrdfuse.NewFS(c, url.Path, func(e error) {
+		log.Println(e)
+	})
+	nfs := pathfs.NewPathNodeFs(fs, nil)
+	server, _, err := nodefs.MountRoot(flag.Arg(1), nfs.Root(), &nodefs.Options{
+		Debug: *verbose,
+	})
+	if err != nil {
+		log.Fatalf("could not mount: %v", err)
+	}
+
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt)
+
+	go server.Serve()
+
+	<-ch
+	err = server.Unmount()
+	if err != nil {
+		log.Fatalf("could not unmount: %v", err)
+	}
+}

--- a/xrootd/xrdfuse/cxx_server_test.go
+++ b/xrootd/xrdfuse/cxx_server_test.go
@@ -1,0 +1,10 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xrdfuse // import "go-hep.org/x/hep/xrootd/xrdfuse"
+
+func init() {
+	// add a C++ XRootD test server hosted in CC-Lyon.
+	testClientAddrs = append(testClientAddrs, "ccxrootdgotest.in2p3.fr:9001")
+}

--- a/xrootd/xrdfuse/file.go
+++ b/xrootd/xrdfuse/file.go
@@ -1,0 +1,97 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xrdfuse // import "go-hep.org/x/hep/xrootd/xrdfuse"
+
+import (
+	"context"
+
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/pkg/errors"
+	"go-hep.org/x/hep/xrootd/xrdfs"
+)
+
+// File represents a file on the remote XRootD server.
+type File struct {
+	nodefs.File
+	xrdfile xrdfs.File
+	fs      *FS
+}
+
+// Read implements nodefs.File.Read
+func (f *File) Read(dest []byte, off int64) (fuse.ReadResult, fuse.Status) {
+	n, err := f.xrdfile.ReadAt(dest, off)
+	if err != nil {
+		f.fs.handler(errors.WithMessage(err, "xrdfuse: error calling ReadAt"))
+		return nil, fuse.EIO
+	}
+
+	return fuse.ReadResultData(dest[:n]), fuse.OK
+}
+
+// Write implements nodefs.File.Write
+func (f *File) Write(data []byte, off int64) (uint32, fuse.Status) {
+	n, err := f.xrdfile.WriteAt(data, off)
+	if err != nil {
+		f.fs.handler(errors.WithMessage(err, "xrdfuse: error calling WriteAt"))
+		return 0, fuse.EIO
+	}
+
+	return uint32(n), fuse.OK
+}
+
+// Truncate implements nodefs.File.Truncate
+func (f *File) Truncate(size uint64) fuse.Status {
+	err := f.xrdfile.Truncate(context.Background(), int64(size))
+	if err != nil {
+		f.fs.handler(errors.WithMessage(err, "xrdfuse: error calling Truncate"))
+		return fuse.EIO
+	}
+
+	return fuse.OK
+}
+
+// Fsync implements nodefs.File.Fsync
+func (f *File) Fsync(flags int) (code fuse.Status) {
+	return f.Flush()
+}
+
+// Flush implements nodefs.File.Flush
+func (f *File) Flush() (code fuse.Status) {
+	err := f.xrdfile.Sync(context.Background())
+	if err != nil {
+		f.fs.handler(errors.WithMessage(err, "xrdfuse: error calling Sync"))
+		return fuse.EIO
+	}
+
+	return fuse.OK
+}
+
+// GetAttr implements nodefs.File.GetAttr
+func (f *File) GetAttr(out *fuse.Attr) fuse.Status {
+	stat, err := f.xrdfile.Stat(context.Background())
+	if err != nil {
+		f.fs.handler(errors.WithMessage(err, "xrdfuse: error calling Stat"))
+		return fuse.EIO
+	}
+
+	out.Size = uint64(stat.Size())
+	out.Mtime = uint64(stat.Mtime)
+	out.Mode = entryStatToMode(stat)
+
+	return fuse.OK
+}
+
+// Release implements nodefs.File.Release
+func (f *File) Release() {
+	err := f.xrdfile.Close(context.Background())
+	if err != nil {
+		f.fs.handler(errors.WithMessage(err, "xrdfuse: error calling Close"))
+	}
+}
+
+var (
+	_ nodefs.File = (*File)(nil)
+)

--- a/xrootd/xrdfuse/xrdfuse.go
+++ b/xrootd/xrdfuse/xrdfuse.go
@@ -1,0 +1,262 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package xrdfuse contains the implementation of the FUSE API
+// accessing a remote filesystem served over the XRootD protocol.
+package xrdfuse // import "go-hep.org/x/hep/xrootd/xrdfuse"
+
+import (
+	"context"
+	"os"
+	"path"
+
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
+	"github.com/pkg/errors"
+	"go-hep.org/x/hep/xrootd/client"
+	"go-hep.org/x/hep/xrootd/xrdfs"
+	"go-hep.org/x/hep/xrootd/xrdproto"
+)
+
+// FS implements a pathfs.FileSystem that makes requests to the remote server over the XRootD protocol.
+type FS struct {
+	pathfs.FileSystem
+	client  *client.Client
+	xrdfs   xrdfs.FileSystem
+	root    string
+	handler ErrorHandler
+}
+
+// ErrorHandler is the function which handles occurred error (e.g. logs it).
+type ErrorHandler func(error)
+
+// NewFS returns a new path.FileSystem representing the filesystem on the remote XRootD server.
+// client is a client connected to the remote XRootD server.
+// root is the path to the remote directory to be used as a root directory.
+// handler is the function which handles occurred error (e.g. logs it). If the handler is nil,
+// then a default handler is used that does nothing.
+func NewFS(client *client.Client, root string, handler ErrorHandler) *FS {
+	if handler == nil {
+		handler = func(error) {}
+	}
+	return &FS{
+		FileSystem: pathfs.NewDefaultFileSystem(),
+		client:     client,
+		xrdfs:      client.FS(),
+		root:       root,
+		handler:    handler,
+	}
+}
+
+// GetAttr implements pathfs.FileSystem.GetAttr
+func (fs *FS) GetAttr(name string, ctx *fuse.Context) (*fuse.Attr, fuse.Status) {
+	stat, err := fs.xrdfs.Stat(context.Background(), path.Join(fs.root, name))
+	status := errorToStatus(err)
+	if status == fuse.EIO {
+		fs.handler(errors.WithMessage(err, "xrdfuse: error calling Stat"))
+	}
+	if status != fuse.OK {
+		return nil, status
+	}
+
+	return &fuse.Attr{
+		Size:  uint64(stat.Size()),
+		Mtime: uint64(stat.Mtime),
+		Mode:  entryStatToMode(stat),
+	}, fuse.OK
+}
+
+// OpenDir implements pathfs.FileSystem.OpenDir
+func (fs *FS) OpenDir(name string, ctx *fuse.Context) (c []fuse.DirEntry, code fuse.Status) {
+	entries, err := fs.xrdfs.Dirlist(context.Background(), path.Join(fs.root, name))
+	status := errorToStatus(err)
+	if status == fuse.EIO {
+		fs.handler(errors.WithMessage(err, "xrdfuse: error calling Dirlist"))
+	}
+	if status != fuse.OK {
+		return nil, status
+	}
+
+	s := make([]fuse.DirEntry, 0, len(entries))
+	for _, entry := range entries {
+		s = append(s, fuse.DirEntry{Name: entry.Name(), Mode: entryStatToMode(entry)})
+	}
+
+	return s, fuse.OK
+}
+
+func convertFlagsToMode(flags uint32) xrdfs.OpenMode {
+	switch {
+	case flags&uint32(os.O_RDWR) != 0:
+		return xrdfs.OpenModeOwnerRead | xrdfs.OpenModeOwnerWrite
+	case flags&uint32(os.O_RDONLY) != 0:
+		return xrdfs.OpenModeOwnerRead
+	case flags&uint32(os.O_WRONLY) != 0:
+		return xrdfs.OpenModeOwnerWrite
+	}
+	return 0
+}
+
+func convertFlagsToOptions(flags uint32) xrdfs.OpenOptions {
+	var result xrdfs.OpenOptions
+	if flags&uint32(os.O_APPEND) != 0 {
+		result |= xrdfs.OpenOptionsOpenAppend
+	}
+	if flags&uint32(os.O_CREATE) != 0 {
+		result |= xrdfs.OpenOptionsNew
+	}
+	if flags&uint32(os.O_TRUNC) != 0 {
+		result |= xrdfs.OpenOptionsDelete
+	}
+	if flags&fuse.O_ANYWRITE != 0 {
+		result |= xrdfs.OpenOptionsOpenUpdate
+	} else {
+		result |= xrdfs.OpenOptionsOpenRead
+	}
+	return result
+}
+
+func convertModeToXrdMode(mode uint32) xrdfs.OpenMode {
+	// XRootD open mode follows Unix permissions.
+	return xrdfs.OpenMode(mode)
+}
+
+// Open implements pathfs.FileSystem.Open
+func (fs *FS) Open(name string, flags uint32, ctx *fuse.Context) (file nodefs.File, code fuse.Status) {
+	mode := convertFlagsToMode(flags)
+	options := convertFlagsToOptions(flags)
+	f, err := fs.xrdfs.Open(context.Background(), path.Join(fs.root, name), mode, options)
+	if serverError, ok := err.(xrdproto.ServerError); ok {
+		if serverError.Code == xrdproto.InvalidRequestCode {
+			// It is possible the request is invalid because the file already exists.
+			// O_CREAT flag can be passed to the fuse API despite the fact that file
+			// is already created. Open should correctly handle this situation, as far
+			// as I can see from the docs.
+			f, err = fs.xrdfs.Open(context.Background(), path.Join(fs.root, name), mode, options^xrdfs.OpenOptionsNew)
+		}
+	}
+	status := errorToStatus(err)
+	if status == fuse.EIO {
+		fs.handler(errors.WithMessage(err, "xrdfuse: error calling Open"))
+	}
+	if status != fuse.OK {
+		return nil, status
+	}
+	return &File{File: nodefs.NewDefaultFile(), xrdfile: f, fs: fs}, fuse.OK
+}
+
+// Mknod implements pathfs.FileSystem.Mknod
+func (fs *FS) Mknod(name string, mode uint32, dev uint32, ctx *fuse.Context) fuse.Status {
+	xrdmode := convertModeToXrdMode(mode)
+	f, err := fs.xrdfs.Open(context.Background(), path.Join(fs.root, name), xrdmode, xrdfs.OpenOptionsNew)
+	status := errorToStatus(err)
+	if status == fuse.EIO {
+		fs.handler(errors.WithMessage(err, "xrdfuse: error calling Open"))
+	}
+	if status != fuse.OK {
+		return status
+	}
+
+	err = f.Close(context.Background())
+	status = errorToStatus(err)
+	if status == fuse.EIO {
+		fs.handler(errors.WithMessage(err, "xrdfuse: error calling Close"))
+	}
+	return status
+}
+
+// Rename implements pathfs.FileSystem.Rename
+func (fs *FS) Rename(oldName string, newName string, ctx *fuse.Context) fuse.Status {
+	err := fs.xrdfs.Rename(context.Background(), path.Join(fs.root, oldName), path.Join(fs.root, newName))
+	status := errorToStatus(err)
+	if status == fuse.EIO {
+		fs.handler(errors.WithMessage(err, "xrdfuse: error calling Rename"))
+	}
+	return status
+}
+
+// Unlink implements pathfs.FileSystem.Unlink
+func (fs *FS) Unlink(name string, ctx *fuse.Context) fuse.Status {
+	err := fs.xrdfs.RemoveFile(context.Background(), path.Join(fs.root, name))
+	status := errorToStatus(err)
+	if status == fuse.EIO {
+		fs.handler(errors.WithMessage(err, "xrdfuse: error calling RemoveFile"))
+	}
+	return status
+}
+
+// Rmdir implements pathfs.FileSystem.Rmdir
+func (fs *FS) Rmdir(name string, ctx *fuse.Context) fuse.Status {
+	err := fs.xrdfs.RemoveDir(context.Background(), path.Join(fs.root, name))
+	status := errorToStatus(err)
+	if status == fuse.EIO {
+		fs.handler(errors.WithMessage(err, "xrdfuse: error calling RemoveDir"))
+	}
+	return status
+}
+
+// Mkdir implements pathfs.FileSystem.Mkdir
+func (fs *FS) Mkdir(name string, mode uint32, ctx *fuse.Context) fuse.Status {
+	xrdmode := convertModeToXrdMode(mode)
+	err := fs.xrdfs.Mkdir(context.Background(), path.Join(fs.root, name), xrdmode)
+	status := errorToStatus(err)
+	if status == fuse.EIO {
+		fs.handler(errors.WithMessage(err, "xrdfuse: error calling Mkdir"))
+	}
+	return status
+}
+
+// Chmod implements pathfs.FileSystem.Chmod
+func (fs *FS) Chmod(name string, mode uint32, ctx *fuse.Context) fuse.Status {
+	xrdmode := convertModeToXrdMode(mode)
+	err := fs.xrdfs.Chmod(context.Background(), path.Join(fs.root, name), xrdmode)
+	status := errorToStatus(err)
+	if status == fuse.EIO {
+		fs.handler(errors.WithMessage(err, "xrdfuse: error calling Chmod"))
+	}
+	return status
+}
+
+func entryStatToMode(stat xrdfs.EntryStat) uint32 {
+	mode := uint32(0)
+	if stat.IsDir() {
+		mode |= fuse.S_IFDIR
+	} else {
+		mode |= fuse.S_IFREG
+	}
+	if stat.IsReadable() {
+		mode |= 0444
+	}
+	if stat.IsWritable() {
+		mode |= 0222
+	}
+	if stat.IsExecutable() {
+		mode |= 0111
+	}
+	return mode
+}
+
+func errorToStatus(err error) fuse.Status {
+	if err == nil {
+		return fuse.OK
+	}
+	if serverError, ok := err.(xrdproto.ServerError); ok {
+		switch serverError.Code {
+		case xrdproto.NotFoundCode:
+			// File does not exists.
+			return fuse.ENOENT
+		case xrdproto.NotAuthorized:
+			// Permission denied.
+			return fuse.EACCES
+		default:
+			return fuse.EIO
+		}
+	}
+	return fuse.EIO
+}
+
+var (
+	_ pathfs.FileSystem = (*FS)(nil)
+)

--- a/xrootd/xrdfuse/xrdfuse_test.go
+++ b/xrootd/xrdfuse/xrdfuse_test.go
@@ -1,0 +1,296 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xrdfuse // import "go-hep.org/x/hep/xrootd/xrdfuse"
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/hanwen/go-fuse/fuse/pathfs"
+	"go-hep.org/x/hep/xrootd/client"
+)
+
+var testClientAddrs []string
+
+func mount(t *testing.T, addr string) (mountPoint string, server *fuse.Server, err error) {
+	tmp, err := ioutil.TempDir("", "xrdfuse-")
+	if err != nil {
+		return "", nil, err
+	}
+
+	c, err := client.NewClient(context.Background(), addr, "gopher")
+	if err != nil {
+		err := os.RemoveAll(tmp)
+		if err != nil {
+			t.Logf("could not remove %q: %v", tmp, err)
+		}
+		return "", nil, err
+	}
+
+	fs := NewFS(c, "/tmp", func(e error) {
+		t.Errorf("got error: %v", e)
+	})
+
+	nfs := pathfs.NewPathNodeFs(fs, nil)
+	server, _, err = nodefs.MountRoot(tmp, nfs.Root(), &nodefs.Options{
+		Debug: true,
+	})
+
+	return tmp, server, err
+}
+
+func testFS_Mkdir(t *testing.T, addr string) {
+	mnt, server, err := mount(t, addr)
+	if err != nil {
+		t.Fatalf("could not mount: %v", err)
+	}
+	defer func() {
+		err := os.RemoveAll(mnt)
+		if err != nil {
+			t.Logf("could not remove %q: %v", mnt, err)
+		}
+	}()
+	defer server.Unmount()
+	go server.Serve()
+
+	tmp, err := ioutil.TempDir(mnt, "xrdfuse-")
+	if err != nil {
+		t.Fatalf("could not create dir: %v", err)
+	}
+	defer func() {
+		err := os.RemoveAll(tmp)
+		if err != nil {
+			t.Logf("could not remove %q: %v", tmp, err)
+		}
+	}()
+}
+
+func TestFS_Mkdir(t *testing.T) {
+	for _, addr := range testClientAddrs {
+		t.Run(addr, func(t *testing.T) {
+			testFS_Mkdir(t, addr)
+		})
+	}
+}
+
+func testFS_OpenDir(t *testing.T, addr string) {
+	mnt, server, err := mount(t, addr)
+	if err != nil {
+		t.Fatalf("could not mount: %v", err)
+	}
+	defer func() {
+		err := os.RemoveAll(mnt)
+		if err != nil {
+			t.Logf("could not remove %q: %v", mnt, err)
+		}
+	}()
+	defer server.Unmount()
+	go server.Serve()
+
+	tmp, err := ioutil.TempDir(mnt, "xrdfuse-")
+	if err != nil {
+		t.Fatalf("could not create dir: %v", err)
+	}
+	defer func() {
+		err := os.RemoveAll(tmp)
+		if err != nil {
+			t.Logf("could not remove %q: %v", tmp, err)
+		}
+	}()
+
+	f, err := os.Open(mnt)
+	if err != nil {
+		t.Fatalf("could not open dir: %v", err)
+	}
+	defer f.Close()
+
+	tmpName := path.Base(tmp)
+
+	dirs, err := f.Readdirnames(0)
+	if err != nil {
+		t.Fatalf("could not readdir: %v", err)
+	}
+	for _, d := range dirs {
+		if d == tmpName {
+			return
+		}
+	}
+	t.Fatalf("could not find child with name %q", tmpName)
+}
+
+func TestFS_OpenDir(t *testing.T) {
+	for _, addr := range testClientAddrs {
+		t.Run(addr, func(t *testing.T) {
+			testFS_OpenDir(t, addr)
+		})
+	}
+}
+
+func testFS_Rename(t *testing.T, addr string) {
+	mnt, server, err := mount(t, addr)
+	if err != nil {
+		t.Fatalf("could not mount: %v", err)
+	}
+	defer func() {
+		err := os.RemoveAll(mnt)
+		if err != nil {
+			t.Logf("could not remove %q: %v", mnt, err)
+		}
+	}()
+	defer server.Unmount()
+	go server.Serve()
+
+	tmp, err := ioutil.TempDir(mnt, "xrdfuse-")
+	if err != nil {
+		t.Fatalf("could not create dir: %v", err)
+	}
+	defer func() {
+		err := os.RemoveAll(tmp)
+		if err != nil {
+			t.Logf("could not remove %q: %v", tmp, err)
+		}
+	}()
+
+	tmpName := path.Base(tmp)
+	newTmpName := tmpName + "-renamed"
+	newTmp := path.Join(mnt, newTmpName)
+
+	err = os.Rename(tmp, newTmp)
+	if err != nil {
+		t.Fatalf("could not rename dir: %v", err)
+	}
+	defer func() {
+		err := os.RemoveAll(newTmp)
+		if err != nil {
+			t.Logf("could not remove %q: %v", newTmp, err)
+		}
+	}()
+
+	f, err := os.Open(mnt)
+	if err != nil {
+		t.Fatalf("could not open dir: %v", err)
+	}
+	defer f.Close()
+
+	dirs, err := f.Readdirnames(0)
+	if err != nil {
+		t.Fatalf("could not readdir: %v", err)
+	}
+
+	ok := false
+	for _, d := range dirs {
+		if d == tmpName {
+			t.Errorf("dir %q was not renamed", tmpName)
+		}
+		if d == newTmpName {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		t.Fatalf("could not find dir with name %q", newTmpName)
+	}
+}
+
+func TestFS_Rename(t *testing.T) {
+	for _, addr := range testClientAddrs {
+		t.Run(addr, func(t *testing.T) {
+			testFS_Rename(t, addr)
+		})
+	}
+}
+
+func testFS_Mknod(t *testing.T, addr string) {
+	mnt, server, err := mount(t, addr)
+	if err != nil {
+		t.Fatalf("could not mount: %v", err)
+	}
+	defer func() {
+		err := os.RemoveAll(mnt)
+		if err != nil {
+			t.Logf("could not remove %q: %v", mnt, err)
+		}
+	}()
+	defer server.Unmount()
+	go server.Serve()
+
+	tmp, err := ioutil.TempFile(mnt, "xrdfuse-")
+	if err != nil {
+		t.Fatalf("could not create file: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+
+	err = tmp.Close()
+	if err != nil {
+		t.Fatalf("could not close %q: %v", tmp.Name(), err)
+	}
+
+	err = os.Remove(tmp.Name())
+	if err != nil {
+		t.Fatalf("could not remove %q: %v", tmp.Name(), err)
+	}
+}
+
+func TestFS_Mknod(t *testing.T) {
+	for _, addr := range testClientAddrs {
+		t.Run(addr, func(t *testing.T) {
+			testFS_Mknod(t, addr)
+		})
+	}
+}
+
+func testFS_Chmod(t *testing.T, addr string) {
+	mnt, server, err := mount(t, addr)
+	if err != nil {
+		t.Fatalf("could not mount: %v", err)
+	}
+	defer func() {
+		err := os.RemoveAll(mnt)
+		if err != nil {
+			t.Logf("could not remove %q: %v", mnt, err)
+		}
+	}()
+	defer server.Unmount()
+	go server.Serve()
+
+	tmp, err := ioutil.TempFile(mnt, "xrdfuse-")
+	if err != nil {
+		t.Fatalf("could not create file: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+
+	err = tmp.Close()
+	if err != nil {
+		t.Fatalf("could not close %q: %v", tmp.Name(), err)
+	}
+
+	want := os.FileMode(0222)
+	err = os.Chmod(tmp.Name(), want)
+	if err != nil {
+		t.Fatalf("could not chmod %q: %v", tmp.Name(), err)
+	}
+
+	stat, err := os.Stat(tmp.Name())
+	if err != nil {
+		t.Fatalf("could not stat %q: %v", tmp.Name(), err)
+	}
+
+	if stat.Mode() != want {
+		t.Fatalf("mode doesn't match:\ngot = %v\nwant = %v\n", stat.Mode(), want)
+	}
+}
+
+func TestFS_Chmod(t *testing.T) {
+	for _, addr := range testClientAddrs {
+		t.Run(addr, func(t *testing.T) {
+			testFS_Chmod(t, addr)
+		})
+	}
+}

--- a/xrootd/xrdproto/protocol.go
+++ b/xrootd/xrdproto/protocol.go
@@ -35,9 +35,18 @@ const (
 
 // ServerError is the error returned by the XRootD server as part of response to the request.
 type ServerError struct {
-	Code    int32
+	Code    ServerErrorCode
 	Message string
 }
+
+// ServerErrorCode is the code of the error returned by the XRootD server as part of response to the request.
+type ServerErrorCode int32
+
+const (
+	InvalidRequestCode ServerErrorCode = 3006 // InvalidRequestCode indicates that request is invalid.
+	NotAuthorized      ServerErrorCode = 3010 // NotAuthorized indicates that user was not authorized for operation.
+	NotFoundCode       ServerErrorCode = 3011 // NotFoundCode indicates that path was not found on the remote server.
+)
 
 func (err ServerError) Error() string {
 	return fmt.Sprintf("xrootd: error %d: %s", err.Code, err.Message)
@@ -103,7 +112,7 @@ func (hdr ResponseHeader) Error(data []byte) error {
 		if len(data) < 5 {
 			return errors.New("xrootd: an server error occurred, but code and message were not provided")
 		}
-		code := int32(binary.BigEndian.Uint32(data[0:4]))
+		code := ServerErrorCode(binary.BigEndian.Uint32(data[0:4]))
 		message := string(data[4 : len(data)-1]) // Skip \0 character at the end
 
 		return ServerError{code, message}


### PR DESCRIPTION
Supports:
- ls
- echo "..." > file
- echo "..." >> file
- cat file

Note: probably I should move error codes to the xrdproto package?

Updates go-hep/hep#174.
Updates go-hep/hep#175.