### PR TITLE
cmd/yoda2root: first import

### DIFF
--- a/cmd/yoda2rio/main.go
+++ b/cmd/yoda2rio/main.go
@@ -46,6 +46,7 @@ ex:
 		log.Printf("missing input file name")
 		flag.Usage()
 		flag.PrintDefaults()
+		os.Exit(1)
 	}
 
 	o, err := rio.NewWriter(os.Stdout)

--- a/cmd/yoda2root/main.go
+++ b/cmd/yoda2root/main.go
@@ -1,0 +1,129 @@
+// Copyright 2018 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// yoda2root converts YODA files containing hbook-like values (H1D, H2D, P1D, ...)
+// into ROOT files.
+//
+// Example:
+//
+//  $> yoda2root rivet.yoda rivet.root
+//  $> yoda2root rivet.yoda.gz rivet.root
+package main
+
+import (
+	"compress/gzip"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"go-hep.org/x/hep/hbook"
+	"go-hep.org/x/hep/hbook/rootcnv"
+	"go-hep.org/x/hep/hbook/yodacnv"
+	"go-hep.org/x/hep/rootio"
+)
+
+func main() {
+	log.SetFlags(0)
+	log.SetPrefix("yoda2root: ")
+	log.SetOutput(os.Stderr)
+
+	flag.Usage = func() {
+		fmt.Fprintf(
+			os.Stderr,
+			`Usage: yoda2root [options] <file1.yoda> [<file2.yoda> [...]] file.root
+
+ex:
+ $> yoda2root rivet.yoda rivet.root
+ $> yoda2root rivet.yoda.gz rivet.root
+`)
+	}
+
+	flag.Parse()
+
+	if flag.NArg() < 2 {
+		log.Printf("missing input and/or output file name(s)")
+		flag.Usage()
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	oname := flag.Arg(flag.NArg() - 1)
+	f, err := rootio.Create(oname)
+	if err != nil {
+		log.Fatalf("could not create output ROOT file: %v", err)
+	}
+	defer f.Close()
+
+	for _, fname := range flag.Args()[:flag.NArg()-1] {
+		err = convert(f, fname)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	err = f.Close()
+	if err != nil {
+		log.Fatalf("could not close output ROOT file: %v", err)
+	}
+}
+
+func convert(w *rootio.File, fname string) error {
+	var r io.ReadCloser
+	r, err := os.Open(fname)
+	if err != nil {
+		return errors.Errorf("error opening file [%s]: %v", fname, err)
+	}
+	defer r.Close()
+
+	if filepath.Ext(fname) == ".gz" {
+		rz, err := gzip.NewReader(r)
+		if err != nil {
+			return errors.Errorf("could not open gzip file [%s]: %v", fname, err)
+		}
+		defer rz.Close()
+		r = rz
+	}
+
+	vs, err := yodacnv.Read(r)
+	if err != nil {
+		return errors.Errorf("error decoding YODA file [%s]: %v", fname, err)
+	}
+
+	for i, v := range vs {
+		var (
+			obj rootio.Object
+			key string
+		)
+		switch v := v.(type) {
+		case *hbook.H1D:
+			key = "h1"
+			obj = rootcnv.FromH1D(v)
+		case *hbook.H2D:
+			key = "h2"
+			obj = rootcnv.FromH2D(v)
+		case *hbook.S2D:
+			key = "scatter"
+			obj = rootcnv.FromS2D(v)
+		default:
+			log.Printf("%s: no YODA -> ROOT conversion for %T", fname, v)
+			continue
+		}
+		switch v.Name() {
+		case "":
+			key = fmt.Sprintf("yoda-%s-%03d", key, i)
+		default:
+			key = v.Name()
+		}
+		err = w.Put(key, obj)
+		if err != nil {
+			return errors.Errorf("error writing %q from YODA file [%s]: %v\n", v.Name(), fname, err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/yoda2root/main_test.go
+++ b/cmd/yoda2root/main_test.go
@@ -1,0 +1,163 @@
+// Copyright 2018 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"compress/gzip"
+	"io"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"go-hep.org/x/hep/hbook"
+	"go-hep.org/x/hep/hbook/rootcnv"
+	"go-hep.org/x/hep/hbook/yodacnv"
+	"go-hep.org/x/hep/rootio"
+)
+
+func TestYODA2ROOT(t *testing.T) {
+
+	h1 := hbook.NewH1D(10, -4, 4)
+	h1.Annotation()["name"] = "h1-name"
+	h1.Annotation()["title"] = "h1-title"
+	h1.Fill(1, 1)
+	h1.Fill(2, 1)
+
+	h2 := hbook.NewH2D(10, -4, 4, 20, -5, 5)
+	h2.Annotation()["name"] = "h2-name"
+	h2.Annotation()["title"] = "h2-title"
+	h2.Fill(1, 1, 1)
+	h2.Fill(2, 2, 2)
+
+	s2 := hbook.NewS2DFrom([]float64{1, 2, 3, 4, 5}, []float64{1, 4, 9, 16, 25})
+	s2.Annotation()["name"] = "s2-name"
+	s2.Annotation()["title"] = "s2-title"
+
+	anon := hbook.NewS2DFrom([]float64{10, 20}, []float64{10, 40})
+	anon.Annotation()["title"] = "no-title"
+
+	for _, tc := range []struct {
+		yfname string
+		rfname string
+	}{
+		{
+			yfname: "f.yoda",
+			rfname: "f.root",
+		},
+		{
+			yfname: "f.yoda.gz",
+			rfname: "f.root",
+		},
+	} {
+		t.Run(tc.yfname, func(t *testing.T) {
+			yfname := tc.yfname
+			rfname := tc.rfname
+
+			defer os.Remove(yfname)
+			defer os.Remove(rfname)
+
+			f, err := os.Create(yfname)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+
+			var yf io.WriteCloser = f
+
+			if strings.HasSuffix(yfname, ".gz") {
+				yf = gzip.NewWriter(f)
+			}
+
+			err = yodacnv.Write(yf, h1, h2, s2, anon)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = yf.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			o, err := rootio.Create(rfname)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer o.Close()
+
+			err = convert(o, yfname)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = o.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rf, err := rootio.Open(rfname)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			robj, err := rf.Get("h1-name")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rh1, err := rootcnv.H1D(robj.(rootio.H1))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if got, want := rh1.XMean(), h1.XMean(); got != want {
+				t.Fatalf("h1 round-trip failed: got: %v, want: %v", got, want)
+			}
+
+			robj, err = rf.Get("h2-name")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rh2, err := rootcnv.H2D(robj.(rootio.H2))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if got, want := rh2.XMean(), h2.XMean(); got != want {
+				t.Fatalf("h2 round-trip failed: got: %v, want: %v", got, want)
+			}
+
+			robj, err = rf.Get("s2-name")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rs2, err := rootcnv.S2D(robj.(rootio.GraphErrors))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(rs2, s2) {
+				t.Fatalf("s2 round-trip failed")
+			}
+
+			robj, err = rf.Get("yoda-scatter-003")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ranon, err := rootcnv.S2D(robj.(rootio.GraphErrors))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(ranon.Points(), anon.Points()) {
+				t.Fatalf("s2-anon round-trip failed")
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
This CL adds a simple command that converts YODA files into ROOT files.

Fixes go-hep/hep#350.