### PR TITLE
groot/rtree: allow Reader with 0-len rvars slice

### DIFF
--- a/groot/rtree/formula_test.go
+++ b/groot/rtree/formula_test.go
@@ -40,6 +40,13 @@ func TestFormula(t *testing.T) {
 		{
 			fname: "../testdata/simple.root",
 			tname: "tree",
+			rvars: 0,
+			expr:  "float64(one) + float64(two*100)",
+			want:  []interface{}{float64(111), float64(222)},
+		},
+		{
+			fname: "../testdata/simple.root",
+			tname: "tree",
 			rvars: 1,
 			expr:  "float64(one) + float64(two*100)",
 			want:  []interface{}{float64(111), float64(222)},

--- a/groot/rtree/scanner.go
+++ b/groot/rtree/scanner.go
@@ -478,10 +478,6 @@ type Scanner struct {
 // NewScannerVars creates a new Scanner from a list of pairs (branch-name, target-address).
 // Scanner will read the branches' data during Scan() and load them into these target-addresses.
 func NewScannerVars(t Tree, vars ...ReadVar) (*Scanner, error) {
-	if len(vars) <= 0 {
-		return nil, fmt.Errorf("rtree: NewScannerVars expects at least one branch name")
-	}
-
 	mbr := make([]Branch, len(vars))
 	ibr := make([]scanField, cap(mbr))
 	cbr := make([]Branch, 0)


### PR DESCRIPTION
Fixes go-hep/hep#643.