### PR TITLE
Option to discard NaNs in hbook.DivideH1D()

### DIFF
--- a/fads/cmd/fads-rivet-mc-generic/mcalg.go
+++ b/fads/cmd/fads-rivet-mc-generic/mcalg.go
@@ -163,7 +163,7 @@ func (tsk *McGeneric) StopTask(ctx fwk.Context) error {
 		{tsk.hEtaPlusCh.Hist, tsk.hEtaMinusCh.Hist, tsk.hetaChPMRatio.Scatter},
 		{tsk.hRapPlusCh.Hist, tsk.hRapMinusCh.Hist, tsk.hrapChPMRatio.Scatter},
 	} {
-		res, err := hbook.DivideH1D(v.num, v.den, false)
+		res, err := hbook.DivideH1D(v.num, v.den)
 		if err != nil {
 			return err
 		}

--- a/fads/cmd/fads-rivet-mc-generic/mcalg.go
+++ b/fads/cmd/fads-rivet-mc-generic/mcalg.go
@@ -163,7 +163,7 @@ func (tsk *McGeneric) StopTask(ctx fwk.Context) error {
 		{tsk.hEtaPlusCh.Hist, tsk.hEtaMinusCh.Hist, tsk.hetaChPMRatio.Scatter},
 		{tsk.hRapPlusCh.Hist, tsk.hRapMinusCh.Hist, tsk.hrapChPMRatio.Scatter},
 	} {
-		res, err := hbook.DivideH1D(v.num, v.den)
+		res, err := hbook.DivideH1D(v.num, v.den, false)
 		if err != nil {
 			return err
 		}

--- a/hbook/ops.go
+++ b/hbook/ops.go
@@ -11,6 +11,7 @@ import (
 
 // DivideH1D divides 2 1D-histograms and returns a 2D scatter.
 // DivideH1D returns an error if the binning of the 1D histograms are not compatible.
+// DivideH1D ignores points with NaN values if ignoreNaN is true.
 func DivideH1D(num, den *H1D, ignoreNaN bool) (*S2D, error) {
 	var s2d S2D
 

--- a/hbook/ops.go
+++ b/hbook/ops.go
@@ -11,6 +11,7 @@ import (
 
 // DivideH1D divides 2 1D-histograms and returns a 2D scatter.
 // DivideH1D returns an error if the binning of the 1D histograms are not compatible.
+// If no DivOptions is passed, NaN raised during division are kept.
 func DivideH1D(num, den *H1D, opts ...DivOptions) (*S2D, error) {
 
 	cfg := newDivConfig()
@@ -38,8 +39,6 @@ func DivideH1D(num, den *H1D, opts ...DivOptions) (*S2D, error) {
 		exp := b1.XMax() - x
 
 		// assemble the y value and error
-		// TODO(sbinet): provide optional alternative behaviours to fill with NaN
-		//               or remove the invalid points
 		var y, ey float64
 		b2h := b2.SumW() / b2.XWidth() // height of the bin
 		b1h := b1.SumW() / b1.XWidth() // ditto
@@ -52,7 +51,7 @@ func DivideH1D(num, den *H1D, opts ...DivOptions) (*S2D, error) {
 				continue
 			} else {
 				y = cfg.replaceNaN
-				ey = 0.0 // TODO(rmadar): I guess this is the most senstive case
+				ey = 0.0 // TODO(rmadar): I guess this is the most sensitive case
 				// but another field could be added to divConfig
 			}
 		default:
@@ -78,8 +77,7 @@ func DivideH1D(num, den *H1D, opts ...DivOptions) (*S2D, error) {
 	return &s2d, nil
 }
 
-// DivOptions is type handling options of DivideH1D()
-// functions.
+// DivOptions allows to customize the behaviour of DivideH1D
 type DivOptions func(c *divConfig)
 
 // divConfig type specifies the possible configurations
@@ -95,16 +93,16 @@ func newDivConfig() *divConfig {
 	return &divConfig{replaceNaN: math.NaN()}
 }
 
-// DivIgnoreNaNs function returns an option of DivideH1D()
-// where NaN values are ignored.
+// DivIgnoreNaNs function configures DivideH1D to
+// ignore data points with NaNs.
 func DivIgnoreNaNs() DivOptions {
 	return func(c *divConfig) {
 		c.ignoreNaN = true
 	}
 }
 
-// DivReplaceNaNs function returns an option of DivideH1D()
-// where NaN values are replaced by v.
+// DivReplaceNaNs function configures DivideH1D to replace
+// NaN raised during divisions with the provided value.
 func DivReplaceNaNs(v float64) DivOptions {
 	return func(c *divConfig) {
 		c.replaceNaN = v

--- a/hbook/ops.go
+++ b/hbook/ops.go
@@ -11,7 +11,7 @@ import (
 
 // DivideH1D divides 2 1D-histograms and returns a 2D scatter.
 // DivideH1D returns an error if the binning of the 1D histograms are not compatible.
-func DivideH1D(num, den *H1D) (*S2D, error) {
+func DivideH1D(num, den *H1D, ignoreNaN bool) (*S2D, error) {
 	var s2d S2D
 
 	bins1 := num.Binning.Bins
@@ -44,6 +44,9 @@ func DivideH1D(num, den *H1D) (*S2D, error) {
 		case b2h == 0 || (b1h == 0 && b1herr != 0): // TODO(sbinet): is it OK?
 			y = math.NaN()
 			ey = math.NaN()
+			if ignoreNaN {
+				continue
+			}
 		default:
 			y = b1h / b2h
 			// TODO(sbinet): is this the exact error treatment for all (uncorrelated) cases?

--- a/hbook/ops_test.go
+++ b/hbook/ops_test.go
@@ -11,6 +11,73 @@ import (
 	"testing"
 )
 
+func ExampleDivideH1D(){
+
+	h1 := NewH1D(5, 0, 5)
+	h1.Fill(0, 1)
+	h1.Fill(1, 2)
+	h1.Fill(2, 3)
+	h1.Fill(3, 3)
+	h1.Fill(4, 4)
+
+	h2 := NewH1D(5, 0, 5)
+	h2.Fill(0, 11)
+	h2.Fill(1, 22)
+	h2.Fill(2, 0)
+	h2.Fill(3, 33)
+	h2.Fill(4, 44)
+
+	s0, err := DivideH1D(h1, h2)
+	if err != nil {
+		panic(err)
+	}
+	s1, err := DivideH1D(h1, h2, DivIgnoreNaNs())
+	if err != nil {
+		panic(err)
+	}
+	s2, err := DivideH1D(h1, h2, DivReplaceNaNs(1.0))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Default:")
+	for i, pt := range s0.Points() {
+		fmt.Printf("Point %v: %.2f  + %.2f  - %.2f\n", i, pt.Y, pt.ErrY.Min, pt.ErrY.Min)
+	}
+
+	fmt.Println("\nDivIgnoreNaNs:")
+	for i, pt := range s1.Points() {
+		fmt.Printf("Point %v: %.2f  + %.2f  - %.2f\n", i, pt.Y, pt.ErrY.Min, pt.ErrY.Min)
+	}
+
+	fmt.Println("\nDivReplaceNaNs with v=1.0:")
+	for i, pt := range s2.Points() {
+		fmt.Printf("Point %v: %.2f  + %.2f  - %.2f\n", i, pt.Y, pt.ErrY.Min, pt.ErrY.Min)
+	}
+	
+	// Output:
+	// Default:
+	// Point 0: 0.09  + 0.13  - 0.13
+	// Point 1: 0.09  + 0.13  - 0.13
+	// Point 2: NaN  + 0.00  - 0.00
+	// Point 3: 0.09  + 0.13  - 0.13
+	// Point 4: 0.09  + 0.13  - 0.13
+	//
+	// DivIgnoreNaNs:
+	// Point 0: 0.09  + 0.13  - 0.13
+	// Point 1: 0.09  + 0.13  - 0.13
+	// Point 2: 0.09  + 0.13  - 0.13
+	// Point 3: 0.09  + 0.13  - 0.13
+	// 
+	// DivReplaceNaNs with v=1.0:
+	// Point 0: 0.09  + 0.13  - 0.13
+	// Point 1: 0.09  + 0.13  - 0.13
+	// Point 2: 1.00  + 0.00  - 0.00
+	// Point 3: 0.09  + 0.13  - 0.13
+	// Point 4: 0.09  + 0.13  - 0.13
+}
+
+
 func TestDivideH1D(t *testing.T) {
 	h1 := NewH1D(5, 0, 5)
 	h2 := NewH1D(5, 0, 5)
@@ -252,3 +319,5 @@ END YODA_HISTO1D_V2
 		)
 	}
 }
+
+

--- a/hbook/ops_test.go
+++ b/hbook/ops_test.go
@@ -16,7 +16,7 @@ func TestDivideH1D(t *testing.T) {
 		h1.Fill(float64(i), float64(i+1))
 		h2.Fill(float64(i), float64(i+3))
 	}
-	s, err := DivideH1D(h1, h2)
+	s, err := DivideH1D(h1, h2, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/hbook/ops_test.go
+++ b/hbook/ops_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-func ExampleDivideH1D(){
+func ExampleDivideH1D() {
 
 	h1 := NewH1D(5, 0, 5)
 	h1.Fill(0, 1)
@@ -54,7 +54,7 @@ func ExampleDivideH1D(){
 	for i, pt := range s2.Points() {
 		fmt.Printf("Point %v: %.2f  + %.2f  - %.2f\n", i, pt.Y, pt.ErrY.Min, pt.ErrY.Min)
 	}
-	
+
 	// Output:
 	// Default:
 	// Point 0: 0.09  + 0.13  - 0.13
@@ -68,7 +68,7 @@ func ExampleDivideH1D(){
 	// Point 1: 0.09  + 0.13  - 0.13
 	// Point 2: 0.09  + 0.13  - 0.13
 	// Point 3: 0.09  + 0.13  - 0.13
-	// 
+	//
 	// DivReplaceNaNs with v=1.0:
 	// Point 0: 0.09  + 0.13  - 0.13
 	// Point 1: 0.09  + 0.13  - 0.13
@@ -76,7 +76,6 @@ func ExampleDivideH1D(){
 	// Point 3: 0.09  + 0.13  - 0.13
 	// Point 4: 0.09  + 0.13  - 0.13
 }
-
 
 func TestDivideH1D(t *testing.T) {
 	h1 := NewH1D(5, 0, 5)
@@ -319,5 +318,3 @@ END YODA_HISTO1D_V2
 		)
 	}
 }
-
-

--- a/hbook/ops_test.go
+++ b/hbook/ops_test.go
@@ -18,7 +18,7 @@ func TestDivideH1D(t *testing.T) {
 		h1.Fill(float64(i), float64(i+1))
 		h2.Fill(float64(i), float64(i+3))
 	}
-	s, err := DivideH1D(h1, h2, false)
+	s, err := DivideH1D(h1, h2)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Following https://github.com/go-hep/hep/issues/659, and ooking at https://github.com/go-hep/hep/blob/a50ee1ad8cc2d7923eec6c476508f67758d52379/hbook/ops.go#L35                                               
                                                                                                                                                      
I think we could just implement this way, *i.e.* explicitly ask to ignore NaN points. This could be done simply by                                    
```go
func DivideH1D(num, den *H1D, ignoreNaN bool) (*S2D, error) {
   for i := range bins1 { 
      // ... 
      switch {                                                                                                                                        
                case b2h == 0 || (b1h == 0 && b1herr != 0): // TODO(sbinet): is it OK?                
                        y = math.NaN()
                        ey = math.NaN() 
                        if ignoreNane {
                                continue
                        }
                //...
      }
     //...
     s2d.Fill(Point2D{X: x, Y: y, ErrX: Range{Min: exm, Max: exp}, ErrY: Range{Min: ey, Max: ey}}) 
   }
}                      
``` 
I have implemented a first version (modifying the corresponding test and `../fads/cmd/fads-rivet-mc-generic/mcalg.go`.