### PR TITLE
 xrootd/xrdproto/auth/krb5: handle unsupported directive parsing errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,8 +34,8 @@ require (
 	gonum.org/v1/plot v0.0.0-20180905080458-5f3c436ce602
 	gopkg.in/jcmturner/aescts.v1 v1.0.1 // indirect
 	gopkg.in/jcmturner/dnsutils.v1 v1.0.1 // indirect
-	gopkg.in/jcmturner/goidentity.v2 v2.0.0 // indirect
-	gopkg.in/jcmturner/gokrb5.v5 v5.3.0
-	gopkg.in/jcmturner/rpc.v0 v0.0.2 // indirect
+	gopkg.in/jcmturner/goidentity.v3 v3.0.0 // indirect
+	gopkg.in/jcmturner/gokrb5.v6 v6.0.1
+	gopkg.in/jcmturner/rpc.v1 v1.1.0 // indirect
 	rsc.io/pdf v0.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -111,11 +111,11 @@ gopkg.in/jcmturner/aescts.v1 v1.0.1 h1:cVVZBK2b1zY26haWB4vbBiZrfFQnfbTVrE3xZq6hr
 gopkg.in/jcmturner/aescts.v1 v1.0.1/go.mod h1:nsR8qBOg+OucoIW+WMhB3GspUQXq9XorLnQb9XtvcOo=
 gopkg.in/jcmturner/dnsutils.v1 v1.0.1 h1:cIuC1OLRGZrld+16ZJvvZxVJeKPsvd5eUIvxfoN5hSM=
 gopkg.in/jcmturner/dnsutils.v1 v1.0.1/go.mod h1:m3v+5svpVOhtFAP/wSz+yzh4Mc0Fg7eRhxkJMWSIz9Q=
-gopkg.in/jcmturner/goidentity.v2 v2.0.0 h1:6Bmcdaxb0dD3HyHbo/MtJ2Q1wXLDuZJFwXZmuZvM+zw=
-gopkg.in/jcmturner/goidentity.v2 v2.0.0/go.mod h1:vCwK9HeXksMeUmQ4SxDd1tRz4LejrKh3KRVjQWhjvZI=
-gopkg.in/jcmturner/gokrb5.v5 v5.3.0 h1:RS1MYApX27Hx1Xw7NECs7XxGxxrm69/4OmaRuX9kwec=
-gopkg.in/jcmturner/gokrb5.v5 v5.3.0/go.mod h1:oQz8Wc5GsctOTgCVyKad1Vw4TCWz5G6gfIQr88RPv4k=
-gopkg.in/jcmturner/rpc.v0 v0.0.2 h1:wBTgrbL1qmLBUPsYVCqdJiI5aJgQhexmK+JkTHPUNJI=
-gopkg.in/jcmturner/rpc.v0 v0.0.2/go.mod h1:NzMq6cRzR9lipgw7WxRBHNx5N8SifBuaCQsOT1kWY/E=
+gopkg.in/jcmturner/goidentity.v3 v3.0.0 h1:1duIyWiTaYvVx3YX2CYtpJbUFd7/UuPYCfgXtQ3VTbI=
+gopkg.in/jcmturner/goidentity.v3 v3.0.0/go.mod h1:oG2kH0IvSYNIu80dVAyu/yoefjq1mNfM5bm88whjWx4=
+gopkg.in/jcmturner/gokrb5.v6 v6.0.1 h1:ubxwoMmqmaR8CpPFE2gNtEWw+faw7xFS8H1myT1roig=
+gopkg.in/jcmturner/gokrb5.v6 v6.0.1/go.mod h1:NFjHNLrHQiruory+EmqDXCGv6CrjkeYeA+bR9mIfNFk=
+gopkg.in/jcmturner/rpc.v1 v1.1.0 h1:QHIUxTX1ISuAv9dD2wJ9HWQVuWDX/Zc0PfeC2tjc4rU=
+gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLvuNnlv8=
 rsc.io/pdf v0.1.1 h1:k1MczvYDUvJBe93bYd7wrZLLUEcLZAuF824/I4e5Xr4=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=

--- a/xrootd/xrdproto/auth/krb5/krb5.go
+++ b/xrootd/xrdproto/auth/krb5/krb5.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/pkg/errors"
 	"go-hep.org/x/hep/xrootd/xrdproto/auth"
-	"gopkg.in/jcmturner/gokrb5.v5/client"
-	"gopkg.in/jcmturner/gokrb5.v5/config"
-	"gopkg.in/jcmturner/gokrb5.v5/credentials"
-	"gopkg.in/jcmturner/gokrb5.v5/crypto"
-	"gopkg.in/jcmturner/gokrb5.v5/messages"
-	"gopkg.in/jcmturner/gokrb5.v5/types"
+	"gopkg.in/jcmturner/gokrb5.v6/client"
+	"gopkg.in/jcmturner/gokrb5.v6/config"
+	"gopkg.in/jcmturner/gokrb5.v6/credentials"
+	"gopkg.in/jcmturner/gokrb5.v6/crypto"
+	"gopkg.in/jcmturner/gokrb5.v6/messages"
+	"gopkg.in/jcmturner/gokrb5.v6/types"
 )
 
 // Default is a Kerberos 5 client configured from cached credentials.

--- a/xrootd/xrdproto/auth/krb5/krb5.go
+++ b/xrootd/xrdproto/auth/krb5/krb5.go
@@ -67,7 +67,12 @@ func WithCredCache() (*Auth, error) {
 
 	cfg, err := config.Load(configPath)
 	if err != nil {
-		return nil, errors.WithMessage(err, "auth/krb5: could not load kerberos-5 configuration")
+		switch err.(type) {
+		case config.UnsupportedDirective:
+			// ok. just ignore it.
+		default:
+			return nil, errors.WithMessage(err, "auth/krb5: could not load kerberos-5 configuration")
+		}
 	}
 
 	krb.WithConfig(cfg)


### PR DESCRIPTION
This CL leverages gokrb5.v6 to properly handle unsupported directive
errors that stem from e.g. krb5.conf sections like:

```
[realms]
 CERN.CH  = {
  default_domain = cern.ch
  kpasswd_server = cerndc.cern.ch
  admin_server = cerndc.cern.ch
   kdc = cerndc.cern.ch
    v4_name_convert = {
     host = {
        rcmd = host
     }
   }
 }
```

the v4 parts are not supported by gokrb5.
this used to be fatal (in the sense that xrootd couldn't generate a
proper authentication token) but didn't need to be.

now, gokrb5.v6 returns this new config.UnsupportedDirective error that
we recognize and "handle" (by ignoring it.)

Fixes go-hep/hep#355.