### PR TITLE
xrootd/cmd/xrd-fuse: rename from xrootd-fuse

### DIFF
--- a/fads/energy_smearing.go
+++ b/fads/energy_smearing.go
@@ -76,7 +76,6 @@ func (tsk *EnergySmearing) Process(ctx fwk.Context) error {
 	for i := range input {
 		cand := &input[i]
 		eta := cand.Pos.Eta()
-		phi := cand.Pos.Phi()
 		ene := cand.Mom.E()
 
 		// apply smearing
@@ -92,7 +91,7 @@ func (tsk *EnergySmearing) Process(ctx fwk.Context) error {
 		mother := cand
 		c := cand.Clone()
 		eta = cand.Mom.Eta()
-		phi = cand.Mom.Phi()
+		phi := cand.Mom.Phi()
 		pt := ene / math.Cosh(eta)
 
 		pxs := pt * math.Cos(phi)

--- a/fads/momentum_smearing.go
+++ b/fads/momentum_smearing.go
@@ -76,7 +76,6 @@ func (tsk *MomentumSmearing) Process(ctx fwk.Context) error {
 	for i := range input {
 		cand := &input[i]
 		eta := cand.Pos.Eta()
-		phi := cand.Pos.Phi()
 		pt := cand.Mom.Pt()
 
 		// apply smearing
@@ -92,7 +91,7 @@ func (tsk *MomentumSmearing) Process(ctx fwk.Context) error {
 		mother := cand
 		c := cand.Clone()
 		eta = cand.Mom.Eta()
-		phi = cand.Mom.Phi()
+		phi := cand.Mom.Phi()
 
 		pxs := pt * math.Cos(phi)
 		pys := pt * math.Sin(phi)

--- a/fwk/app.go
+++ b/fwk/app.go
@@ -565,10 +565,12 @@ func (app *appmgr) runSequential(ctx Context) error {
 		app.msg.Infof(">>> running evt=%d...\n", ievt)
 		err = store.reset(keys)
 		if err != nil {
+			evtCancel()
 			return err
 		}
 		err = app.istream.Process(ctxs[0])
 		if err != nil {
+			evtCancel()
 			store.close()
 			app.msg.flush()
 			return err
@@ -595,6 +597,7 @@ func (app *appmgr) runSequential(ctx Context) error {
 				break errloop
 			}
 		}
+		evtCancel()
 		store.close()
 		app.msg.flush()
 	}

--- a/hbook/ntup/ntuple_test.go
+++ b/hbook/ntup/ntuple_test.go
@@ -416,6 +416,9 @@ func init() {
 	}
 
 	tx, err := db.Begin()
+	if err != nil {
+		panic(err)
+	}
 	_, err = tx.Exec("create table data (id int, x float64);")
 	if err != nil {
 		panic(err)

--- a/hplot/h1d.go
+++ b/hplot/h1d.go
@@ -285,12 +285,9 @@ func (l *histLegend) draw(c draw.Canvas) {
 	textx := c.Min.X
 	hdr := l.entryWidth() //+ l.TextStyle.Width(" ")
 	l.ColWidth = hdr
-	valx := textx + l.ColWidth + l.TextStyle.Width(" ")
 	if !l.Left {
 		textx = c.Max.X - l.ColWidth
-		valx = textx - l.TextStyle.Width(" ")
 	}
-	valx += l.XOffs
 	textx += l.XOffs
 
 	enth := l.entryHeight()

--- a/lhef/reader.go
+++ b/lhef/reader.go
@@ -9,6 +9,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+
+	"github.com/pkg/errors"
 )
 
 // Decoder represents an LHEF parser reading a particular input stream.
@@ -134,8 +136,10 @@ Loop:
 			&d.Run.XMAXUP[i],
 			&d.Run.LPRUP[i],
 		)
+		if err != nil {
+			return nil, errors.Errorf("lhef: failed to decode NPRUP %d: %v", i, err)
+		}
 	}
-	//fmt.Printf(">>> data: %v\n", d.Run)
 
 	if d.Version >= 2 {
 		// do version-2 specific stuff

--- a/pawgo/cmd.go
+++ b/pawgo/cmd.go
@@ -90,6 +90,9 @@ func (c *Cmd) Close() error {
 	var err error
 
 	err = c.fmgr.Close()
+	if err != nil {
+		return err
+	}
 
 	f, err := os.Create(".pawgo.history")
 	if err == nil {

--- a/rootio/cmd/root-diff/main.go
+++ b/rootio/cmd/root-diff/main.go
@@ -174,7 +174,6 @@ func diffObject(key string, ref, chk rootio.Object) error {
 		return fmt.Errorf("unhandled type %T (key=%v)", ref, key)
 
 	}
-	return nil
 }
 
 func diffTree(key string, ref, chk rootio.Tree) error {

--- a/rootio/cmd/root-srv/server/plots.go
+++ b/rootio/cmd/root-srv/server/plots.go
@@ -203,14 +203,6 @@ func (srv *server) plotBranchHandle(w http.ResponseWriter, r *http.Request) erro
 
 	leaves := b.Leaves()
 	leaf := leaves[0]
-	tname := leaf.TypeName()
-	switch {
-	case leaf.LeafCount() != nil:
-		tname = "[]" + tname
-	case leaf.Len() > 1:
-		tname = fmt.Sprintf("[%d]%s", leaf.Len(), tname)
-	}
-
 	fv, err := newFloats(leaf)
 	if err != nil {
 		log.Printf("error creating float-val: %v\n", err)

--- a/rootio/read_streamers.go
+++ b/rootio/read_streamers.go
@@ -725,8 +725,6 @@ func rstreamerFrom(se StreamerElement, ptr interface{}, lcnt leafCount, sictx St
 						r.CheckByteCount(pos, bcnt, start, se.TypeName())
 						return r.err
 					}
-
-					panic(fmt.Errorf("rootio: read-streamer for %T not implemented", rf.Interface()))
 				}
 			}
 		default:

--- a/sio/stream.go
+++ b/sio/stream.go
@@ -212,9 +212,10 @@ func (stream *Stream) ReadRecord() (*Record, error) {
 			return nil, ErrStreamNoRecMarker
 		}
 
-		curpos := stream.CurPos()
-		// fmt.Printf(">>> pos --0: %d (%d)\n", curpos, rechdr.Len-8)
-		var recdata recordData
+		var (
+			curpos  int64
+			recdata recordData
+		)
 		err = stream.read(&recdata)
 		if err != nil {
 			return nil, err
@@ -270,7 +271,7 @@ func (stream *Stream) ReadRecord() (*Record, error) {
 			// record header start on a 4-bytes boundary in the file.
 			padlen := align4U32(recdata.DataLen) - recdata.DataLen
 			if padlen > 0 {
-				curpos, err = stream.Seek(int64(padlen), 1)
+				_, err = stream.Seek(int64(padlen), 1)
 				if err != nil {
 					return nil, err
 				}

--- a/xrootd/client/file_test.go
+++ b/xrootd/client/file_test.go
@@ -167,6 +167,9 @@ func testFile_WriteAt(t *testing.T, addr string) {
 
 	file.Close(context.Background())
 	file, err = fs.Open(context.Background(), filePath, xrdfs.OpenModeOwnerRead, xrdfs.OpenOptionsOpenRead)
+	if err != nil {
+		t.Fatalf("could not open %q: %v", filePath, err)
+	}
 	defer file.Close(context.Background())
 
 	got := make([]uint8, len(want)+10)

--- a/xrootd/client/filesystem_test.go
+++ b/xrootd/client/filesystem_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 var fstest = map[string]*xrdfs.EntryStat{
-	"/tmp/dir1/file1.txt": &xrdfs.EntryStat{
+	"/tmp/dir1/file1.txt": {
 		HasStatInfo: true,
 		ID:          139698106334466,
 		EntrySize:   0,

--- a/xrootd/client/filesystem_test.go
+++ b/xrootd/client/filesystem_test.go
@@ -600,6 +600,9 @@ func testFileSystem_Chmod(t *testing.T, addr string) {
 	}
 
 	err = fs.Chmod(context.Background(), file, newPerm)
+	if err != nil {
+		t.Fatalf("could not chmod %q: %v", file, err)
+	}
 
 	s, err = fs.Stat(context.Background(), file)
 	if err != nil {
@@ -611,6 +614,9 @@ func testFileSystem_Chmod(t *testing.T, addr string) {
 	}
 
 	err = fs.Chmod(context.Background(), file, oldPerm)
+	if err != nil {
+		t.Fatalf("could not chmod %q: %v", file, err)
+	}
 
 	s, err = fs.Stat(context.Background(), file)
 	if err != nil {

--- a/xrootd/cmd/xrd-client/main.go
+++ b/xrootd/cmd/xrd-client/main.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Command xrootd-client provides access to data hosted on XRootD clusters.
-package main // import "go-hep.org/x/hep/xrootd/cmd/xrootd-client"
+// Command xrd-client provides access to data hosted on XRootD clusters.
+package main // import "go-hep.org/x/hep/xrootd/cmd/xrd-client"
 
 func main() {}

--- a/xrootd/cmd/xrd-fuse/main.go
+++ b/xrootd/cmd/xrd-fuse/main.go
@@ -2,16 +2,16 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Command xrootd-fuse mounts the directory contents of a remote xrootd server to a local directory.
+// Command xrd-fuse mounts the directory contents of a remote xrootd server to a local directory.
 //
 // Usage:
 //
-//  $> xrootd-fuse [OPTIONS] <remote-dir> <local-dir>
+//  $> xrd-fuse [OPTIONS] <remote-dir> <local-dir>
 //
 // Example:
 //
-//  $> xrootd-fuse root://server.example.com/some/dir /mnt
-//  $> xrootd-fuse -v root://server.example.com/some/dir /mnt
+//  $> xrd-fuse root://server.example.com/some/dir /mnt
+//  $> xrd-fuse -v root://server.example.com/some/dir /mnt
 //
 // Options:
 //   -v	enable verbose mode
@@ -34,16 +34,16 @@ import (
 
 func init() {
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, `xrootd-fuse mounts the directory contents of a remote xrootd server to a local directory.
+		fmt.Fprintf(os.Stderr, `xrd-fuse mounts the directory contents of a remote xrootd server to a local directory.
 
 Usage:
 
- $> xrootd-fuse [OPTIONS] <remote-dir> <local-dir>
+ $> xrd-fuse [OPTIONS] <remote-dir> <local-dir>
 
 Example:
 
- $> xrootd-fuse root://server.example.com/some/dir /mnt
- $> xrootd-fuse -v root://server.example.com/some/dir /mnt
+ $> xrd-fuse root://server.example.com/some/dir /mnt
+ $> xrd-fuse -v root://server.example.com/some/dir /mnt
 
 Options:
 `)
@@ -52,7 +52,7 @@ Options:
 }
 
 func main() {
-	log.SetPrefix("xrootd-fuse: ")
+	log.SetPrefix("xrd-fuse: ")
 	log.SetFlags(0)
 
 	verbose := flag.Bool("v", false, "enable verbose mode")

--- a/xrootd/cmd/xrd-srv/main.go
+++ b/xrootd/cmd/xrd-srv/main.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Command xrootd-srv serves data from XRootD clusters.
-package main // import "go-hep.org/x/hep/xrootd/cmd/xrootd-srv"
+// Command xrd-srv serves data from XRootD clusters.
+package main // import "go-hep.org/x/hep/xrootd/cmd/xrd-srv"
 
 func main() {}

--- a/xrootd/cmd/xrootd-fuse/main.go
+++ b/xrootd/cmd/xrootd-fuse/main.go
@@ -65,6 +65,9 @@ func main() {
 	}
 
 	url, err := xrdio.Parse(flag.Arg(0))
+	if err != nil {
+		log.Fatalf("could not parse remote address %q: %v", flag.Arg(0), err)
+	}
 
 	c, err := client.NewClient(context.Background(), url.Addr, url.User)
 	if err != nil {

--- a/xrootd/xrdproto/dirlist/dirlist.go
+++ b/xrootd/xrdproto/dirlist/dirlist.go
@@ -32,7 +32,6 @@ func (resp *Response) RespID() uint16 { return RequestID }
 func (o Response) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
 	// TODO: implement
 	panic(errors.New("xrootd: MarshalXrd is not implemented"))
-	return nil
 }
 
 // UnmarshalXrd implements xrdproto.Unmarshaler


### PR DESCRIPTION
For consistency with the other go-hep/xrootd commands, rename
xrootd-fuse as xrd-fuse.