### PR TITLE
xrootd/cmd/xrd-ls: fix output format

### DIFF
--- a/xrootd/cmd/xrd-ls/main.go
+++ b/xrootd/cmd/xrd-ls/main.go
@@ -126,8 +126,8 @@ func display(ctx context.Context, fs xrdfs.FileSystem, root string, fi os.FileIn
 		end = ":"
 	}
 
-	fmt.Printf("%s%s\n", path.Join(root, fi.Name()), end)
 	dir := path.Join(root, fi.Name())
+	fmt.Printf("%s%s\n", dir, end)
 	if long {
 		fmt.Printf("total %d\n", fi.Size())
 	}
@@ -137,7 +137,7 @@ func display(ctx context.Context, fs xrdfs.FileSystem, root string, fi os.FileIn
 	}
 	o := tabwriter.NewWriter(os.Stdout, 8, 4, 0, ' ', tabwriter.AlignRight)
 	for _, e := range ents {
-		format(o, root, e, long)
+		format(o, dir, e, long)
 	}
 	o.Flush()
 	if recursive {


### PR DESCRIPTION
Fixes output format of xrd-ls. 
Previously, directory name was omitted which resulted in ` \tmp\x\y\a.txt` being shown as `\tmp\x\a.txt`.