### PR TITLE
rootio: fix tmpFile behaviour under Windows

### DIFF
--- a/rootio/fileplugin.go
+++ b/rootio/fileplugin.go
@@ -56,8 +56,12 @@ type tmpFile struct {
 }
 
 func (f *tmpFile) Close() error {
-	os.Remove(f.File.Name())
-	return f.File.Close()
+	err1 := f.File.Close()
+	err2 := os.Remove(f.File.Name())
+	if err1 != nil {
+		return err1
+	}
+	return err2
 }
 
 var (

--- a/rootio/fileplugin_test.go
+++ b/rootio/fileplugin_test.go
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !windows
-
 package rootio
 
 import (


### PR DESCRIPTION
We cannot delete file that is currently opened.

Closes go-hep/hep#334.