### PR TITLE
xrootd/cmd/xrd-ls: avoid empty printouts

### DIFF
--- a/xrootd/cmd/xrd-ls/main.go
+++ b/xrootd/cmd/xrd-ls/main.go
@@ -73,7 +73,11 @@ func main() {
 		log.Fatalf("missing directory operand")
 	}
 
-	for _, dir := range flag.Args() {
+	for i, dir := range flag.Args() {
+		if i > 0 {
+			// separate consecutive files by an empty line
+			fmt.Printf("\n")
+		}
 		err := xrdls(dir, *longFlag, *recFlag)
 		if err != nil {
 			log.Fatalf("could not list %q content: %v", dir, err)
@@ -134,12 +138,13 @@ func display(ctx context.Context, fs xrdfs.FileSystem, root string, fi os.FileIn
 		format(o, root, e, long)
 	}
 	o.Flush()
-	fmt.Printf("\n")
 	if recursive {
 		for _, e := range ents {
 			if !e.IsDir() {
 				continue
 			}
+			// make an empty line before going into a subdirectory.
+			fmt.Printf("\n")
 			err := display(ctx, fs, dir, e, long, recursive)
 			if err != nil {
 				return err

--- a/xrootd/cmd/xrd-ls/main.go
+++ b/xrootd/cmd/xrd-ls/main.go
@@ -102,6 +102,7 @@ func xrdls(name string, long, recursive bool) error {
 	fs := c.FS()
 
 	fi, err := fs.Stat(ctx, url.Path)
+	// TODO fi.Name() here is an empty string (see handling in format() below)
 	if err != nil {
 		return errors.Errorf("could not stat %q: %v", url.Path, err)
 	}
@@ -115,6 +116,7 @@ func xrdls(name string, long, recursive bool) error {
 
 func display(ctx context.Context, fs xrdfs.FileSystem, root string, fi os.FileInfo, long, recursive bool) error {
 	if !fi.IsDir() {
+		// TODO fi.Name() here is an empty string (see handling in format() below)
 		format(os.Stdout, root, fi, long)
 		return nil
 	}
@@ -161,5 +163,11 @@ func format(o io.Writer, root string, fi os.FileInfo, long bool) {
 		return
 	}
 
-	fmt.Fprintf(o, "%v\t %d\t %s\t %s\n", fi.Mode(), fi.Size(), fi.ModTime().Format("Jan 02 15:04"), fi.Name())
+	var name string
+	if fi.Name() == "" {
+		name = root
+	} else {
+		name = fi.Name()
+	}
+	fmt.Fprintf(o, "%v\t %d\t %s\t %s\n", fi.Mode(), fi.Size(), fi.ModTime().Format("Jan 02 15:04"), name)
 }

--- a/xrootd/cmd/xrd-ls/main.go
+++ b/xrootd/cmd/xrd-ls/main.go
@@ -163,11 +163,9 @@ func format(o io.Writer, root string, fi os.FileInfo, long bool) {
 		return
 	}
 
-	var name string
-	if fi.Name() == "" {
+	name := fi.Name()
+	if name == "" {
 		name = root
-	} else {
-		name = fi.Name()
 	}
 	fmt.Fprintf(o, "%v\t %d\t %s\t %s\n", fi.Mode(), fi.Size(), fi.ModTime().Format("Jan 02 15:04"), name)
 }


### PR DESCRIPTION
Old behaviour:
 * Print empty line after any directory listing.
   - This means that the full printout ends with an empty line
 * xrd-ls -l <file> with a file instead of a directory does not show
   filenames.

New behaviour:
 * Print one empty line between requested directories.
   - This means that no empty line is printed after the last of multiple
     directories.
 * Print one empty line before printing a subdirectory with -R
   - This means an empty line occurs only after listing a directory in
     the recursive mode when there are actually subdirectories
 * xrd-ls -l <file> shows the file's name after Mode, Size, and ModTime
   filenames.

TODO: the second commit is a workaround the fact that `fi, err := fs.Stat(ctx,
url.Path)` for me returns `fi` objects with empty `Name()`.

w/o `-l` this is not a problem because `path.Join(root, fi.Name())` is printed
and the entire path is in `root`. Also, when calling `xrd-ls` on a dir, the
`fi` objects for printing come from `fs.Dirlist()`.
