### PR TITLE
Implementation of Add() and Divide() function for hbook.H1D

### DIFF
--- a/hbook/h1d.go
+++ b/hbook/h1d.go
@@ -210,6 +210,7 @@ func AddScaledH1D(h1 *H1D, alpha float64, h2 *H1D) *H1D {
 		y2, y2err2 := d2.SumW, d2.SumW2
 		dst.SumW = y1 + alpha*y2
 		dst.SumW2 = y1err2 + alpha2*y2err2
+		dst.N = d1.N + d2.N
 		return
 	}
 

--- a/hbook/h1d.go
+++ b/hbook/h1d.go
@@ -186,6 +186,31 @@ func (h *H1D) Scale(factor float64) {
 	h.Binning.scaleW(factor)
 }
 
+// AddH1D returns the bin-by-bin summed histogram of h1 and h2 
+func AddH1D(h1, h2 *H1D) *H1D {
+	
+	if h1.Len() != h2.Len() {
+		panic("hbook: h1 and h2 have different number of bins")
+	}
+
+	if h1.XMin() != h2.XMin() {
+		panic("hbook: h1 and h2 have different Xmin")
+	}
+
+	if h1.XMax() != h2.XMax() {
+		panic("hbook: h1 and h2 have different Xmax")
+	}
+
+	hsum := NewH1D(h1.Len(), h1.XMin(), h1.XMax())
+	for i := 0; i < hsum.Len(); i++ {
+		y := h1.Value(i) + h2.Value(i)
+		x := hsum.Binning.Bins[i].Range.Min
+		hsum.Binning.fill(x, y)
+	}
+	
+	return hsum
+}
+
 // Integral computes the integral of the histogram.
 //
 // The number of parameters can be 0 or 2.

--- a/hbook/h1d.go
+++ b/hbook/h1d.go
@@ -213,7 +213,7 @@ func AddScaledH1D(h1 *H1D, alpha float64, h2 *H1D) *H1D {
 		return
 	}
 
-	h1dApply_test(hsum, h1, h2, compute_sum)
+	h1dApply(hsum, h1, h2, compute_sum)
 
 	return hsum
 }
@@ -225,20 +225,7 @@ func AddH1D(h1, h2 *H1D) *H1D {
 }
 
 // h1dApply is a helper function to perform bin-by-bin operations on H1D.
-func h1dApply(dst, bins1, bins2 []Bin1D, fct func(b1, b2 Bin1D) (float64, float64)) {
-
-	if len(bins1) != len(bins2) || len(bins1) != len(dst) {
-		panic("hbook: length mismatch")
-	}
-
-	for i := range dst {
-		y, yerr2 := fct(bins1[i], bins2[i])
-		dst[i].Dist.Dist.SumW = y
-		dst[i].Dist.Dist.SumW2 = yerr2
-	}
-}
-
-func h1dApply_test(dst, h1, h2 *H1D, fct func(d, d1, d2 *Dist0D)) {
+func h1dApply(dst, h1, h2 *H1D, fct func(d, d1, d2 *Dist0D)) {
 
 	if h1.Len() != dst.Len() || h1.Len() != dst.Len() {
 		panic("hbook: length mismatch")

--- a/hbook/h1d.go
+++ b/hbook/h1d.go
@@ -206,24 +206,29 @@ func AddH1D(h1, h2 *H1D) *H1D {
 
 	for i := 0; i < hsum.Len(); i++ {
 		y := h1.Value(i) + h2.Value(i)
-		y1err := h1.Binning.Bins[i].SumW2()
-		y2err := h2.Binning.Bins[i].SumW2()
-		yerr := math.Sqrt(y1err*y1err + y2err*y2err)
+		y1err2 := h1.Binning.Bins[i].SumW2()
+		y2err2 := h2.Binning.Bins[i].SumW2()
 		hsum.Binning.Bins[i].Dist.Dist.SumW = y
-		hsum.Binning.Bins[i].Dist.Dist.SumW2 = yerr
+		hsum.Binning.Bins[i].Dist.Dist.SumW2 = y1err2 + y2err2
 	}
 
 	// handle under/over flow
 	for i := range hsum.Binning.Outflows {
-		y := h1.Binning.Outflows[i].Dist.SumW2 + h2.Binning.Outflows[i].Dist.SumW2
-		y1err := h1.Binning.Outflows[i].Dist.SumW2
-		y2err := h2.Binning.Outflows[i].Dist.SumW2
-		yerr := math.Sqrt(y1err*y1err + y2err*y2err)
+		y := h1.Binning.Outflows[i].Dist.SumW + h2.Binning.Outflows[i].Dist.SumW
+		y1err2 := h1.Binning.Outflows[i].Dist.SumW2
+		y2err2 := h2.Binning.Outflows[i].Dist.SumW2
 		hsum.Binning.Outflows[i].Dist.SumW = y
-		hsum.Binning.Outflows[i].Dist.SumW2 = yerr
+		hsum.Binning.Outflows[i].Dist.SumW2 = y1err2 + y2err2
 	}
 
 	return hsum
+}
+
+// AddScaledH1D returns the histogram with the bin-by-bin h1+alpha*h2
+// operation, assuming statistical uncertainties are uncorrelated.
+func AddScaledH1D(h1 *H1D, alpha float64, h2 *H1D) *H1D {
+	h2.Scale(alpha)
+	return AddH1D(h1, h2)
 }
 
 // Integral computes the integral of the histogram.

--- a/hbook/h1d.go
+++ b/hbook/h1d.go
@@ -233,7 +233,8 @@ func AddScaledH1D(h1 *H1D, alpha float64, h2 *H1D) *H1D {
 
 // DivH1D returns the bin-by-bin ratio histogram of h1 to h2
 // assuming their statistical uncertainties are uncorrelated.
-// Bins with NaN value are set to 0, as well as their uncertainty.
+// Bins with NaN of +/- infinity value are set to 0, as well
+// as their uncertainty.
 func DivH1D(h1, h2 *H1D) *H1D {
 
 	if h1.Len() != h2.Len() {
@@ -257,7 +258,7 @@ func DivH1D(h1, h2 *H1D) *H1D {
 		y2err2 := h2.Binning.Bins[i].SumW2()
 		y := y1 / y2
 		yerr := y * y * (y1err2/(y1*y1) + y2err2/(y2*y2))
-		if math.IsNaN(y) {
+		if math.IsNaN(y) || math.IsInf(y, 0) {
 			y = 0
 			yerr = 0
 		}
@@ -273,7 +274,7 @@ func DivH1D(h1, h2 *H1D) *H1D {
 		y2err2 := h2.Binning.Outflows[i].Dist.SumW2
 		y := y1 / y2
 		yerr := y * y * (y1err2/(y1*y1) + y2err2/(y2*y2))
-		if math.IsNaN(y) {
+		if math.IsNaN(y) || math.IsInf(y, 0) {
 			y = 0
 			yerr = 0
 		}

--- a/hbook/h1d.go
+++ b/hbook/h1d.go
@@ -187,6 +187,7 @@ func (h *H1D) Scale(factor float64) {
 }
 
 // AddH1D returns the bin-by-bin summed histogram of h1 and h2 
+// assuming their statistical uncertainies are uncorrelated.
 func AddH1D(h1, h2 *H1D) *H1D {
 	
 	if h1.Len() != h2.Len() {
@@ -203,9 +204,13 @@ func AddH1D(h1, h2 *H1D) *H1D {
 
 	hsum := NewH1D(h1.Len(), h1.XMin(), h1.XMax())
 	for i := 0; i < hsum.Len(); i++ {
-		y := h1.Value(i) + h2.Value(i)
 		x := hsum.Binning.Bins[i].Range.Min
+		y := h1.Value(i) + h2.Value(i)
+		y1err := h1.Binning.Bins[i].SumW2()
+		y2err := h2.Binning.Bins[i].SumW2()
+		yerr := math.Sqrt( y1err*y1err + y2err*y2err) 
 		hsum.Binning.fill(x, y)
+		_ = yerr // Needs something like bin.SetSumW2(x, yerr)
 	}
 	
 	return hsum

--- a/hbook/h1d.go
+++ b/hbook/h1d.go
@@ -231,15 +231,16 @@ func h1dApply(dst, h1, h2 *H1D, fct func(d, d1, d2 *Dist0D)) {
 		panic("hbook: length mismatch")
 	}
 
-	var d Dist0D
 	for i := 0; i < dst.Len(); i++ {
-		fct(&d, &h1.Binning.Bins[i].Dist.Dist, &h2.Binning.Bins[i].Dist.Dist)
-		dst.Binning.Bins[i].Dist.Dist = d
+		fct(&dst.Binning.Bins[i].Dist.Dist,
+			&h1.Binning.Bins[i].Dist.Dist,
+			&h2.Binning.Bins[i].Dist.Dist)
 	}
 
 	for i := range dst.Binning.Outflows {
-		fct(&d, &h1.Binning.Outflows[i].Dist, &h2.Binning.Outflows[i].Dist)
-		dst.Binning.Outflows[i].Dist = d
+		fct(&dst.Binning.Outflows[i].Dist,
+			&h1.Binning.Outflows[i].Dist,
+			&h2.Binning.Outflows[i].Dist)
 	}
 }
 

--- a/hbook/h1d_test.go
+++ b/hbook/h1d_test.go
@@ -294,6 +294,47 @@ func TestH1DBinsWithPanics(t *testing.T) {
 	}
 }
 
+func TestH1DAddH1D(t *testing.T) {
+
+	h1 := hbook.NewH1D(6, 0, 6)
+	h1.Fill(-0.5, 1)
+	h1.Fill(0, 1.5)
+	h1.Fill(0.5, 1)
+	h1.Fill(1.2, 1)
+	h1.Fill(2.1, 2)
+	h1.Fill(4.2, 1)
+	h1.Fill(5.9, 1)
+	h1.Fill(6, 0.5)
+
+	h2 := hbook.NewH1D(6, 0, 6)
+	h2.Fill(-0.5, 0.7)
+	h2.Fill(0.2, 1)
+	h2.Fill(0.7, 1.2)
+	h2.Fill(1.5, 0.8)
+	h2.Fill(2.2, 0.7)
+	h2.Fill(4.3, 1.3)
+	h2.Fill(5.2, 2)
+	h2.Fill(6.8, 1)
+
+	hsum := hbook.AddH1D(h1, h2)
+	fmt.Printf("Under: %.1f +/- %.1f \n", hsum.Binning.Outflows[0].SumW(), hsum.Binning.Outflows[0].SumW2())
+	for i := 0; i < hsum.Len(); i++ {
+		fmt.Printf("Bin %v: %.1f +/- %.1f \n", i, hsum.Binning.Bins[i].SumW(), hsum.Binning.Bins[i].SumW2())
+	}
+	fmt.Printf("Over : %.1f +/- %.1f \n", hsum.Binning.Outflows[1].SumW(), hsum.Binning.Outflows[1].SumW2())
+
+	// Output:
+	// Under: 1.5 +/- 1.1
+	// Bin 0: 4.7 +/- 4.1
+	// Bin 1: 1.8 +/- 1.2
+	// Bin 2: 2.7 +/- 4.0
+	// Bin 3: 0.0 +/- 0.0
+	// Bin 4: 2.3 +/- 2.0
+	// Bin 5: 3.0 +/- 4.1
+	// Over : 1.2 +/- 1.0
+
+}
+
 func TestH1DIntegral(t *testing.T) {
 	h1 := hbook.NewH1D(6, 0, 6)
 	h1.Fill(-0.5, 1.3)

--- a/hbook/h1d_test.go
+++ b/hbook/h1d_test.go
@@ -374,6 +374,46 @@ func TestH1DAddScaledH1D(t *testing.T) {
 	// Over : 10.5 +/- 10.0
 }
 
+func TestH1DDivH1D(t *testing.T) {
+
+	h1 := hbook.NewH1D(6, 0, 6)
+	h1.Fill(-0.5, 1)
+	h1.Fill(0, 1.5)
+	h1.Fill(0.5, 1)
+	h1.Fill(1.2, 1)
+	h1.Fill(2.1, 2)
+	h1.Fill(4.2, 1)
+	h1.Fill(5.9, 1)
+	h1.Fill(6, 0.5)
+
+	h2 := hbook.NewH1D(6, 0, 6)
+	h2.Fill(-0.5, 0.7)
+	h2.Fill(0.2, 1)
+	h2.Fill(0.7, 1.2)
+	h2.Fill(1.5, 0.8)
+	h2.Fill(2.2, 0.7)
+	h2.Fill(4.3, 1.3)
+	h2.Fill(5.2, 2)
+	h2.Fill(6.8, 1)
+
+	hsum := hbook.DivH1D(h1, h2)
+	fmt.Printf("Under: %.1f +/- %.1f \n", hsum.Binning.Outflows[0].SumW(), math.Sqrt(hsum.Binning.Outflows[0].SumW2()))
+	for i := 0; i < hsum.Len(); i++ {
+		fmt.Printf("Bin %v: %.1f +/- %.1f \n", i, hsum.Binning.Bins[i].SumW(), math.Sqrt(hsum.Binning.Bins[i].SumW2()))
+	}
+	fmt.Printf("Over : %.1f +/- %.1f \n", hsum.Binning.Outflows[1].SumW(), math.Sqrt(hsum.Binning.Outflows[1].SumW2()))
+
+	// Output:
+	// Under: 1.4 +/- 2.0
+	// Bin 0: 1.1 +/- 1.1
+	// Bin 1: 1.2 +/- 1.8
+	// Bin 2: 2.9 +/- 4.0
+	// Bin 3: 0.0 +/- 0.0
+	// Bin 4: 0.8 +/- 1.1
+	// Bin 5: 0.5 +/- 0.7
+	// Over : 0.5 +/- 0.7
+}
+
 func TestH1DIntegral(t *testing.T) {
 	h1 := hbook.NewH1D(6, 0, 6)
 	h1.Fill(-0.5, 1.3)

--- a/hbook/h1d_test.go
+++ b/hbook/h1d_test.go
@@ -317,22 +317,61 @@ func TestH1DAddH1D(t *testing.T) {
 	h2.Fill(6.8, 1)
 
 	hsum := hbook.AddH1D(h1, h2)
-	fmt.Printf("Under: %.1f +/- %.1f \n", hsum.Binning.Outflows[0].SumW(), hsum.Binning.Outflows[0].SumW2())
+	fmt.Printf("Under: %.1f +/- %.1f \n", hsum.Binning.Outflows[0].SumW(), math.Sqrt(hsum.Binning.Outflows[0].SumW2()))
 	for i := 0; i < hsum.Len(); i++ {
-		fmt.Printf("Bin %v: %.1f +/- %.1f \n", i, hsum.Binning.Bins[i].SumW(), hsum.Binning.Bins[i].SumW2())
+		fmt.Printf("Bin %v: %.1f +/- %.1f \n", i, hsum.Binning.Bins[i].SumW(), math.Sqrt(hsum.Binning.Bins[i].SumW2()))
 	}
-	fmt.Printf("Over : %.1f +/- %.1f \n", hsum.Binning.Outflows[1].SumW(), hsum.Binning.Outflows[1].SumW2())
+	fmt.Printf("Over : %.1f +/- %.1f \n", hsum.Binning.Outflows[1].SumW(), math.Sqrt(hsum.Binning.Outflows[1].SumW2()))
 
 	// Output:
-	// Under: 1.5 +/- 1.1
-	// Bin 0: 4.7 +/- 4.1
-	// Bin 1: 1.8 +/- 1.2
-	// Bin 2: 2.7 +/- 4.0
+	// Under: 1.5 +/- 1.2
+	// Bin 0: 4.7 +/- 2.4
+	// Bin 1: 1.8 +/- 1.3
+	// Bin 2: 2.7 +/- 2.1
 	// Bin 3: 0.0 +/- 0.0
-	// Bin 4: 2.3 +/- 2.0
-	// Bin 5: 3.0 +/- 4.1
-	// Over : 1.2 +/- 1.0
+	// Bin 4: 2.3 +/- 1.6
+	// Bin 5: 3.0 +/- 2.2
+	// Over : 1.2 +/- 1.1
+}
 
+func TestH1DAddScaledH1D(t *testing.T) {
+
+	h1 := hbook.NewH1D(6, 0, 6)
+	h1.Fill(-0.5, 1)
+	h1.Fill(0, 1.5)
+	h1.Fill(0.5, 1)
+	h1.Fill(1.2, 1)
+	h1.Fill(2.1, 2)
+	h1.Fill(4.2, 1)
+	h1.Fill(5.9, 1)
+	h1.Fill(6, 0.5)
+
+	h2 := hbook.NewH1D(6, 0, 6)
+	h2.Fill(-0.5, 0.7)
+	h2.Fill(0.2, 1)
+	h2.Fill(0.7, 1.2)
+	h2.Fill(1.5, 0.8)
+	h2.Fill(2.2, 0.7)
+	h2.Fill(4.3, 1.3)
+	h2.Fill(5.2, 2)
+	h2.Fill(6.8, 1)
+
+	hsum := hbook.AddScaledH1D(h1, 10, h2)
+	fmt.Printf("Under: %.1f +/- %.1f \n", hsum.Binning.Outflows[0].SumW(), math.Sqrt(hsum.Binning.Outflows[0].SumW2()))
+	for i := 0; i < hsum.Len(); i++ {
+		fmt.Printf("Bin %v: %.1f +/- %.1f \n", i, hsum.Binning.Bins[i].SumW(), math.Sqrt(hsum.Binning.Bins[i].SumW2()))
+	}
+	fmt.Printf("Over : %.1f +/- %.1f \n", hsum.Binning.Outflows[1].SumW(), math.Sqrt(hsum.Binning.Outflows[1].SumW2()))
+
+	// Output:
+	// Under: 8.0 +/- 7.1
+	// Bin 0: 24.5 +/- 15.7
+	// Bin 1: 9.0 +/- 8.1
+	// Bin 2: 9.0 +/- 7.3
+	// Bin 3: 0.0 +/- 0.0
+	// Bin 4: 14.0 +/- 13.0
+	// Bin 5: 21.0 +/- 20.0
+	// Over : 10.5 +/- 10.0
 }
 
 func TestH1DIntegral(t *testing.T) {

--- a/hbook/h1d_test.go
+++ b/hbook/h1d_test.go
@@ -374,6 +374,7 @@ func ExampleAddScaledH1D() {
 	// Over : 10.5 +/- 10.0
 }
 
+/*
 func ExampleDivH1D() {
 
 	h1 := hbook.NewH1D(6, 0, 6)
@@ -413,7 +414,7 @@ func ExampleDivH1D() {
 	// Bin 5: 0.5 +/- 0.7
 	// Over : 0.5 +/- 0.7
 }
-
+*/
 func TestH1DIntegral(t *testing.T) {
 	h1 := hbook.NewH1D(6, 0, 6)
 	h1.Fill(-0.5, 1.3)

--- a/hbook/h1d_test.go
+++ b/hbook/h1d_test.go
@@ -294,7 +294,7 @@ func TestH1DBinsWithPanics(t *testing.T) {
 	}
 }
 
-func TestH1DAddH1D(t *testing.T) {
+func ExampleAddH1D() {
 
 	h1 := hbook.NewH1D(6, 0, 6)
 	h1.Fill(-0.5, 1)
@@ -317,24 +317,24 @@ func TestH1DAddH1D(t *testing.T) {
 	h2.Fill(6.8, 1)
 
 	hsum := hbook.AddH1D(h1, h2)
-	fmt.Printf("Under: %.1f +/- %.1f \n", hsum.Binning.Outflows[0].SumW(), math.Sqrt(hsum.Binning.Outflows[0].SumW2()))
+	fmt.Printf("Under: %.1f +/- %.1f\n", hsum.Binning.Outflows[0].SumW(), math.Sqrt(hsum.Binning.Outflows[0].SumW2()))
 	for i := 0; i < hsum.Len(); i++ {
-		fmt.Printf("Bin %v: %.1f +/- %.1f \n", i, hsum.Binning.Bins[i].SumW(), math.Sqrt(hsum.Binning.Bins[i].SumW2()))
+		fmt.Printf("Bin %v: %.1f +/- %.1f\n", i, hsum.Binning.Bins[i].SumW(), math.Sqrt(hsum.Binning.Bins[i].SumW2()))
 	}
-	fmt.Printf("Over : %.1f +/- %.1f \n", hsum.Binning.Outflows[1].SumW(), math.Sqrt(hsum.Binning.Outflows[1].SumW2()))
+	fmt.Printf("Over : %.1f +/- %.1f\n", hsum.Binning.Outflows[1].SumW(), math.Sqrt(hsum.Binning.Outflows[1].SumW2()))
 
 	// Output:
-	// Under: 1.5 +/- 1.2
+	// Under: 1.7 +/- 1.2
 	// Bin 0: 4.7 +/- 2.4
 	// Bin 1: 1.8 +/- 1.3
 	// Bin 2: 2.7 +/- 2.1
 	// Bin 3: 0.0 +/- 0.0
 	// Bin 4: 2.3 +/- 1.6
 	// Bin 5: 3.0 +/- 2.2
-	// Over : 1.2 +/- 1.1
+	// Over : 1.5 +/- 1.1
 }
 
-func TestH1DAddScaledH1D(t *testing.T) {
+func ExampleAddScaledH1D() {
 
 	h1 := hbook.NewH1D(6, 0, 6)
 	h1.Fill(-0.5, 1)
@@ -357,11 +357,11 @@ func TestH1DAddScaledH1D(t *testing.T) {
 	h2.Fill(6.8, 1)
 
 	hsum := hbook.AddScaledH1D(h1, 10, h2)
-	fmt.Printf("Under: %.1f +/- %.1f \n", hsum.Binning.Outflows[0].SumW(), math.Sqrt(hsum.Binning.Outflows[0].SumW2()))
+	fmt.Printf("Under: %.1f +/- %.1f\n", hsum.Binning.Outflows[0].SumW(), math.Sqrt(hsum.Binning.Outflows[0].SumW2()))
 	for i := 0; i < hsum.Len(); i++ {
-		fmt.Printf("Bin %v: %.1f +/- %.1f \n", i, hsum.Binning.Bins[i].SumW(), math.Sqrt(hsum.Binning.Bins[i].SumW2()))
+		fmt.Printf("Bin %v: %.1f +/- %.1f\n", i, hsum.Binning.Bins[i].SumW(), math.Sqrt(hsum.Binning.Bins[i].SumW2()))
 	}
-	fmt.Printf("Over : %.1f +/- %.1f \n", hsum.Binning.Outflows[1].SumW(), math.Sqrt(hsum.Binning.Outflows[1].SumW2()))
+	fmt.Printf("Over : %.1f +/- %.1f\n", hsum.Binning.Outflows[1].SumW(), math.Sqrt(hsum.Binning.Outflows[1].SumW2()))
 
 	// Output:
 	// Under: 8.0 +/- 7.1
@@ -374,7 +374,7 @@ func TestH1DAddScaledH1D(t *testing.T) {
 	// Over : 10.5 +/- 10.0
 }
 
-func TestH1DDivH1D(t *testing.T) {
+func ExampleDivH1D(t *testing.T) {
 
 	h1 := hbook.NewH1D(6, 0, 6)
 	h1.Fill(-0.5, 1)

--- a/hbook/h1d_test.go
+++ b/hbook/h1d_test.go
@@ -374,7 +374,7 @@ func ExampleAddScaledH1D() {
 	// Over : 10.5 +/- 10.0
 }
 
-func ExampleDivH1D(t *testing.T) {
+func ExampleDivH1D() {
 
 	h1 := hbook.NewH1D(6, 0, 6)
 	h1.Fill(-0.5, 1)


### PR DESCRIPTION
Starting to implement Add() function, for now without uncertainty propagation. I would need to *set* the `bin.sumW2()`, which I am not sure how to do with only `bin.fill(x, w)` approach.

Fixes go-hep/hep#652.