### PR TITLE
hotfixes for root-ls -t

### DIFF
--- a/rootio/cmd/root-ls/main.go
+++ b/rootio/cmd/root-ls/main.go
@@ -132,14 +132,14 @@ func walk(w io.Writer, k rootio.Key) {
 	if *doTree {
 		tree, ok := obj.(rootio.Tree)
 		if ok {
-			w := tabwriter.NewWriter(w, 8, 4, 1, ' ', 0)
-			fmt.Fprintf(w, "%s\t%s\t%s\t(entries=%d)\n", k.Class(), k.Name(), k.Title(), tree.Entries())
+			w := newWindent(2, w)
+			fmt.Fprintf(w, "%s\t%s\t%s\t(entries=%d)\n", k.ClassName(), k.Name(), k.Title(), tree.Entries())
 			displayBranches(w, tree, 2)
 			w.Flush()
 			return
 		}
 	}
-	fmt.Fprintf(w, "%s\t%s\t%s\t(cycle=%d)\n", k.Class(), k.Name(), k.Title(), k.Cycle())
+	fmt.Fprintf(w, "%s\t%s\t%s\t(cycle=%d)\n", k.ClassName(), k.Name(), k.Title(), k.Cycle())
 	if dir, ok := obj.(rootio.Directory); ok {
 		w := newWindent(2, w)
 		for _, k := range dir.Keys() {


### PR DESCRIPTION
 - printout was corrupted with trees in directories
 - printout did write `TKey` for all classes for me

I was testing with /afs/cern.ch/user/p/pseyfert/public/sbinet/DTT.root (file
currently readable for @sbinet, I didn't check if I can publish the file and
didn't yet cook up an example for which could be used for testing).

Without fixing I got as printout:

```
peyfert@robusta ~/coding/go > go run src/github.com/go-hep/hep/rootio/cmd/root-ls/main.go -t /afs/cern.ch/user/p/pseyfert/DTT.root
=== [/afs/cern.ch/user/p/pseyfert/DTT.root] ===
version: 60205
TKey    EventTuple EventTuple (cycle=1)
  TKey  TKey    B02DD   B02DD   (cycle=1)
  TKey  TKey    GetIntegratedLuminosity GetIntegratedLuminosity (cycle=1)
  TKey  %                                                                     
peyfert@robusta ~/coding/go >
```

(the percent sign is not printed by root-ls but by the shell/terminal to indicate a missing linebreak)

after my patch

```
pseyfert@robusta ~/coding/go > go run src/github.com/go-hep/hep/rootio/cmd/root-ls/main.go -t /afs/cern.ch/user/p/pseyfert/DTT.root
=== [/afs/cern.ch/user/p/pseyfert/DTT.root] ===
version: 60205
TDirectory            EventTuple          EventTuple (cycle=1)
    TTree             EventTuple          EventTuple (entries=168)
      EventInSequence "EventInSequence/l" TBranch
      runNumber       "runNumber/i"       TBranch
      eventNumber     "eventNumber/l"     TBranch
<snap>
      L0Global        "L0Global/I"        TBranch
      Hlt1Global      "Hlt1Global/i"      TBranch
      Hlt2Global      "Hlt2Global/i"      TBranch
TDirectory                                                 B02DD                                                    B02DD     (cycle=1)
    TTree                                                  DecayTree                                                DecayTree (entries=142)
      B0_LOKI_ENERGY                                       "B0_LOKI_ENERGY/D"                                       TBranch
      B0_LOKI_ETA                                          "B0_LOKI_ETA/D"                                          TBranch
<snap>
      MaxRoutingBits                                       "MaxRoutingBits/I"                                       TBranch
      RoutingBits                                          "RoutingBits[MaxRoutingBits]/F"                          TBranch
TDirectory                    GetIntegratedLuminosity     GetIntegratedLuminosity (cycle=1)
    TTree                     LumiTuple                   LumiTuple               (entries=1)
      IntegratedLuminosity    "IntegratedLuminosity/D"    TBranch
      IntegratedLuminosityErr "IntegratedLuminosityErr/D" TBranch
```

It is not clear to me why the tabwriter didn't work.
