### PR TITLE
hep: use gomacro from go-hep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,3 +37,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71
 	modernc.org/ql v1.0.1
 )
+
+replace github.com/cosmos72/gomacro => github.com/go-hep/gomacro v0.0.0-20200506165324-d28799dcbb28

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,6 @@ github.com/astrogo/fitsio v0.1.0/go.mod h1:AMazbBDPn8fcAglKAWIR5+5iDBnBv78pf6UHm
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/campoy/embedmd v1.0.0 h1:V4kI2qTJJLf4J29RzI/MAt2c3Bl4dQSYPuflzwFH2hY=
 github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX3MzVl8=
-github.com/cosmos72/gomacro v0.0.0-20200226185326-30b9859a00de h1:gUJE5bKlPtnxETIo4fczG4lOybE/q07wnkkANJTZLko=
-github.com/cosmos72/gomacro v0.0.0-20200226185326-30b9859a00de/go.mod h1:Osdpin0EoLKzHqueN0M7mrcai0vkT6+WfVM4L1mK46M=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -35,6 +33,8 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4 h1:WtGNWLvXpe6ZudgnXrq0barxBImvnnJoMEhXAzcbM0I=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-hep/gomacro v0.0.0-20200506165324-d28799dcbb28 h1:JT/NZ8e7apWD5gTlJ0u7/5wLtvcCWlmp7B/1Wpu7eIg=
+github.com/go-hep/gomacro v0.0.0-20200506165324-d28799dcbb28/go.mod h1:Osdpin0EoLKzHqueN0M7mrcai0vkT6+WfVM4L1mK46M=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=


### PR DESCRIPTION
this CL uses a hopefully temporary fork of gomacro that doesn't import
testing/quick.