### PR TITLE
rootio: introduce Key.Type to infer key's payload's type

### DIFF
--- a/ci/run-tests.go
+++ b/ci/run-tests.go
@@ -46,7 +46,7 @@ func main() {
 	}
 	defer f.Close()
 
-	args := []string{"test"}
+	args := []string{"test", "-v"}
 
 	if *cover {
 		args = append(args, "-coverprofile=profile.out", "-covermode=atomic")

--- a/hbook/dist_brio.go
+++ b/hbook/dist_brio.go
@@ -42,9 +42,9 @@ func (o *Dist1D) MarshalBinary() (data []byte, err error) {
 		data = append(data, buf[:8]...)
 		data = append(data, sub...)
 	}
-	binary.LittleEndian.PutUint64(buf[:8], math.Float64bits(o.SumWX))
+	binary.LittleEndian.PutUint64(buf[:8], math.Float64bits(o.Stats.SumWX))
 	data = append(data, buf[:8]...)
-	binary.LittleEndian.PutUint64(buf[:8], math.Float64bits(o.SumWX2))
+	binary.LittleEndian.PutUint64(buf[:8], math.Float64bits(o.Stats.SumWX2))
 	data = append(data, buf[:8]...)
 	return data, err
 }
@@ -60,9 +60,9 @@ func (o *Dist1D) UnmarshalBinary(data []byte) (err error) {
 		}
 		data = data[n:]
 	}
-	o.SumWX = math.Float64frombits(binary.LittleEndian.Uint64(data[:8]))
+	o.Stats.SumWX = math.Float64frombits(binary.LittleEndian.Uint64(data[:8]))
 	data = data[8:]
-	o.SumWX2 = math.Float64frombits(binary.LittleEndian.Uint64(data[:8]))
+	o.Stats.SumWX2 = math.Float64frombits(binary.LittleEndian.Uint64(data[:8]))
 	data = data[8:]
 	return err
 }
@@ -88,7 +88,7 @@ func (o *Dist2D) MarshalBinary() (data []byte, err error) {
 		data = append(data, buf[:8]...)
 		data = append(data, sub...)
 	}
-	binary.LittleEndian.PutUint64(buf[:8], math.Float64bits(o.SumWXY))
+	binary.LittleEndian.PutUint64(buf[:8], math.Float64bits(o.Stats.SumWXY))
 	data = append(data, buf[:8]...)
 	return data, err
 }
@@ -113,7 +113,7 @@ func (o *Dist2D) UnmarshalBinary(data []byte) (err error) {
 		}
 		data = data[n:]
 	}
-	o.SumWXY = math.Float64frombits(binary.LittleEndian.Uint64(data[:8]))
+	o.Stats.SumWXY = math.Float64frombits(binary.LittleEndian.Uint64(data[:8]))
 	data = data[8:]
 	return err
 }

--- a/hbook/h1d.go
+++ b/hbook/h1d.go
@@ -99,12 +99,12 @@ func (h *H1D) SumW2() float64 {
 
 // SumWX returns the 1st order weighted x moment
 func (h *H1D) SumWX() float64 {
-	return h.Binning.Dist.SumWX
+	return h.Binning.Dist.SumWX()
 }
 
 // SumWX2 returns the 2nd order weighted x moment
 func (h *H1D) SumWX2() float64 {
-	return h.Binning.Dist.SumWX2
+	return h.Binning.Dist.SumWX2()
 }
 
 // XMean returns the mean X.
@@ -343,20 +343,20 @@ func (h *H1D) MarshalYODA() ([]byte, error) {
 	fmt.Fprintf(
 		buf,
 		"Total   \tTotal   \t%e\t%e\t%e\t%e\t%d\n",
-		d.SumW(), d.SumW2(), d.SumWX, d.SumWX2, d.Entries(),
+		d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.Entries(),
 	)
 	d = h.Binning.Outflows[0]
 	fmt.Fprintf(
 		buf,
 		"Underflow\tUnderflow\t%e\t%e\t%e\t%e\t%d\n",
-		d.SumW(), d.SumW2(), d.SumWX, d.SumWX2, d.Entries(),
+		d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.Entries(),
 	)
 
 	d = h.Binning.Outflows[1]
 	fmt.Fprintf(
 		buf,
 		"Overflow\tOverflow\t%e\t%e\t%e\t%e\t%d\n",
-		d.SumW(), d.SumW2(), d.SumWX, d.SumWX2, d.Entries(),
+		d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.Entries(),
 	)
 
 	// bins
@@ -367,7 +367,7 @@ func (h *H1D) MarshalYODA() ([]byte, error) {
 			buf,
 			"%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 			bin.Range.Min, bin.Range.Max,
-			d.SumW(), d.SumW2(), d.SumWX, d.SumWX2, d.Entries(),
+			d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.Entries(),
 		)
 	}
 	fmt.Fprintf(buf, "END YODA_HISTO1D\n\n")
@@ -430,7 +430,7 @@ scanLoop:
 				rbuf,
 				"Total   \tTotal   \t%e\t%e\t%e\t%e\t%d\n",
 				&d.Dist.SumW, &d.Dist.SumW2,
-				&d.SumWX, &d.SumWX2,
+				&d.Stats.SumWX, &d.Stats.SumWX2,
 				&d.Dist.N,
 			)
 			if err != nil {
@@ -443,7 +443,7 @@ scanLoop:
 				rbuf,
 				"Underflow\tUnderflow\t%e\t%e\t%e\t%e\t%d\n",
 				&d.Dist.SumW, &d.Dist.SumW2,
-				&d.SumWX, &d.SumWX2,
+				&d.Stats.SumWX, &d.Stats.SumWX2,
 				&d.Dist.N,
 			)
 			if err != nil {
@@ -456,7 +456,7 @@ scanLoop:
 				rbuf,
 				"Overflow\tOverflow\t%e\t%e\t%e\t%e\t%d\n",
 				&d.Dist.SumW, &d.Dist.SumW2,
-				&d.SumWX, &d.SumWX2,
+				&d.Stats.SumWX, &d.Stats.SumWX2,
 				&d.Dist.N,
 			)
 			if err != nil {
@@ -471,7 +471,7 @@ scanLoop:
 				"%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 				&bin.Range.Min, &bin.Range.Max,
 				&d.Dist.SumW, &d.Dist.SumW2,
-				&d.SumWX, &d.SumWX2,
+				&d.Stats.SumWX, &d.Stats.SumWX2,
 				&d.Dist.N,
 			)
 			if err != nil {

--- a/hbook/h2d.go
+++ b/hbook/h2d.go
@@ -110,7 +110,7 @@ func (h *H2D) SumWY2() float64 {
 // SumWXY returns the 1st order weighted x*y moment
 // Overflows are included in the computation.
 func (h *H2D) SumWXY() float64 {
-	return h.Binning.Dist.SumWXY
+	return h.Binning.Dist.SumWXY()
 }
 
 // XMean returns the mean X.
@@ -294,7 +294,7 @@ func (h *H2D) MarshalYODA() ([]byte, error) {
 	fmt.Fprintf(
 		buf,
 		"Total   \tTotal   \t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
-		d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY, d.Entries(),
+		d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY(), d.Entries(),
 	)
 
 	// outflows
@@ -310,7 +310,7 @@ func (h *H2D) MarshalYODA() ([]byte, error) {
 				buf,
 				"%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 				bin.XRange.Min, bin.XRange.Max, bin.YRange.Min, bin.YRange.Max,
-				d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY, d.Entries(),
+				d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY(), d.Entries(),
 			)
 		}
 	}
@@ -374,9 +374,9 @@ scanLoop:
 				rbuf,
 				"Total   \tTotal   \t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 				&d.X.Dist.SumW, &d.X.Dist.SumW2,
-				&d.X.SumWX, &d.X.SumWX2,
-				&d.Y.SumWX, &d.Y.SumWX2,
-				&d.SumWXY, &d.X.Dist.N,
+				&d.X.Stats.SumWX, &d.X.Stats.SumWX2,
+				&d.Y.Stats.SumWX, &d.Y.Stats.SumWX2,
+				&d.Stats.SumWXY, &d.X.Dist.N,
 			)
 			if err != nil {
 				return fmt.Errorf("hbook: %v\nhbook: %q", err, string(buf))
@@ -391,9 +391,9 @@ scanLoop:
 				"%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 				&bin.XRange.Min, &bin.XRange.Max, &bin.YRange.Min, &bin.YRange.Max,
 				&d.X.Dist.SumW, &d.X.Dist.SumW2,
-				&d.X.SumWX, &d.X.SumWX2,
-				&d.Y.SumWX, &d.Y.SumWX2,
-				&d.SumWXY, &d.X.Dist.N,
+				&d.X.Stats.SumWX, &d.X.Stats.SumWX2,
+				&d.Y.Stats.SumWX, &d.Y.Stats.SumWX2,
+				&d.Stats.SumWXY, &d.X.Dist.N,
 			)
 			if err != nil {
 				return fmt.Errorf("hbook: %v\nhbook: %q", err, string(buf))

--- a/hbook/p1d.go
+++ b/hbook/p1d.go
@@ -285,8 +285,8 @@ scanLoop:
 				rbuf,
 				"Total   \tTotal   \t%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 				&d.X.Dist.SumW, &d.X.Dist.SumW2,
-				&d.X.SumWX, &d.X.SumWX2,
-				&d.Y.SumWX, &d.Y.SumWX2,
+				&d.X.Stats.SumWX, &d.X.Stats.SumWX2,
+				&d.Y.Stats.SumWX, &d.Y.Stats.SumWX2,
 				&d.X.Dist.N,
 			)
 			if err != nil {
@@ -300,8 +300,8 @@ scanLoop:
 				rbuf,
 				"Underflow\tUnderflow\t%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 				&d.X.Dist.SumW, &d.X.Dist.SumW2,
-				&d.X.SumWX, &d.X.SumWX2,
-				&d.Y.SumWX, &d.Y.SumWX2,
+				&d.X.Stats.SumWX, &d.X.Stats.SumWX2,
+				&d.Y.Stats.SumWX, &d.Y.Stats.SumWX2,
 				&d.X.Dist.N,
 			)
 			if err != nil {
@@ -315,8 +315,8 @@ scanLoop:
 				rbuf,
 				"Overflow\tOverflow\t%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 				&d.X.Dist.SumW, &d.X.Dist.SumW2,
-				&d.X.SumWX, &d.X.SumWX2,
-				&d.Y.SumWX, &d.Y.SumWX2,
+				&d.X.Stats.SumWX, &d.X.Stats.SumWX2,
+				&d.Y.Stats.SumWX, &d.Y.Stats.SumWX2,
 				&d.X.Dist.N,
 			)
 			if err != nil {
@@ -332,8 +332,8 @@ scanLoop:
 				"%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 				&bin.xrange.Min, &bin.xrange.Max,
 				&d.X.Dist.SumW, &d.X.Dist.SumW2,
-				&d.X.SumWX, &d.X.SumWX2,
-				&d.Y.SumWX, &d.Y.SumWX2,
+				&d.X.Stats.SumWX, &d.X.Stats.SumWX2,
+				&d.Y.Stats.SumWX, &d.Y.Stats.SumWX2,
 				&d.X.Dist.N,
 			)
 			if err != nil {

--- a/rootio/compress_test.go
+++ b/rootio/compress_test.go
@@ -24,8 +24,9 @@ func TestCompress(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	wants := map[string]Object{
-		"big":   NewObjString(strings.Repeat("*", 512)),
 		"small": NewObjString("hello"),
+		"10mb":  NewObjString(strings.Repeat("-+", 10*1024*1024)),
+		"16mb":  NewObjString(strings.Repeat("-+", 16*1024*1024)),
 	}
 
 	cxxROOT, err := exec.LookPath("root.exe")
@@ -74,6 +75,11 @@ void testcompress(const char *fname, int size) {
 		{name: "zlib-best-compr", opt: WithZlib(flate.BestCompression)},
 	} {
 		for k, want := range wants {
+			if (k == "16mb" || k == "10mb") &&
+				!strings.HasSuffix(tc.name, "best-compr") &&
+				!strings.HasSuffix(tc.name, "-1") {
+				continue
+			}
 			tname := fmt.Sprintf("%s-%s", k, tc.name)
 			t.Run(tname, func(t *testing.T) {
 				fname := filepath.Join(dir, "test-"+tname+".root")

--- a/rootio/consts.go
+++ b/rootio/consts.go
@@ -105,20 +105,4 @@ const (
 	kDisplacementMask = 0xFF000000
 )
 
-type compressAlgType int
-
-// constants for compression/decompression
-const (
-	kZLIB                          compressAlgType = 1
-	kLZMA                          compressAlgType = 2
-	kOldCompressionAlgo            compressAlgType = 3
-	kLZ4                           compressAlgType = 4
-	kUndefinedCompressionAlgorithm compressAlgType = 5
-)
-
-// Note: this contains ZL[src][dst] where src and dst are 3 bytes each.
-// Won't bother with this for the moment, since we can cross-check against
-// objlen.
-const rootHDRSIZE = 9
-
 var ptrSize = 4 << (^uintptr(0) >> 63)

--- a/rootio/gen-code.go
+++ b/rootio/gen-code.go
@@ -927,11 +927,11 @@ func (h *{{.Name}}) MarshalYODA() ([]byte, error) {
 				SumW:   float64(h.SumW()),
 				SumW2:  float64(h.SumW2()),
 			},
-			SumWX:  float64(h.SumWX()),
-			SumWX2: float64(h.SumWX2()),
 		}
 		dists = make([]hbook.Dist1D, int(nx))
 	)
+	dtot.Stats.SumWX = float64(h.SumWX())
+	dtot.Stats.SumWX2 = float64(h.SumWX2())
 
 	for i := 0; i < nx; i++ {
 		dists[i] = h.dist1D(i+1)
@@ -952,7 +952,7 @@ func (h *{{.Name}}) MarshalYODA() ([]byte, error) {
 		buf,
 		"%s\t%s\t%e\t%e\t%e\t%e\t%d\n",
 		name, name,
-		dtot.SumW(), dtot.SumW2(), dtot.SumWX, dtot.SumWX2, dtot.Entries(),
+		dtot.SumW(), dtot.SumW2(), dtot.SumWX(), dtot.SumWX2(), dtot.Entries(),
 	)
 
 	name = "Underflow"
@@ -960,7 +960,7 @@ func (h *{{.Name}}) MarshalYODA() ([]byte, error) {
 		buf,
 		"%s\t%s\t%e\t%e\t%e\t%e\t%d\n",
 		name, name,
-		dflow[0].SumW(), dflow[0].SumW2(), dflow[0].SumWX, dflow[0].SumWX2, dflow[0].Entries(),
+		dflow[0].SumW(), dflow[0].SumW2(), dflow[0].SumWX(), dflow[0].SumWX2(), dflow[0].Entries(),
 	)
 
 	name = "Overflow"
@@ -968,7 +968,7 @@ func (h *{{.Name}}) MarshalYODA() ([]byte, error) {
 		buf,
 		"%s\t%s\t%e\t%e\t%e\t%e\t%d\n",
 		name, name,
-		dflow[1].SumW(), dflow[1].SumW2(), dflow[1].SumWX, dflow[1].SumWX2, dflow[1].Entries(),
+		dflow[1].SumW(), dflow[1].SumW2(), dflow[1].SumWX(), dflow[1].SumWX2(), dflow[1].Entries(),
 	)
 	fmt.Fprintf(buf, "# xlow	 xhigh	 sumw	 sumw2	 sumwx	 sumwx2	 numEntries\n")
 	for i, d := range dists {
@@ -978,7 +978,7 @@ func (h *{{.Name}}) MarshalYODA() ([]byte, error) {
 			buf,
 			"%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 			xmin, xmax,
-			d.SumW(), d.SumW2(), d.SumWX, d.SumWX2, d.Entries(),
+			d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.Entries(),
 		)
 	}
 	fmt.Fprintf(buf, "END YODA_HISTO1D\n\n")
@@ -1288,8 +1288,6 @@ func (h *{{.Name}}) MarshalYODA() ([]byte, error) {
 					SumW:   float64(h.SumW()),
 					SumW2:  float64(h.SumW2()),
 				},
-				SumWX:  float64(h.SumWX()),
-				SumWX2: float64(h.SumWX2()),
 			},
 			Y: hbook.Dist1D{
 				Dist: hbook.Dist0D{
@@ -1297,13 +1295,16 @@ func (h *{{.Name}}) MarshalYODA() ([]byte, error) {
 					SumW:   float64(h.SumW()),
 					SumW2:  float64(h.SumW2()),
 				},
-				SumWX:  float64(h.SumWY()),
-				SumWX2: float64(h.SumWY2()),
 			},
-			SumWXY: h.SumWXY(),
 		}
 		dists = make([]hbook.Dist2D, int(nx*ny))
 	)
+	dtot.X.Stats.SumWX = float64(h.SumWX())
+	dtot.X.Stats.SumWX2 = float64(h.SumWX2())
+	dtot.Y.Stats.SumWX = float64(h.SumWY())
+	dtot.Y.Stats.SumWX2 = float64(h.SumWY2())
+	dtot.Stats.SumWXY = h.SumWXY()
+
 	for ix := 0; ix < nx; ix++ {
 		for iy := 0; iy < ny; iy++ {
 			i := iy*nx + ix
@@ -1327,7 +1328,7 @@ func (h *{{.Name}}) MarshalYODA() ([]byte, error) {
 		buf,
 		"%s\t%s\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 		name, name,
-		d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY, d.Entries(),
+		d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY(), d.Entries(),
 	)
 
 	if false { // FIXME(sbinet)
@@ -1336,7 +1337,7 @@ func (h *{{.Name}}) MarshalYODA() ([]byte, error) {
 				buf,
 				"%s\t%s\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 				name, name,
-				d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY, d.Entries(),
+				d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY(), d.Entries(),
 			)
 
 		}
@@ -1359,7 +1360,7 @@ func (h *{{.Name}}) MarshalYODA() ([]byte, error) {
 				buf,
 				"%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 				xmin, xmax, ymin, ymax,
-				d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY, d.Entries(),
+				d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY(), d.Entries(),
 			)
 		}
 	}

--- a/rootio/h1_gen.go
+++ b/rootio/h1_gen.go
@@ -232,11 +232,11 @@ func (h *H1F) MarshalYODA() ([]byte, error) {
 				SumW:  float64(h.SumW()),
 				SumW2: float64(h.SumW2()),
 			},
-			SumWX:  float64(h.SumWX()),
-			SumWX2: float64(h.SumWX2()),
 		}
 		dists = make([]hbook.Dist1D, int(nx))
 	)
+	dtot.Stats.SumWX = float64(h.SumWX())
+	dtot.Stats.SumWX2 = float64(h.SumWX2())
 
 	for i := 0; i < nx; i++ {
 		dists[i] = h.dist1D(i + 1)
@@ -257,7 +257,7 @@ func (h *H1F) MarshalYODA() ([]byte, error) {
 		buf,
 		"%s\t%s\t%e\t%e\t%e\t%e\t%d\n",
 		name, name,
-		dtot.SumW(), dtot.SumW2(), dtot.SumWX, dtot.SumWX2, dtot.Entries(),
+		dtot.SumW(), dtot.SumW2(), dtot.SumWX(), dtot.SumWX2(), dtot.Entries(),
 	)
 
 	name = "Underflow"
@@ -265,7 +265,7 @@ func (h *H1F) MarshalYODA() ([]byte, error) {
 		buf,
 		"%s\t%s\t%e\t%e\t%e\t%e\t%d\n",
 		name, name,
-		dflow[0].SumW(), dflow[0].SumW2(), dflow[0].SumWX, dflow[0].SumWX2, dflow[0].Entries(),
+		dflow[0].SumW(), dflow[0].SumW2(), dflow[0].SumWX(), dflow[0].SumWX2(), dflow[0].Entries(),
 	)
 
 	name = "Overflow"
@@ -273,7 +273,7 @@ func (h *H1F) MarshalYODA() ([]byte, error) {
 		buf,
 		"%s\t%s\t%e\t%e\t%e\t%e\t%d\n",
 		name, name,
-		dflow[1].SumW(), dflow[1].SumW2(), dflow[1].SumWX, dflow[1].SumWX2, dflow[1].Entries(),
+		dflow[1].SumW(), dflow[1].SumW2(), dflow[1].SumWX(), dflow[1].SumWX2(), dflow[1].Entries(),
 	)
 	fmt.Fprintf(buf, "# xlow	 xhigh	 sumw	 sumw2	 sumwx	 sumwx2	 numEntries\n")
 	for i, d := range dists {
@@ -283,7 +283,7 @@ func (h *H1F) MarshalYODA() ([]byte, error) {
 			buf,
 			"%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 			xmin, xmax,
-			d.SumW(), d.SumW2(), d.SumWX, d.SumWX2, d.Entries(),
+			d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.Entries(),
 		)
 	}
 	fmt.Fprintf(buf, "END YODA_HISTO1D\n\n")
@@ -537,11 +537,11 @@ func (h *H1D) MarshalYODA() ([]byte, error) {
 				SumW:  float64(h.SumW()),
 				SumW2: float64(h.SumW2()),
 			},
-			SumWX:  float64(h.SumWX()),
-			SumWX2: float64(h.SumWX2()),
 		}
 		dists = make([]hbook.Dist1D, int(nx))
 	)
+	dtot.Stats.SumWX = float64(h.SumWX())
+	dtot.Stats.SumWX2 = float64(h.SumWX2())
 
 	for i := 0; i < nx; i++ {
 		dists[i] = h.dist1D(i + 1)
@@ -562,7 +562,7 @@ func (h *H1D) MarshalYODA() ([]byte, error) {
 		buf,
 		"%s\t%s\t%e\t%e\t%e\t%e\t%d\n",
 		name, name,
-		dtot.SumW(), dtot.SumW2(), dtot.SumWX, dtot.SumWX2, dtot.Entries(),
+		dtot.SumW(), dtot.SumW2(), dtot.SumWX(), dtot.SumWX2(), dtot.Entries(),
 	)
 
 	name = "Underflow"
@@ -570,7 +570,7 @@ func (h *H1D) MarshalYODA() ([]byte, error) {
 		buf,
 		"%s\t%s\t%e\t%e\t%e\t%e\t%d\n",
 		name, name,
-		dflow[0].SumW(), dflow[0].SumW2(), dflow[0].SumWX, dflow[0].SumWX2, dflow[0].Entries(),
+		dflow[0].SumW(), dflow[0].SumW2(), dflow[0].SumWX(), dflow[0].SumWX2(), dflow[0].Entries(),
 	)
 
 	name = "Overflow"
@@ -578,7 +578,7 @@ func (h *H1D) MarshalYODA() ([]byte, error) {
 		buf,
 		"%s\t%s\t%e\t%e\t%e\t%e\t%d\n",
 		name, name,
-		dflow[1].SumW(), dflow[1].SumW2(), dflow[1].SumWX, dflow[1].SumWX2, dflow[1].Entries(),
+		dflow[1].SumW(), dflow[1].SumW2(), dflow[1].SumWX(), dflow[1].SumWX2(), dflow[1].Entries(),
 	)
 	fmt.Fprintf(buf, "# xlow	 xhigh	 sumw	 sumw2	 sumwx	 sumwx2	 numEntries\n")
 	for i, d := range dists {
@@ -588,7 +588,7 @@ func (h *H1D) MarshalYODA() ([]byte, error) {
 			buf,
 			"%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 			xmin, xmax,
-			d.SumW(), d.SumW2(), d.SumWX, d.SumWX2, d.Entries(),
+			d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.Entries(),
 		)
 	}
 	fmt.Fprintf(buf, "END YODA_HISTO1D\n\n")
@@ -842,11 +842,11 @@ func (h *H1I) MarshalYODA() ([]byte, error) {
 				SumW:  float64(h.SumW()),
 				SumW2: float64(h.SumW2()),
 			},
-			SumWX:  float64(h.SumWX()),
-			SumWX2: float64(h.SumWX2()),
 		}
 		dists = make([]hbook.Dist1D, int(nx))
 	)
+	dtot.Stats.SumWX = float64(h.SumWX())
+	dtot.Stats.SumWX2 = float64(h.SumWX2())
 
 	for i := 0; i < nx; i++ {
 		dists[i] = h.dist1D(i + 1)
@@ -867,7 +867,7 @@ func (h *H1I) MarshalYODA() ([]byte, error) {
 		buf,
 		"%s\t%s\t%e\t%e\t%e\t%e\t%d\n",
 		name, name,
-		dtot.SumW(), dtot.SumW2(), dtot.SumWX, dtot.SumWX2, dtot.Entries(),
+		dtot.SumW(), dtot.SumW2(), dtot.SumWX(), dtot.SumWX2(), dtot.Entries(),
 	)
 
 	name = "Underflow"
@@ -875,7 +875,7 @@ func (h *H1I) MarshalYODA() ([]byte, error) {
 		buf,
 		"%s\t%s\t%e\t%e\t%e\t%e\t%d\n",
 		name, name,
-		dflow[0].SumW(), dflow[0].SumW2(), dflow[0].SumWX, dflow[0].SumWX2, dflow[0].Entries(),
+		dflow[0].SumW(), dflow[0].SumW2(), dflow[0].SumWX(), dflow[0].SumWX2(), dflow[0].Entries(),
 	)
 
 	name = "Overflow"
@@ -883,7 +883,7 @@ func (h *H1I) MarshalYODA() ([]byte, error) {
 		buf,
 		"%s\t%s\t%e\t%e\t%e\t%e\t%d\n",
 		name, name,
-		dflow[1].SumW(), dflow[1].SumW2(), dflow[1].SumWX, dflow[1].SumWX2, dflow[1].Entries(),
+		dflow[1].SumW(), dflow[1].SumW2(), dflow[1].SumWX(), dflow[1].SumWX2(), dflow[1].Entries(),
 	)
 	fmt.Fprintf(buf, "# xlow	 xhigh	 sumw	 sumw2	 sumwx	 sumwx2	 numEntries\n")
 	for i, d := range dists {
@@ -893,7 +893,7 @@ func (h *H1I) MarshalYODA() ([]byte, error) {
 			buf,
 			"%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 			xmin, xmax,
-			d.SumW(), d.SumW2(), d.SumWX, d.SumWX2, d.Entries(),
+			d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.Entries(),
 		)
 	}
 	fmt.Fprintf(buf, "END YODA_HISTO1D\n\n")

--- a/rootio/h2_gen.go
+++ b/rootio/h2_gen.go
@@ -287,8 +287,6 @@ func (h *H2F) MarshalYODA() ([]byte, error) {
 					SumW:  float64(h.SumW()),
 					SumW2: float64(h.SumW2()),
 				},
-				SumWX:  float64(h.SumWX()),
-				SumWX2: float64(h.SumWX2()),
 			},
 			Y: hbook.Dist1D{
 				Dist: hbook.Dist0D{
@@ -296,13 +294,16 @@ func (h *H2F) MarshalYODA() ([]byte, error) {
 					SumW:  float64(h.SumW()),
 					SumW2: float64(h.SumW2()),
 				},
-				SumWX:  float64(h.SumWY()),
-				SumWX2: float64(h.SumWY2()),
 			},
-			SumWXY: h.SumWXY(),
 		}
 		dists = make([]hbook.Dist2D, int(nx*ny))
 	)
+	dtot.X.Stats.SumWX = float64(h.SumWX())
+	dtot.X.Stats.SumWX2 = float64(h.SumWX2())
+	dtot.Y.Stats.SumWX = float64(h.SumWY())
+	dtot.Y.Stats.SumWX2 = float64(h.SumWY2())
+	dtot.Stats.SumWXY = h.SumWXY()
+
 	for ix := 0; ix < nx; ix++ {
 		for iy := 0; iy < ny; iy++ {
 			i := iy*nx + ix
@@ -326,7 +327,7 @@ func (h *H2F) MarshalYODA() ([]byte, error) {
 		buf,
 		"%s\t%s\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 		name, name,
-		d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY, d.Entries(),
+		d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY(), d.Entries(),
 	)
 
 	if false { // FIXME(sbinet)
@@ -335,7 +336,7 @@ func (h *H2F) MarshalYODA() ([]byte, error) {
 				buf,
 				"%s\t%s\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 				name, name,
-				d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY, d.Entries(),
+				d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY(), d.Entries(),
 			)
 
 		}
@@ -358,7 +359,7 @@ func (h *H2F) MarshalYODA() ([]byte, error) {
 				buf,
 				"%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 				xmin, xmax, ymin, ymax,
-				d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY, d.Entries(),
+				d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY(), d.Entries(),
 			)
 		}
 	}
@@ -714,8 +715,6 @@ func (h *H2D) MarshalYODA() ([]byte, error) {
 					SumW:  float64(h.SumW()),
 					SumW2: float64(h.SumW2()),
 				},
-				SumWX:  float64(h.SumWX()),
-				SumWX2: float64(h.SumWX2()),
 			},
 			Y: hbook.Dist1D{
 				Dist: hbook.Dist0D{
@@ -723,13 +722,16 @@ func (h *H2D) MarshalYODA() ([]byte, error) {
 					SumW:  float64(h.SumW()),
 					SumW2: float64(h.SumW2()),
 				},
-				SumWX:  float64(h.SumWY()),
-				SumWX2: float64(h.SumWY2()),
 			},
-			SumWXY: h.SumWXY(),
 		}
 		dists = make([]hbook.Dist2D, int(nx*ny))
 	)
+	dtot.X.Stats.SumWX = float64(h.SumWX())
+	dtot.X.Stats.SumWX2 = float64(h.SumWX2())
+	dtot.Y.Stats.SumWX = float64(h.SumWY())
+	dtot.Y.Stats.SumWX2 = float64(h.SumWY2())
+	dtot.Stats.SumWXY = h.SumWXY()
+
 	for ix := 0; ix < nx; ix++ {
 		for iy := 0; iy < ny; iy++ {
 			i := iy*nx + ix
@@ -753,7 +755,7 @@ func (h *H2D) MarshalYODA() ([]byte, error) {
 		buf,
 		"%s\t%s\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 		name, name,
-		d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY, d.Entries(),
+		d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY(), d.Entries(),
 	)
 
 	if false { // FIXME(sbinet)
@@ -762,7 +764,7 @@ func (h *H2D) MarshalYODA() ([]byte, error) {
 				buf,
 				"%s\t%s\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 				name, name,
-				d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY, d.Entries(),
+				d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY(), d.Entries(),
 			)
 
 		}
@@ -785,7 +787,7 @@ func (h *H2D) MarshalYODA() ([]byte, error) {
 				buf,
 				"%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 				xmin, xmax, ymin, ymax,
-				d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY, d.Entries(),
+				d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY(), d.Entries(),
 			)
 		}
 	}
@@ -1141,8 +1143,6 @@ func (h *H2I) MarshalYODA() ([]byte, error) {
 					SumW:  float64(h.SumW()),
 					SumW2: float64(h.SumW2()),
 				},
-				SumWX:  float64(h.SumWX()),
-				SumWX2: float64(h.SumWX2()),
 			},
 			Y: hbook.Dist1D{
 				Dist: hbook.Dist0D{
@@ -1150,13 +1150,16 @@ func (h *H2I) MarshalYODA() ([]byte, error) {
 					SumW:  float64(h.SumW()),
 					SumW2: float64(h.SumW2()),
 				},
-				SumWX:  float64(h.SumWY()),
-				SumWX2: float64(h.SumWY2()),
 			},
-			SumWXY: h.SumWXY(),
 		}
 		dists = make([]hbook.Dist2D, int(nx*ny))
 	)
+	dtot.X.Stats.SumWX = float64(h.SumWX())
+	dtot.X.Stats.SumWX2 = float64(h.SumWX2())
+	dtot.Y.Stats.SumWX = float64(h.SumWY())
+	dtot.Y.Stats.SumWX2 = float64(h.SumWY2())
+	dtot.Stats.SumWXY = h.SumWXY()
+
 	for ix := 0; ix < nx; ix++ {
 		for iy := 0; iy < ny; iy++ {
 			i := iy*nx + ix
@@ -1180,7 +1183,7 @@ func (h *H2I) MarshalYODA() ([]byte, error) {
 		buf,
 		"%s\t%s\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 		name, name,
-		d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY, d.Entries(),
+		d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY(), d.Entries(),
 	)
 
 	if false { // FIXME(sbinet)
@@ -1189,7 +1192,7 @@ func (h *H2I) MarshalYODA() ([]byte, error) {
 				buf,
 				"%s\t%s\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 				name, name,
-				d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY, d.Entries(),
+				d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY(), d.Entries(),
 			)
 
 		}
@@ -1212,7 +1215,7 @@ func (h *H2I) MarshalYODA() ([]byte, error) {
 				buf,
 				"%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%e\t%d\n",
 				xmin, xmax, ymin, ymax,
-				d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY, d.Entries(),
+				d.SumW(), d.SumW2(), d.SumWX(), d.SumWX2(), d.SumWY(), d.SumWY2(), d.SumWXY(), d.Entries(),
 			)
 		}
 	}

--- a/rootio/key.go
+++ b/rootio/key.go
@@ -59,6 +59,8 @@ type Key struct {
 
 	buf []byte // buffer of the Key's value
 	obj Object // Key's value
+
+	otyp reflect.Type // Go type of the Key's payload.
 }
 
 func newKey(name, title, class string, nbytes int32, f *File) Key {
@@ -123,6 +125,7 @@ func newKeyFrom(obj Object, wbuf *WBuffer) (Key, error) {
 		title:    title,
 		buf:      data,
 		obj:      obj,
+		otyp:     reflect.TypeOf(obj),
 	}
 	return k, nil
 }
@@ -145,6 +148,21 @@ func (k *Key) Title() string {
 
 func (k *Key) Cycle() int {
 	return int(k.cycle)
+}
+
+// ObjectType returns the Key's payload type.
+//
+// ObjectType returns nil if the Key's payload type is not known
+// to the registry of rootio.
+func (k *Key) ObjectType() reflect.Type {
+	if k.otyp != nil {
+		return k.otyp
+	}
+	if !Factory.HasKey(k.class) {
+		return nil
+	}
+	k.otyp = Factory.Get(k.class)().Type()
+	return k.otyp
 }
 
 // Value returns the data corresponding to the Key's value

--- a/rootio/key_test.go
+++ b/rootio/key_test.go
@@ -90,6 +90,63 @@ func TestKeyNewKeyFrom(t *testing.T) {
 			if got := v.(*tobjstring); !reflect.DeepEqual(got, tc.want) {
 				t.Fatalf("error:\ngot = %#v\nwant= %#v\n", got, tc.want)
 			}
+
+			otyp := k.ObjectType()
+			if otyp == nil {
+				t.Fatalf("could not retrieve key's payload's type")
+			}
+			if otyp != nil {
+				switch v := reflect.New(otyp).Elem().Interface(); v.(type) {
+				case ObjString:
+					// ok
+				default:
+					t.Fatalf("expected a rootio.ObjString (got %T)", v)
+				}
+			}
+		})
+	}
+}
+
+func TestKeyObjectType(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		key  Key
+		typ  reflect.Type
+	}{
+		{
+			name: "TObjString",
+			key:  Key{class: "TObjString"},
+			typ:  reflect.TypeOf((*tobjstring)(nil)),
+		},
+		{
+			name: "rootio.tobjstring",
+			key:  Key{class: "*rootio.tobjstring"},
+			typ:  reflect.TypeOf((*tobjstring)(nil)),
+		},
+		{
+			name: "invalid",
+			key:  Key{class: "invalid"},
+			typ:  nil,
+		},
+		{
+			name: "TH1D",
+			key:  Key{class: "TH1D"},
+			typ:  reflect.TypeOf((*H1D)(nil)),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			otyp := tc.key.ObjectType()
+			if otyp != tc.typ {
+				t.Fatalf("got: %+v, want=%+v", otyp, tc.typ)
+			}
+			if otyp == nil {
+				return
+			}
+
+			otyp2 := tc.key.ObjectType()
+			if otyp != otyp2 {
+				t.Fatalf("got: %+v, want=%+v", otyp2, otyp)
+			}
 		})
 	}
 }

--- a/rootio/objstring.go
+++ b/rootio/objstring.go
@@ -78,7 +78,7 @@ func init() {
 		return reflect.ValueOf(o)
 	}
 	Factory.add("TObjString", f)
-	Factory.add("*rootio.tobjString", f)
+	Factory.add("*rootio.tobjstring", f)
 }
 
 var (


### PR DESCRIPTION
Key.Type() allows to infer a key's payload's type w/o having to actually
unmarshal the whole object from disk.