### PR TITLE
sliceop/f64s: improve performances of Take

### DIFF
--- a/sliceop/f64s/f64s.go
+++ b/sliceop/f64s/f64s.go
@@ -7,7 +7,6 @@ package f64s
 
 import (
 	"fmt"
-	"sort"
 )
 
 var (
@@ -82,10 +81,6 @@ func Find(dst []int, src []float64, f func(v float64) bool) []int {
 // Take will panic if length of indices is different from length of dst.
 func Take(dst, src []float64, indices []int) []float64 {
 
-	if !sort.IntsAreSorted(indices) {
-		panic(errSortedIndices)
-	}
-
 	if len(indices) > len(src) {
 		panic(errLength)
 	}
@@ -98,15 +93,21 @@ func Take(dst, src []float64, indices []int) []float64 {
 		panic(errLength)
 	}
 
-	dst = dst[:len(indices)]
+	if len(indices) == 0 {
+		return dst
+	}
 
-	set := make(map[int]struct{}, len(indices))
-	for i, v := range indices {
-		if _, dup := set[v]; dup {
+	dst[0] = src[indices[0]]
+	for i := 1; i < len(indices); i++ {
+		v0 := indices[i-1]
+		v1 := indices[i]
+		switch {
+		case v0 == v1:
 			panic(errDuplicateIndices)
+		case v0 > v1:
+			panic(errSortedIndices)
 		}
-		set[v] = struct{}{}
-		dst[i] = src[v]
+		dst[i] = src[v1]
 	}
 
 	return dst

--- a/sliceop/f64s/f64s_test.go
+++ b/sliceop/f64s/f64s_test.go
@@ -116,7 +116,7 @@ var takeSink []float64
 
 func BenchmarkTake(b *testing.B) {
 	for _, size := range []int{2, 4, 8, 128, 1024, 1024 * 1024} {
-		b.Run(fmt.Sprintf("%d", size), func(b *testing.B) {
+		b.Run(fmt.Sprintf("Len=%d", size), func(b *testing.B) {
 			src := make([]float64, size)
 			ind := make([]int, 0, len(src))
 			rnd := rand.New(rand.NewSource(0))
@@ -127,10 +127,9 @@ func BenchmarkTake(b *testing.B) {
 				}
 			}
 			dst := make([]float64, len(ind))
-
 			b.ReportAllocs()
-			b.ResetTimer()
 
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				takeSink = Take(dst, src, ind)
 			}


### PR DESCRIPTION
Reduce memory allocation:
- from populating the map and
- from using sort.IntsAreSorted.

also removed a loop over indices by removing sort.IntsAreSorted.

```
name                old time/op    new time/op    delta
Take/Len=2-4          63.5ns ± 3%     6.1ns ± 1%   -90.45%  (p=0.000 n=18+18)
Take/Len=4-4          82.7ns ± 2%     6.9ns ± 2%   -91.64%  (p=0.000 n=19+20)
Take/Len=8-4           116ns ± 2%       8ns ± 2%   -93.33%  (p=0.000 n=18+20)
Take/Len=128-4        4.03µs ± 1%    0.07µs ± 2%   -98.24%  (p=0.000 n=20+19)
Take/Len=1024-4       31.8µs ± 1%     0.5µs ± 3%   -98.44%  (p=0.000 n=17+19)
Take/Len=1048576-4    57.2ms ± 2%     3.1ms ± 4%   -94.61%  (p=0.000 n=19+20)

name                old alloc/op   new alloc/op   delta
Take/Len=2-4           32.0B ± 0%      0.0B       -100.00%  (p=0.000 n=20+20)
Take/Len=4-4           32.0B ± 0%      0.0B       -100.00%  (p=0.000 n=20+20)
Take/Len=8-4           32.0B ± 0%      0.0B       -100.00%  (p=0.000 n=20+20)
Take/Len=128-4        1.49kB ± 0%    0.00kB       -100.00%  (p=0.000 n=20+20)
Take/Len=1024-4       11.0kB ± 0%     0.0kB       -100.00%  (p=0.000 n=20+20)
Take/Len=1048576-4    11.2MB ± 0%     0.0MB       -100.00%  (p=0.000 n=18+20)

name                old allocs/op  new allocs/op  delta
Take/Len=2-4            1.00 ± 0%      0.00       -100.00%  (p=0.000 n=20+20)
Take/Len=4-4            1.00 ± 0%      0.00       -100.00%  (p=0.000 n=20+20)
Take/Len=8-4            1.00 ± 0%      0.00       -100.00%  (p=0.000 n=20+20)
Take/Len=128-4          3.00 ± 0%      0.00       -100.00%  (p=0.000 n=20+20)
Take/Len=1024-4         6.00 ± 0%      0.00       -100.00%  (p=0.000 n=20+20)
Take/Len=1048576-4      19.0 ± 0%       0.0       -100.00%  (p=0.000 n=20+20)
```