### PR TITLE
groot/rtree: make tree.writer close idempotent

### DIFF
--- a/groot/rtree/rw_test.go
+++ b/groot/rtree/rw_test.go
@@ -1172,6 +1172,7 @@ func TestTreeRW(t *testing.T) {
 				if err != nil {
 					t.Fatalf("could not create tree writer: %v", err)
 				}
+				defer tw.Close()
 				for i, b := range tw.Branches() {
 					if got, want := b.Name(), tc.wvars[i].Name; got != want {
 						t.Fatalf("branch[%d]: got=%q, want=%q", i, got, want)
@@ -1386,6 +1387,7 @@ func TestTreeWriteSubdir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create tree: %+v", err)
 	}
+	defer ntup.Close()
 
 	for i := 0; i < 5; i++ {
 		data.I32 = int32(i)

--- a/groot/rtree/writer.go
+++ b/groot/rtree/writer.go
@@ -97,6 +97,8 @@ func WithTitle(title string) WriteOption {
 type wtree struct {
 	ttree
 	wvars []WriteVar
+
+	closed bool
 }
 
 // WriteVar describes a variable to be written out to a tree.
@@ -311,6 +313,13 @@ func (w *wtree) Flush() error {
 
 // Close writes metadata and closes the tree.
 func (w *wtree) Close() error {
+	if w.closed {
+		return nil
+	}
+	defer func() {
+		w.closed = true
+	}()
+
 	if err := w.Flush(); err != nil {
 		return fmt.Errorf("rtree: could not flush tree %q: %w", w.Name(), err)
 	}

--- a/groot/rtree/writer_example_test.go
+++ b/groot/rtree/writer_example_test.go
@@ -48,6 +48,7 @@ func Example_createFlatNtuple() {
 		if err != nil {
 			log.Fatalf("could not create tree writer: %+v", err)
 		}
+		defer tree.Close()
 
 		fmt.Printf("-- created tree %q:\n", tree.Name())
 		for i, b := range tree.Branches() {
@@ -169,6 +170,7 @@ func Example_createFlatNtupleWithLZMA() {
 		if err != nil {
 			log.Fatalf("could not create tree writer: %+v", err)
 		}
+		defer tree.Close()
 
 		fmt.Printf("-- created tree %q:\n", tree.Name())
 		for i, b := range tree.Branches() {
@@ -282,6 +284,7 @@ func Example_createFlatNtupleFromStruct() {
 		if err != nil {
 			log.Fatalf("could not create tree writer: %+v", err)
 		}
+		defer tree.Close()
 
 		fmt.Printf("-- created tree %q:\n", tree.Name())
 		for i, b := range tree.Branches() {


### PR DESCRIPTION
This allows to reliably defer Writer.Close()