### PR TITLE
rootio: introduce default streamers

### DIFF
--- a/rootio/attfill.go
+++ b/rootio/attfill.go
@@ -20,6 +20,10 @@ func newAttFill() *attfill {
 	}
 }
 
+func (*attfill) Class() string {
+	return "TAttFill"
+}
+
 func (a *attfill) MarshalROOT(w *WBuffer) (int, error) {
 	if w.err != nil {
 		return 0, w.err
@@ -59,6 +63,7 @@ func init() {
 }
 
 var (
+	_ Object          = (*attfill)(nil)
 	_ ROOTMarshaler   = (*attfill)(nil)
 	_ ROOTUnmarshaler = (*attfill)(nil)
 )

--- a/rootio/attline.go
+++ b/rootio/attline.go
@@ -21,6 +21,9 @@ func newAttLine() *attline {
 		width: 1,
 	}
 }
+func (*attline) Class() string {
+	return "TAttLine"
+}
 
 func (a *attline) MarshalROOT(w *WBuffer) (int, error) {
 	if w.err != nil {
@@ -63,6 +66,7 @@ func init() {
 }
 
 var (
+	_ Object          = (*attline)(nil)
 	_ ROOTMarshaler   = (*attline)(nil)
 	_ ROOTUnmarshaler = (*attline)(nil)
 )

--- a/rootio/attmarker.go
+++ b/rootio/attmarker.go
@@ -22,6 +22,10 @@ func newAttMarker() *attmarker {
 	}
 }
 
+func (*attmarker) Class() string {
+	return "TAttMarker"
+}
+
 func (a *attmarker) MarshalROOT(w *WBuffer) (int, error) {
 	if w.err != nil {
 		return 0, w.err
@@ -61,6 +65,7 @@ func init() {
 }
 
 var (
+	_ Object          = (*attmarker)(nil)
 	_ ROOTMarshaler   = (*attmarker)(nil)
 	_ ROOTUnmarshaler = (*attmarker)(nil)
 )

--- a/rootio/factory_test.go
+++ b/rootio/factory_test.go
@@ -1,0 +1,28 @@
+// Copyright 2018 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package rootio
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFactory(t *testing.T) {
+	n := Factory.Len()
+	if got, want := len(Factory.Keys()), n; got != want {
+		t.Fatalf("got=%d, want=%d", got, want)
+	}
+
+	for _, name := range Factory.Keys() {
+		if strings.HasPrefix(name, "*rootio") || strings.HasPrefix(name, "rootio") {
+			continue
+		}
+		fct := Factory.Get(name)
+		obj := fct().Interface().(Object)
+		if got, want := obj.Class(), name; got != want {
+			t.Fatalf("got=%q, want=%q", got, want)
+		}
+	}
+}

--- a/rootio/file.go
+++ b/rootio/file.go
@@ -169,7 +169,7 @@ func Create(name string, opts ...FileOption) (*File, error) {
 		end:         kBEGIN,
 		units:       4,
 		compression: 1,
-		sinfos:      []StreamerInfo{},
+		sinfos:      defaultStreamerInfos, // FIXME(sbinet): drop default streamers
 	}
 	f.dir = *newDirectoryFile(name, f)
 	f.spans.add(kBEGIN, kStartBigFile)

--- a/rootio/file_example_test.go
+++ b/rootio/file_example_test.go
@@ -38,12 +38,8 @@ func ExampleCreate_empty() {
 
 	fmt.Printf("file: %q\n", r.Name())
 
-	sinfos := r.StreamerInfos()
-	fmt.Printf("streamer infos: %d\n", len(sinfos))
-
 	// Output:
 	// file: "empty.root"
-	// streamer infos: 0
 }
 
 func ExampleCreate() {

--- a/rootio/hist.go
+++ b/rootio/hist.go
@@ -39,7 +39,7 @@ type th1 struct {
 
 func newH1() *th1 {
 	return &th1{
-		rvers:     7, // FIXME(sbinet): harmonize versions
+		rvers:     8, // FIXME(sbinet): harmonize versions
 		tnamed:    *newNamed("", ""),
 		attline:   *newAttLine(),
 		attfill:   *newAttFill(),

--- a/rootio/streamers.go
+++ b/rootio/streamers.go
@@ -954,6 +954,19 @@ func streamerInfoFrom(obj Object, sictx streamerInfoStore) (StreamerInfo, error)
 	return si, nil
 }
 
+var defaultStreamerInfos []StreamerInfo
+
+func init() {
+	r := &memFile{bytes.NewReader(rstreamerspkg.Data)}
+	f, err := NewReader(r)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	defaultStreamerInfos = f.StreamerInfos()
+}
+
 var (
 	_ Object          = (*tstreamerInfo)(nil)
 	_ Named           = (*tstreamerInfo)(nil)


### PR DESCRIPTION
This CL introduces and hardcodes default streamers.
This is temporary, until we correctly manage (possibly deep) inheritance
hierarchies.

Updates #370.