### PR TITLE
Adding h.Error() function

### DIFF
--- a/hbook/h1d.go
+++ b/hbook/h1d.go
@@ -249,7 +249,7 @@ func (h *H1D) Value(i int) float64 {
 
 // Error returns the error, defined as sqrt(sumW2), of the idx-th bin.
 func (h *H1D) Error(i int) float64 {
-	return h.Binning.Bins[i].SumW2()
+	return math.Sqrt(h.Binning.Bins[i].SumW2())
 }
 
 // Len returns the number of bins for this histogram

--- a/hbook/h1d.go
+++ b/hbook/h1d.go
@@ -247,6 +247,11 @@ func (h *H1D) Value(i int) float64 {
 	return h.Binning.Bins[i].SumW()
 }
 
+// Error returns the error, defined as sqrt(sumW2), of the idx-th bin.
+func (h *H1D) Error(i int) float64 {
+	return h.Binning.Bins[i].SumW2()
+}
+
 // Len returns the number of bins for this histogram
 //
 // Len implements gonum/plot/plotter.Valuer

--- a/hbook/h1d_test.go
+++ b/hbook/h1d_test.go
@@ -354,6 +354,9 @@ func TestH1DIntegral(t *testing.T) {
 		if got, want := h2.Value(ibin), 1.0; got != want {
 			t.Errorf("got H1D.Value(%d) = %v. want %v\n", ibin, got, want)
 		}
+		if got, want := h2.Error(ibin), 1.0; got != want {
+			t.Errorf("got H1D.Error(%d) = %v. want %v\n", ibin, got, want)
+		}
 	}
 
 	if got, want := h2.Integral(), 2.0; got != want {


### PR DESCRIPTION
I am not sure this can be done respecting the logic of the code, given this comment for `h.Value()`
>  Value implements `gonum/plot/plotter.Valuer`

But if it is possible, here is the (super simple) function.

Fixes go-hep/hep#656.