### PR TITLE
xrootd: fix Read fshandler

### DIFF
--- a/xrootd/fshandler.go
+++ b/xrootd/fshandler.go
@@ -211,7 +211,7 @@ func (h *fshandler) Read(sessionID [16]byte, request *read.Request) (xrdproto.Ma
 	}
 
 	buf := make([]byte, request.Length)
-	_, err := file.ReadAt(buf, request.Offset)
+	n, err := file.ReadAt(buf, request.Offset)
 	if err != nil && err != io.EOF {
 		return xrdproto.ServerError{
 			Code:    xrdproto.IOError,
@@ -219,7 +219,7 @@ func (h *fshandler) Read(sessionID [16]byte, request *read.Request) (xrdproto.Ma
 		}, xrdproto.Error
 	}
 
-	return read.Response{Data: buf}, xrdproto.Ok
+	return read.Response{Data: buf[:n]}, xrdproto.Ok
 }
 
 // Write implements server.Handler.Write.


### PR DESCRIPTION
According to http://xrootd.org/doc/dev45/XRdv310.pdf, p. 100:
If more data is requested than the file contains, the total of all
dlen’s will be less than rlen (in other words, response length will be
less that requested length).