### PR TITLE
groot: add sensible defaults for AttLine, Axis and H1

### DIFF
--- a/groot/rbase/attline.go
+++ b/groot/rbase/attline.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"go-hep.org/x/hep/groot/rbytes"
+	"go-hep.org/x/hep/groot/rcolors"
 	"go-hep.org/x/hep/groot/root"
 	"go-hep.org/x/hep/groot/rtypes"
 	"go-hep.org/x/hep/groot/rvers"
@@ -21,7 +22,7 @@ type AttLine struct {
 
 func NewAttLine() *AttLine {
 	return &AttLine{
-		Color: 1, // FIXME(sbinet)
+		Color: rcolors.Blue + 2,
 		Style: 1,
 		Width: 1,
 	}

--- a/groot/rcolors/colors.go
+++ b/groot/rcolors/colors.go
@@ -1,0 +1,23 @@
+// Copyright 2019 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package rcolors // import "go-hep.org/x/hep/groot/rcolors"
+
+const (
+	White   = 0
+	Black   = 1
+	Yellow  = 400
+	Green   = 416
+	Cyan    = 432
+	Blue    = 600
+	Magenta = 616
+	Red     = 632
+	Orange  = 800
+	Spring  = 820
+	Teal    = 840
+	Azure   = 860
+	Violet  = 880
+	Pink    = 900
+	Gray    = 920
+)

--- a/groot/rhist/axis.go
+++ b/groot/rhist/axis.go
@@ -36,6 +36,9 @@ func NewAxis(name string) *taxis {
 	return &taxis{
 		Named:   *rbase.NewNamed(name, ""),
 		attaxis: *rbase.NewAttAxis(),
+		nbins:   1,
+		xmin:    0,
+		xmax:    1,
 	}
 }
 

--- a/groot/rhist/hist.go
+++ b/groot/rhist/hist.go
@@ -53,7 +53,11 @@ func newH1() *th1 {
 		xaxis:     *NewAxis("xaxis"),
 		yaxis:     *NewAxis("yaxis"),
 		zaxis:     *NewAxis("zaxis"),
+		bwidth:    1000,
+		max:       -1111,
+		min:       -1111,
 		funcs:     *rcont.NewList("", nil),
+		oflow:     2, // kNeutral
 	}
 }
 


### PR DESCRIPTION
So a H1D created with groot can be correctly displayed by ROOT.