### PR TITLE
xrootd: cleanup

### DIFF
--- a/xrootd/client/filesystem_test.go
+++ b/xrootd/client/filesystem_test.go
@@ -97,19 +97,19 @@ func testFileSystem_Open(t *testing.T, addr string, options xrdfs.OpenOptions, w
 	defer gotFile.Close(context.Background())
 
 	if !reflect.DeepEqual(gotFile.Handle(), wantFileHandle) {
-		t.Errorf("Filesystem.Open()\ngotFile.Handle() = %v\nwantFileHandle = %v", gotFile.Handle(), wantFileHandle)
+		t.Errorf("FileSystem.Open()\ngotFile.Handle() = %v\nwantFileHandle = %v", gotFile.Handle(), wantFileHandle)
 	}
 
 	if !reflect.DeepEqual(gotFile.Compression(), wantFileCompression) {
 		// TODO: Remove this workaround when fix for https://github.com/xrootd/xrootd/issues/721 will be released.
 		skippedDefaultCompressionValue := reflect.DeepEqual(wantFileCompression, &xrdfs.FileCompression{}) && gotFile.Compression() == nil
 		if !skippedDefaultCompressionValue {
-			t.Errorf("Filesystem.Open()\ngotFile.Compression() = %v\nwantFileCompression = %v", gotFile.Compression(), wantFileCompression)
+			t.Errorf("FileSystem.Open()\ngotFile.Compression() = %v\nwantFileCompression = %v", gotFile.Compression(), wantFileCompression)
 		}
 	}
 
 	if !reflect.DeepEqual(gotFile.Info(), wantFileInfo) {
-		t.Errorf("Filesystem.Open()\ngotFile.Info() = %v\nwantFileInfo = %v", gotFile.Info(), wantFileInfo)
+		t.Errorf("FileSystem.Open()\ngotFile.Info() = %v\nwantFileInfo = %v", gotFile.Info(), wantFileInfo)
 	}
 }
 
@@ -290,7 +290,7 @@ func testFileSystem_Stat(t *testing.T, addr string) {
 	}
 
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Filesystem.Open()\ngot = %v\nwant = %v", got, want)
+		t.Errorf("FileSystem.Stat()\ngot = %v\nwant = %v", got, want)
 	}
 }
 
@@ -655,7 +655,7 @@ func testFileSystem_Statx(t *testing.T, addr string) {
 	}
 
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Filesystem.Statx()\ngot = %v\nwant = %v", got, want)
+		t.Errorf("FileSystem.Statx()\ngot = %v\nwant = %v", got, want)
 	}
 }
 

--- a/xrootd/client/main_mock_test.go
+++ b/xrootd/client/main_mock_test.go
@@ -25,7 +25,7 @@ func testClientWithMockServer(serverFunc func(cancel func(), conn net.Conn), cli
 	defer server.Close()
 	defer conn.Close()
 
-	client := &Client{cancel: cancel, sessions: make(map[string]*session)}
+	client := &Client{cancel: cancel, sessions: make(map[string]*session), maxRedirections: 8}
 	session := &session{cancel: cancel, ctx: ctx, conn: conn, mux: mux.New(), requests: make(map[xrdproto.StreamID]pendingRequest), client: client, signRequirements: signing.Default()}
 	client.initialSessionID = "test.org:1234"
 	client.sessions[client.initialSessionID] = session

--- a/xrootd/client/ping_mock_test.go
+++ b/xrootd/client/ping_mock_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestSession_Ping_Mock(t *testing.T) {
 	serverFunc := func(cancel func(), conn net.Conn) {
-		data, err := readRequest(conn)
+		data, err := xrdproto.ReadRequest(conn)
 		if err != nil {
 			cancel()
 			t.Fatalf("could not read request: %v", err)
@@ -28,25 +28,10 @@ func TestSession_Ping_Mock(t *testing.T) {
 			t.Fatalf("could not unmarshal request: %v", err)
 		}
 
-		if gotHeader.RequestID != gotRequest.ReqID() {
-			cancel()
-			t.Fatalf("invalid request id was specified:\nwant = %d\ngot = %d\n", gotRequest.ReqID(), gotHeader.RequestID)
-		}
-
-		responseHeader := xrdproto.ResponseHeader{
-			StreamID:   gotHeader.StreamID,
-			DataLength: 0,
-		}
-
-		response, err := marshalResponse(responseHeader)
+		err = xrdproto.WriteResponse(conn, gotHeader.StreamID, xrdproto.Ok, nil)
 		if err != nil {
 			cancel()
-			t.Fatalf("could not marshal response: %v", err)
-		}
-
-		if err := writeResponse(conn, response); err != nil {
-			cancel()
-			t.Fatalf("invalid write: %s", err)
+			t.Fatalf("could not write response: %v", err)
 		}
 	}
 

--- a/xrootd/client/ping_test.go
+++ b/xrootd/client/ping_test.go
@@ -29,3 +29,28 @@ func TestSession_Ping(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkSession_Ping(b *testing.B) {
+	for _, addr := range testClientAddrs {
+		b.Run(addr, func(b *testing.B) {
+			benchmarkSession_Ping(b, addr)
+		})
+	}
+}
+
+func benchmarkSession_Ping(b *testing.B, addr string) {
+	client, err := NewClient(context.Background(), addr, "gopher")
+	if err != nil {
+		b.Fatalf("could not create client: %v", err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := client.sessions[client.initialSessionID].Ping(context.Background())
+		if err != nil {
+			b.Errorf("could not ping: %v", err)
+		}
+	}
+	if err := client.Close(); err != nil {
+		b.Fatalf("could not close client: %v", err)
+	}
+}

--- a/xrootd/client/session_mock_test.go
+++ b/xrootd/client/session_mock_test.go
@@ -10,8 +10,11 @@ import (
 	"testing"
 	"time"
 
+	"go-hep.org/x/hep/xrootd/internal/mux"
 	"go-hep.org/x/hep/xrootd/xrdproto"
 	"go-hep.org/x/hep/xrootd/xrdproto/ping"
+	"go-hep.org/x/hep/xrootd/xrdproto/signing"
+	"go-hep.org/x/hep/xrootd/xrdproto/truncate"
 )
 
 func TestSession_WaitResponse(t *testing.T) {
@@ -65,6 +68,65 @@ func TestSession_WaitResponse(t *testing.T) {
 		err := client.sessions[client.initialSessionID].Ping(context.Background())
 		if err != nil {
 			t.Fatalf("invalid ping call: %v", err)
+		}
+	}
+
+	testClientWithMockServer(serverFunc, clientFunc)
+}
+
+func TestSession_ConnectionAbort(t *testing.T) {
+	serverFunc := func(cancel func(), conn net.Conn) {
+		data, err := xrdproto.ReadRequest(conn)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not read request: %v", err)
+		}
+
+		var gotRequest truncate.Request
+		gotHeader, err := unmarshalRequest(data, &gotRequest)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not unmarshal request: %v", err)
+		}
+
+		err = xrdproto.WriteResponse(conn, gotHeader.StreamID, xrdproto.Ok, xrdproto.WaitResponse{Duration: time.Second})
+		if err != nil {
+			cancel()
+			t.Fatalf("could not write response: %v", err)
+		}
+	}
+	serverFuncForSecondConnection := func(cancel func(), conn net.Conn) {
+		_, err := xrdproto.ReadRequest(conn)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not read request: %v", err)
+		}
+		conn.Close()
+	}
+
+	clientFunc := func(cancel func(), client *Client) {
+		p1, p2 := net.Pipe()
+		go serverFuncForSecondConnection(cancel, p2)
+		session := &session{
+			cancel:           cancel,
+			ctx:              context.Background(),
+			conn:             p1,
+			mux:              mux.New(),
+			requests:         make(map[xrdproto.StreamID]pendingRequest),
+			client:           client,
+			signRequirements: signing.Default(),
+			sessionID:        client.initialSessionID + "2",
+			isSub:            true,
+		}
+		defer session.Close()
+		defer p1.Close()
+		client.sessions[session.sessionID] = session
+		go session.consume()
+
+		f := file{sessionID: session.sessionID, fs: client.FS().(*fileSystem)}
+		err := f.Truncate(context.Background(), 0)
+		if err != nil {
+			t.Fatalf("invalid truncate call: %v", err)
 		}
 	}
 

--- a/xrootd/client/session_mock_test.go
+++ b/xrootd/client/session_mock_test.go
@@ -1,0 +1,72 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package client // import "go-hep.org/x/hep/xrootd/client"
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"go-hep.org/x/hep/xrootd/xrdproto"
+	"go-hep.org/x/hep/xrootd/xrdproto/ping"
+)
+
+func TestSession_WaitResponse(t *testing.T) {
+	serverFunc := func(cancel func(), conn net.Conn) {
+		data, err := xrdproto.ReadRequest(conn)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not read request: %v", err)
+		}
+
+		var gotRequest ping.Request
+		gotHeader, err := unmarshalRequest(data, &gotRequest)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not unmarshal request: %v", err)
+		}
+
+		err = xrdproto.WriteResponse(conn, gotHeader.StreamID, xrdproto.Wait, xrdproto.WaitResponse{Duration: time.Second})
+		if err != nil {
+			cancel()
+			t.Fatalf("could not write response: %v", err)
+		}
+
+		responseTime := time.Now()
+
+		data, err = xrdproto.ReadRequest(conn)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not read request: %v", err)
+		}
+
+		sleepTime := time.Now().Sub(responseTime)
+		if sleepTime < time.Second/2 {
+			t.Errorf("client should wait around 1 second before re-issuing request, waited %v", sleepTime)
+		}
+
+		gotHeader, err = unmarshalRequest(data, &gotRequest)
+		if err != nil {
+			cancel()
+			t.Fatalf("could not unmarshal request: %v", err)
+		}
+
+		err = xrdproto.WriteResponse(conn, gotHeader.StreamID, xrdproto.Ok, xrdproto.WaitResponse{Duration: time.Second})
+		if err != nil {
+			cancel()
+			t.Fatalf("could not write response: %v", err)
+		}
+	}
+
+	clientFunc := func(cancel func(), client *Client) {
+		err := client.sessions[client.initialSessionID].Ping(context.Background())
+		if err != nil {
+			t.Fatalf("invalid ping call: %v", err)
+		}
+	}
+
+	testClientWithMockServer(serverFunc, clientFunc)
+}

--- a/xrootd/cmd/xrd-srv/handler.go
+++ b/xrootd/cmd/xrd-srv/handler.go
@@ -30,7 +30,7 @@ func (h *handler) Dirlist(sessionID [16]byte, request *dirlist.Request) (xrdprot
 	files, err := ioutil.ReadDir(path.Join(h.basePath, request.Path))
 	if err != nil {
 		return xrdproto.ServerError{
-			Code:    xrdproto.IOErrorCode,
+			Code:    xrdproto.IOError,
 			Message: fmt.Sprintf("An IO error occurred: %v", err),
 		}, xrdproto.Error
 	}

--- a/xrootd/cmd/xrd-srv/main_test.go
+++ b/xrootd/cmd/xrd-srv/main_test.go
@@ -133,8 +133,8 @@ func TestHandler_Dirlist_WhenPathIsInvalid(t *testing.T) {
 	if !ok {
 		t.Fatalf("could not cast err to ServerError: %v", err)
 	}
-	if serverError.Code != xrdproto.IOErrorCode {
-		t.Fatalf("wrong error code:\ngot = %v\nwant = %v", serverError.Code, xrdproto.IOErrorCode)
+	if serverError.Code != xrdproto.IOError {
+		t.Fatalf("wrong error code:\ngot = %v\nwant = %v", serverError.Code, xrdproto.IOError)
 	}
 }
 

--- a/xrootd/server/default_handler.go
+++ b/xrootd/server/default_handler.go
@@ -36,7 +36,7 @@ func (h *defaultHandler) Protocol(sessionID [16]byte, request *protocol.Request)
 
 // Dirlist implements Handler.Dirlist.
 func (h *defaultHandler) Dirlist(sessionID [16]byte, request *dirlist.Request) (xrdproto.Marshaler, xrdproto.ResponseStatus) {
-	resp := xrdproto.ServerError{Code: xrdproto.InvalidRequestCode, Message: "Dirlist request is not implemented"}
+	resp := xrdproto.ServerError{Code: xrdproto.InvalidRequest, Message: "Dirlist request is not implemented"}
 	return resp, xrdproto.Error
 }
 

--- a/xrootd/server/server.go
+++ b/xrootd/server/server.go
@@ -223,7 +223,7 @@ func (s *Server) handleHandshake(conn net.Conn) error {
 
 func newUnmarshalingErrorResponse(err error) (xrdproto.Marshaler, xrdproto.ResponseStatus) {
 	response := xrdproto.ServerError{
-		Code:    xrdproto.InvalidRequestCode,
+		Code:    xrdproto.InvalidRequest,
 		Message: fmt.Sprintf("An error occurred while parsing the request: %v", err),
 	}
 	return response, xrdproto.Error
@@ -254,7 +254,7 @@ func (s *Server) handleRequest(sessionID [16]byte, requestID uint16, rBuffer *xr
 		return s.handler.Dirlist(sessionID, &request)
 	default:
 		response := xrdproto.ServerError{
-			Code:    xrdproto.InvalidRequestCode,
+			Code:    xrdproto.InvalidRequest,
 			Message: fmt.Sprintf("Unknown request id: %d", requestID),
 		}
 		return response, xrdproto.Error

--- a/xrootd/server/server_test.go
+++ b/xrootd/server/server_test.go
@@ -283,7 +283,7 @@ func TestServe_Dirlist(t *testing.T) {
 			t.Errorf("wrong response header:\ngot = %v\nwant = %v", respHeader, wantHeader)
 		}
 
-		want := xrdproto.ServerError{Code: xrdproto.InvalidRequestCode, Message: "Dirlist request is not implemented"}
+		want := xrdproto.ServerError{Code: xrdproto.InvalidRequest, Message: "Dirlist request is not implemented"}
 		if !reflect.DeepEqual(want, errorResp) {
 			t.Errorf("wrong response:\ngot = %v\nwant = %v", errorResp, want)
 		}

--- a/xrootd/xrdfuse/xrdfuse.go
+++ b/xrootd/xrdfuse/xrdfuse.go
@@ -129,7 +129,7 @@ func (fs *FS) Open(name string, flags uint32, ctx *fuse.Context) (file nodefs.Fi
 	options := convertFlagsToOptions(flags)
 	f, err := fs.xrdfs.Open(context.Background(), path.Join(fs.root, name), mode, options)
 	if serverError, ok := err.(xrdproto.ServerError); ok {
-		if serverError.Code == xrdproto.InvalidRequestCode {
+		if serverError.Code == xrdproto.InvalidRequest {
 			// It is possible the request is invalid because the file already exists.
 			// O_CREAT flag can be passed to the fuse API despite the fact that file
 			// is already created. Open should correctly handle this situation, as far
@@ -244,7 +244,7 @@ func errorToStatus(err error) fuse.Status {
 	}
 	if serverError, ok := err.(xrdproto.ServerError); ok {
 		switch serverError.Code {
-		case xrdproto.NotFoundCode:
+		case xrdproto.NotFound:
 			// File does not exists.
 			return fuse.ENOENT
 		case xrdproto.NotAuthorized:

--- a/xrootd/xrdproto/protocol.go
+++ b/xrootd/xrdproto/protocol.go
@@ -44,10 +44,10 @@ type ServerError struct {
 type ServerErrorCode int32
 
 const (
-	InvalidRequestCode ServerErrorCode = 3006 // InvalidRequestCode indicates that request is invalid.
-	IOErrorCode        ServerErrorCode = 3007 // IOErrorCode indicates that an IO error has occurred on the server side.
-	NotAuthorized      ServerErrorCode = 3010 // NotAuthorized indicates that user was not authorized for operation.
-	NotFoundCode       ServerErrorCode = 3011 // NotFoundCode indicates that path was not found on the remote server.
+	InvalidRequest ServerErrorCode = 3006 // InvalidRequest indicates that request is invalid.
+	IOError        ServerErrorCode = 3007 // IOError indicates that an IO error has occurred on the server side.
+	NotAuthorized  ServerErrorCode = 3010 // NotAuthorized indicates that user was not authorized for operation.
+	NotFound       ServerErrorCode = 3011 // NotFound indicates that path was not found on the remote server.
 )
 
 func (err ServerError) Error() string {

--- a/xrootd/xrdproto/protocol.go
+++ b/xrootd/xrdproto/protocol.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"go-hep.org/x/hep/xrootd/internal/xrdenc"
@@ -33,6 +34,24 @@ const (
 	// Wait indicates that the client must wait the indicated number of seconds and retry the request.
 	Wait ResponseStatus = 4005
 )
+
+// WaitResponse is the response indicating that the client must wait and retry the request.
+// See http://xrootd.org/doc/dev45/XRdv310.pdf, p. 35 for details.
+type WaitResponse struct {
+	Duration time.Duration
+}
+
+// MarshalXrd implements Marshaler.
+func (o WaitResponse) MarshalXrd(wBuffer *xrdenc.WBuffer) error {
+	wBuffer.WriteI32(int32(o.Duration.Seconds()))
+	return nil
+}
+
+// UnmarshalXrd implements Unmarshaler.
+func (o *WaitResponse) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
+	o.Duration = time.Second * time.Duration(rBuffer.ReadI32())
+	return nil
+}
 
 // ServerError is the error returned by the XRootD server as part of response to the request.
 type ServerError struct {

--- a/xrootd/xrdproto/protocol_test.go
+++ b/xrootd/xrdproto/protocol_test.go
@@ -1,0 +1,160 @@
+// Copyright 2018 The go-hep Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xrdproto // import "go-hep.org/x/hep/xrootd/xrdproto"
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/binary"
+	"io"
+	"reflect"
+	"testing"
+)
+
+func TestReadRequest(t *testing.T) {
+	header := make([]byte, RequestHeaderLength+16+4)
+	data := make([]byte, 10)
+	rand.Read(data)
+	binary.BigEndian.PutUint32(header[RequestHeaderLength+16:], 10)
+
+	for _, tc := range []struct {
+		name string
+		data []byte
+		want []byte
+		err  error
+	}{
+		{
+			name: "EOF",
+			err:  io.EOF,
+			data: []byte{},
+		},
+		{
+			name: "Without data",
+			data: make([]byte, RequestHeaderLength+16+4),
+			want: make([]byte, RequestHeaderLength+16+4),
+		},
+		{
+			name: "With data",
+			data: append(header, data...),
+			want: append(header, data...),
+		},
+		{
+			name: "Header with non-zero length but without data",
+			err:  io.EOF,
+			data: header,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reader := bytes.NewBuffer(tc.data)
+			got, err := ReadRequest(reader)
+			if err != tc.err {
+				t.Errorf("error doesn't match:\ngot = %v\nwant = %v", err, tc.err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("data doesn't match:\ngot = %v\nwant = %v", got, tc.want)
+			}
+			if reader.Len() != 0 {
+				t.Errorf("reader was not read to the end: %v", reader.Bytes())
+			}
+		})
+	}
+}
+
+func TestReadResponse(t *testing.T) {
+	header := make([]byte, RequestHeaderLength+16+4)
+	data := make([]byte, 10)
+	rand.Read(data)
+	binary.BigEndian.PutUint32(header[RequestHeaderLength+16:], 10)
+
+	for _, tc := range []struct {
+		name       string
+		data       []byte
+		wantHeader ResponseHeader
+		wantData   []byte
+		err        error
+	}{
+		{
+			name: "EOF",
+			err:  io.EOF,
+			data: []byte{},
+		},
+		{
+			name:       "Without data",
+			data:       []byte{1, 2, 0, 0, 0, 0, 0, 0},
+			wantHeader: ResponseHeader{StreamID: StreamID{1, 2}},
+		},
+		{
+			name:       "With data",
+			data:       []byte{1, 2, 0, 0, 0, 0, 0, 5, 1, 2, 3, 4, 5},
+			wantHeader: ResponseHeader{StreamID: StreamID{1, 2}, DataLength: 5},
+			wantData:   []byte{1, 2, 3, 4, 5},
+		},
+		{
+			name:       "Header with non-zero length but without data",
+			err:        io.EOF,
+			data:       []byte{1, 2, 0, 0, 0, 0, 0, 5},
+			wantHeader: ResponseHeader{StreamID: StreamID{1, 2}, DataLength: 5},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reader := bytes.NewBuffer(tc.data)
+			gotHeader, gotData, err := ReadResponse(reader)
+			if err != tc.err {
+				t.Errorf("error doesn't match:\ngot = %v\nwant = %v", err, tc.err)
+			}
+			if !reflect.DeepEqual(gotHeader, tc.wantHeader) {
+				t.Errorf("header doesn't match:\ngot = %v\nwant = %v", gotHeader, tc.wantHeader)
+			}
+			if !reflect.DeepEqual(gotData, tc.wantData) {
+				t.Errorf("data doesn't match:\ngot = %v\nwant = %v", gotData, tc.wantData)
+			}
+			if reader.Len() != 0 {
+				t.Errorf("reader was not read to the end: %v", reader.Bytes())
+			}
+		})
+	}
+}
+
+func TestWriteResponse(t *testing.T) {
+	header := make([]byte, RequestHeaderLength+16+4)
+	data := make([]byte, 10)
+	rand.Read(data)
+	binary.BigEndian.PutUint32(header[RequestHeaderLength+16:], 10)
+
+	for _, tc := range []struct {
+		name     string
+		wantData []byte
+		header   ResponseHeader
+		err      error
+		streamID StreamID
+		status   ResponseStatus
+		resp     Marshaler
+	}{
+		{
+			name:     "With data",
+			wantData: []byte{1, 2, 15, 163, 0, 0, 0, 5, 0, 0, 0, 12, 0},
+			status:   Error,
+			streamID: StreamID{1, 2},
+			resp:     &ServerError{Code: 12},
+		},
+		{
+			name:     "Without data",
+			wantData: []byte{1, 2, 0, 0, 0, 0, 0, 0},
+			status:   Ok,
+			streamID: StreamID{1, 2},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var writer bytes.Buffer
+			err := WriteResponse(&writer, tc.streamID, tc.status, tc.resp)
+			if err != tc.err {
+				t.Errorf("error doesn't match:\ngot = %v\nwant = %v", err, tc.err)
+			}
+			if !reflect.DeepEqual(writer.Bytes(), tc.wantData) {
+				t.Errorf("data doesn't match:\ngot = %v\nwant = %v", writer.Bytes(), tc.wantData)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cleanup tests and main code by extracting `SendResponse`, `ReadResponse`, and `ReadRequest` functions.
Add for the sake of perfomance and avoiding extra allocations `ReadResponseWithReuse` that takes `headerBytes` slice and pointer to `header` as arguments.
Extract helper methods from session.consume for the better readability.
Rename `*Code` constants in `protocol.go`