### PR TITLE
groot: dont clobber basket buffer

### DIFF
--- a/groot/cmd/root-srv/data.go
+++ b/groot/cmd/root-srv/data.go
@@ -11,7 +11,6 @@ import (
 	stdpath "path"
 	"strings"
 
-	"github.com/pkg/errors"
 	"gonum.org/v1/plot/vg"
 
 	"go-hep.org/x/hep/groot/riofs"
@@ -255,5 +254,6 @@ func attrFor(obj root.Object, node jsNode) (jsAttr, error) {
 			"cmd":  cmd.String(),
 		}, nil
 	}
-	return nil, errors.Errorf("unknown node type %q", cls)
+	// TODO(sbinet) do something clever with things we don't know how to handle?
+	return nil, nil
 }

--- a/groot/rtree/branch.go
+++ b/groot/rtree/branch.go
@@ -356,10 +356,7 @@ func (b *tbranch) setupBasket(bk *Basket, ib int, entry int64) error {
 	bk.key.SetFile(f)
 	b.firstEntry = b.basketEntry[ib]
 
-	if len(b.basketBuf) < int(bk.key.ObjLen()) {
-		b.basketBuf = make([]byte, bk.key.ObjLen())
-	}
-	buf = b.basketBuf[:int(b.basket.key.ObjLen())]
+	buf = make([]byte, int(b.basket.key.ObjLen()))
 	_, err = bk.key.Load(buf)
 	if err != nil {
 		return err

--- a/groot/rtree/branch.go
+++ b/groot/rtree/branch.go
@@ -349,25 +349,25 @@ func (b *tbranch) setupBasket(bk *Basket, ib int, entry int64) error {
 	}
 
 	sictx := b.tree.getFile()
-	err = b.basket.UnmarshalROOT(rbytes.NewRBuffer(buf, nil, 0, sictx))
+	err = bk.UnmarshalROOT(rbytes.NewRBuffer(buf, nil, 0, sictx))
 	if err != nil {
 		return err
 	}
-	b.basket.key.SetFile(f)
+	bk.key.SetFile(f)
 	b.firstEntry = b.basketEntry[ib]
 
-	if len(b.basketBuf) < int(b.basket.key.ObjLen()) {
-		b.basketBuf = make([]byte, b.basket.key.ObjLen())
+	if len(b.basketBuf) < int(bk.key.ObjLen()) {
+		b.basketBuf = make([]byte, bk.key.ObjLen())
 	}
 	buf = b.basketBuf[:int(b.basket.key.ObjLen())]
-	_, err = b.basket.key.Load(buf)
+	_, err = bk.key.Load(buf)
 	if err != nil {
 		return err
 	}
-	b.basket.rbuf = rbytes.NewRBuffer(buf, nil, uint32(b.basket.key.KeyLen()), sictx)
+	bk.rbuf = rbytes.NewRBuffer(buf, nil, uint32(bk.key.KeyLen()), sictx)
 
 	for _, leaf := range b.leaves {
-		err = leaf.readBasket(b.basket.rbuf)
+		err = leaf.readBasket(bk.rbuf)
 		if err != nil {
 			return err
 		}
@@ -375,16 +375,17 @@ func (b *tbranch) setupBasket(bk *Basket, ib int, entry int64) error {
 
 	if b.entryOffsetLen > 0 {
 		last := int64(b.basket.last)
-		err = b.basket.rbuf.SetPos(last)
+		err = bk.rbuf.SetPos(last)
 		if err != nil {
 			return err
 		}
-		n := b.basket.rbuf.ReadI32()
-		b.basket.offsets = b.basket.rbuf.ReadFastArrayI32(int(n))
-		if b.basket.rbuf.Err() != nil {
-			return b.basket.rbuf.Err()
+		n := bk.rbuf.ReadI32()
+		bk.offsets = bk.rbuf.ReadFastArrayI32(int(n))
+		if err := bk.rbuf.Err(); err != nil {
+			return err
 		}
 	}
+
 	return err
 }
 


### PR DESCRIPTION
This CL makes sure we don't clobber previously read baskets' buffers.
Previously, we were trying to be clever and re-use a per-branch buffer
for reading baskets' contents.

This worked correctly when crawling through data once.
But when going through events twice, the data part of the buffer for
event, e.g., 10, could contain random data from previously read event
190001.

Fixes #390.