### PR TITLE
Groot reader perf

### DIFF
--- a/groot/gen.rtree.go
+++ b/groot/gen.rtree.go
@@ -162,7 +162,7 @@ func genLeaves() {
 			LenType:             4,
 			GoLenType:           int(reflect.TypeOf(root.Float16(0)).Size()),
 			RFunc:               "r.ReadF16(leaf.elm)",
-			RFuncArray:          "r.ReadFastArrayF16",
+			RFuncArray:          "r.ReadArrayF16",
 			ResizeFunc:          "rbytes.ResizeF16",
 			WFunc:               "w.WriteF16",
 			WFuncArray:          "w.WriteFastArrayF16",
@@ -176,7 +176,7 @@ func genLeaves() {
 			LenType:             8,
 			GoLenType:           int(reflect.TypeOf(root.Double32(0)).Size()),
 			RFunc:               "r.ReadD32(leaf.elm)",
-			RFuncArray:          "r.ReadFastArrayD32",
+			RFuncArray:          "r.ReadArrayD32",
 			ResizeFunc:          "rbytes.ResizeD32",
 			WFunc:               "w.WriteD32",
 			WFuncArray:          "w.WriteFastArrayD32",
@@ -398,19 +398,19 @@ func (leaf *{{.Name}}) readFromBuffer(r *rbytes.RBuffer) error {
                         if n > max {
                                 n = max
                         }
-{{- if .WithStreamerElement}}
-                        *leaf.sli = {{.RFuncArray}}(leaf.tleaf.len * n, leaf.elm)
-{{- else}}
 						nn := leaf.tleaf.len * n
 						*leaf.sli = {{.ResizeFunc}}(*leaf.sli, nn)
+{{- if .WithStreamerElement}}
+                        {{.RFuncArray}}(*leaf.sli, leaf.elm)
+{{- else}}
                         {{.RFuncArray}}(*leaf.sli)
 {{- end}}
                 } else {
-{{- if .WithStreamerElement}}
-						copy(*leaf.sli, {{.RFuncArray}}(leaf.tleaf.len, leaf.elm))
-{{- else}}
 						nn := leaf.tleaf.len
 						*leaf.sli = {{.ResizeFunc}}(*leaf.sli, nn)
+{{- if .WithStreamerElement}}
+						{{.RFuncArray}}(*leaf.sli, leaf.elm)
+{{- else}}
 						{{.RFuncArray}}(*leaf.sli)
 {{- end}}
                 }

--- a/groot/gen.rtree.go
+++ b/groot/gen.rtree.go
@@ -393,10 +393,6 @@ func (leaf *{{.Name}}) readFromBuffer(r *rbytes.RBuffer) error {
                 *leaf.ptr = {{.RFunc}}
         } else {
                 if leaf.count != nil {
-                        entry := leaf.Branch().getReadEntry()
-                        if leaf.count.Branch().getReadEntry() != entry {
-                                leaf.count.Branch().getEntry(entry)
-                        }
                         n := leaf.count.ivalue()
                         max := leaf.count.imax()
                         if n > max {

--- a/groot/gen.rtree.go
+++ b/groot/gen.rtree.go
@@ -385,37 +385,37 @@ func (leaf *{{.Name}}) UnmarshalROOT(r *rbytes.RBuffer) error {
 }
 
 func (leaf *{{.Name}}) readFromBuffer(r *rbytes.RBuffer) error {
-        if r.Err() != nil {
-                return r.Err()
-        }
+	if r.Err() != nil {
+		return r.Err()
+	}
 
-        if leaf.count == nil && leaf.ptr != nil {
-                *leaf.ptr = {{.RFunc}}
-        } else {
-                if leaf.count != nil {
-                        n := leaf.count.ivalue()
-                        max := leaf.count.imax()
-                        if n > max {
-                                n = max
-                        }
-						nn := leaf.tleaf.len * n
-						*leaf.sli = {{.ResizeFunc}}(*leaf.sli, nn)
-{{- if .WithStreamerElement}}
-                        {{.RFuncArray}}(*leaf.sli, leaf.elm)
-{{- else}}
-                        {{.RFuncArray}}(*leaf.sli)
-{{- end}}
-                } else {
-						nn := leaf.tleaf.len
-						*leaf.sli = {{.ResizeFunc}}(*leaf.sli, nn)
-{{- if .WithStreamerElement}}
-						{{.RFuncArray}}(*leaf.sli, leaf.elm)
-{{- else}}
-						{{.RFuncArray}}(*leaf.sli)
-{{- end}}
+	if leaf.count == nil && leaf.ptr != nil {
+		*leaf.ptr = {{.RFunc}}
+	} else {
+            if leaf.count != nil {
+                n := leaf.count.ivalue()
+                max := leaf.count.imax()
+                if n > max {
+                        n = max
                 }
-        }
-        return r.Err()
+				nn := leaf.tleaf.len * n
+				*leaf.sli = {{.ResizeFunc}}(*leaf.sli, nn)
+{{- if .WithStreamerElement}}
+                {{.RFuncArray}}(*leaf.sli, leaf.elm)
+{{- else}}
+                {{.RFuncArray}}(*leaf.sli)
+{{- end}}
+            } else {
+				nn := leaf.tleaf.len
+				*leaf.sli = {{.ResizeFunc}}(*leaf.sli, nn)
+{{- if .WithStreamerElement}}
+				{{.RFuncArray}}(*leaf.sli, leaf.elm)
+{{- else}}
+				{{.RFuncArray}}(*leaf.sli)
+{{- end}}
+            }
+    }
+    return r.Err()
 }
 
 func (leaf *{{.Name}}) scan(r *rbytes.RBuffer, ptr interface{}) error {

--- a/groot/rbytes/rbuffer.go
+++ b/groot/rbytes/rbuffer.go
@@ -58,7 +58,7 @@ func (r *rbuff) Seek(offset int64, whence int) (int64, error) {
 
 // RBuffer is a read-only ROOT buffer for streaming.
 type RBuffer struct {
-	r      *rbuff
+	r      rbuff
 	err    error
 	offset uint32
 	refs   map[int64]interface{}
@@ -71,7 +71,7 @@ func NewRBuffer(data []byte, refs map[int64]interface{}, offset uint32, ctx Stre
 	}
 
 	return &RBuffer{
-		r:      &rbuff{p: data, c: 0},
+		r:      rbuff{p: data, c: 0},
 		refs:   refs,
 		offset: offset,
 		sictx:  ctx,

--- a/groot/rbytes/rbuffer.go
+++ b/groot/rbytes/rbuffer.go
@@ -400,42 +400,33 @@ func (r *RBuffer) ReadArrayU8(arr []uint8) {
 	}
 }
 
-func (r *RBuffer) ReadFastArrayF16(n int, elm StreamerElement) []root.Float16 {
+func (r *RBuffer) ReadArrayF16(arr []root.Float16, elm StreamerElement) {
 	if r.err != nil {
-		return nil
+		return
 	}
+	n := len(arr)
 	if n <= 0 || int64(n) > r.Len() {
-		return nil
+		return
 	}
 
-	arr := make([]root.Float16, n)
 	for i := range arr {
 		arr[i] = r.ReadF16(elm)
 	}
-
-	if r.err != nil {
-		return nil
-	}
-	return arr
 }
 
-func (r *RBuffer) ReadFastArrayD32(n int, elm StreamerElement) []root.Double32 {
+func (r *RBuffer) ReadArrayD32(arr []root.Double32, elm StreamerElement) {
 	if r.err != nil {
-		return nil
-	}
-	if n <= 0 || int64(n) > r.Len() {
-		return nil
+		return
 	}
 
-	arr := make([]root.Double32, n)
+	n := len(arr)
+	if n <= 0 || int64(n) > r.Len() {
+		return
+	}
+
 	for i := range arr {
 		arr[i] = r.ReadD32(elm)
 	}
-
-	if r.err != nil {
-		return nil
-	}
-	return arr
 }
 
 func (r *RBuffer) ReadArrayString(arr []string) {

--- a/groot/rbytes/rw_test.go
+++ b/groot/rbytes/rw_test.go
@@ -150,7 +150,8 @@ func TestRWFloat16(t *testing.T) {
 			}
 
 			rbuf := rbytes.NewRBuffer(wbuf.Bytes(), nil, 0, nil)
-			got := rbuf.ReadFastArrayF16(1, elm)
+			got := make([]root.Float16, 1)
+			rbuf.ReadArrayF16(got, elm)
 			if err := rbuf.Err(); err != nil {
 				t.Fatalf("could not read f16=%v: %+v", tc.v, err)
 			}
@@ -224,7 +225,8 @@ func TestRWDouble32(t *testing.T) {
 			}
 
 			rbuf := rbytes.NewRBuffer(wbuf.Bytes(), nil, 0, nil)
-			got := rbuf.ReadFastArrayD32(1, elm)
+			got := make([]root.Double32, 1)
+			rbuf.ReadArrayD32(got, elm)
 			if err := rbuf.Err(); err != nil {
 				t.Fatalf("could not read d32=%v: %+v", tc.v, err)
 			}

--- a/groot/rtree/basket.go
+++ b/groot/rtree/basket.go
@@ -251,18 +251,7 @@ func (b *Basket) UnmarshalROOT(r *rbytes.RBuffer) error {
 	return r.Err()
 }
 
-func (b *Basket) loadEntry(entry int64) error {
-	var err error
-	var offset = int64(b.key.KeyLen())
-	if len(b.offsets) > 0 {
-		offset = int64(b.offsets[int(entry)])
-	}
-	pos := entry*int64(b.nevsize) + offset
-	err = b.rbuf.SetPos(pos)
-	return err
-}
-
-func (b *Basket) readLeaf(entry int64, leaf Leaf) error {
+func (b *Basket) loadLeaf(entry int64, leaf Leaf) error {
 	var offset int64
 	if len(b.offsets) == 0 {
 		offset = entry*int64(b.nevsize) + int64(leaf.Offset()) + int64(b.key.KeyLen())

--- a/groot/rtree/branch.go
+++ b/groot/rtree/branch.go
@@ -225,6 +225,9 @@ func (b *tbranch) getReadEntry() int64 {
 }
 
 func (b *tbranch) getEntry(i int64) {
+	if b.ctx.entry == i {
+		return
+	}
 	err := b.loadEntry(i)
 	if err != nil {
 		panic(fmt.Errorf("rtree: branch [%s] failed to load entry %d: %w", b.Name(), i, err))

--- a/groot/rtree/branch.go
+++ b/groot/rtree/branch.go
@@ -589,11 +589,6 @@ func (b *tbranch) loadEntry(ientry int64) error {
 	b.firstEntry = b.ctx.first
 
 	jentry := ientry - b.ctx.first
-	err = b.ctx.bk.loadEntry(jentry)
-	if err != nil {
-		return err
-	}
-
 	switch len(b.leaves) {
 	case 1:
 		err = b.ctx.bk.readLeaf(jentry, b.leaves[0])

--- a/groot/rtree/branch.go
+++ b/groot/rtree/branch.go
@@ -591,13 +591,13 @@ func (b *tbranch) loadEntry(ientry int64) error {
 	jentry := ientry - b.ctx.first
 	switch len(b.leaves) {
 	case 1:
-		err = b.ctx.bk.readLeaf(jentry, b.leaves[0])
+		err = b.ctx.bk.loadLeaf(jentry, b.leaves[0])
 		if err != nil {
 			return err
 		}
 	default:
 		for _, leaf := range b.leaves {
-			err = b.ctx.bk.readLeaf(jentry, leaf)
+			err = b.ctx.bk.loadLeaf(jentry, leaf)
 			if err != nil {
 				return err
 			}

--- a/groot/rtree/branch.go
+++ b/groot/rtree/branch.go
@@ -53,7 +53,7 @@ type tbranch struct {
 
 	ctx basketCtx // basket context for the current basket
 
-	tree Tree            // tree header
+	tree *ttree          // tree header
 	btop Branch          // top-level parent branch in the tree
 	bup  Branch          // parent branch
 	dir  riofs.Directory // directory where this branch's buffers are stored
@@ -155,11 +155,11 @@ func (b *tbranch) Class() string {
 	return "TBranch"
 }
 
-func (b *tbranch) getTree() Tree {
+func (b *tbranch) getTree() *ttree {
 	return b.tree
 }
 
-func (b *tbranch) setTree(t Tree) {
+func (b *tbranch) setTree(t *ttree) {
 	b.tree = t
 	for _, sub := range b.branches {
 		sub.setTree(t)

--- a/groot/rtree/branch.go
+++ b/groot/rtree/branch.go
@@ -424,16 +424,16 @@ func (b *tbranch) UnmarshalROOT(r *rbytes.RBuffer) error {
 			if err := baskets.UnmarshalROOT(r); err != nil {
 				return err
 			}
-			b.baskets = make([]Basket, 0, baskets.Last()+1)
-			for i := 0; i < baskets.Last()+1; i++ {
+
+			b.baskets = make([]Basket, baskets.Last()+1)
+			for i := range b.baskets {
 				bkt := baskets.At(i)
 				// FIXME(sbinet) check why some are nil
 				if bkt == nil {
-					b.baskets = append(b.baskets, Basket{})
 					continue
 				}
 				bk := bkt.(*Basket)
-				b.baskets = append(b.baskets, *bk)
+				b.baskets[i] = *bk
 			}
 		}
 
@@ -515,16 +515,15 @@ func (b *tbranch) UnmarshalROOT(r *rbytes.RBuffer) error {
 			if err := baskets.UnmarshalROOT(r); err != nil {
 				return err
 			}
-			b.baskets = make([]Basket, 0, baskets.Last()+1)
-			for i := 0; i < baskets.Last()+1; i++ {
+			b.baskets = make([]Basket, baskets.Last()+1)
+			for i := range b.baskets {
 				bkt := baskets.At(i)
 				// FIXME(sbinet) check why some are nil
 				if bkt == nil {
-					b.baskets = append(b.baskets, Basket{})
 					continue
 				}
 				bk := bkt.(*Basket)
-				b.baskets = append(b.baskets, *bk)
+				b.baskets[i] = *bk
 			}
 		}
 

--- a/groot/rtree/leaf_gen.go
+++ b/groot/rtree/leaf_gen.go
@@ -1984,9 +1984,13 @@ func (leaf *LeafF16) readFromBuffer(r *rbytes.RBuffer) error {
 			if n > max {
 				n = max
 			}
-			*leaf.sli = r.ReadFastArrayF16(leaf.tleaf.len*n, leaf.elm)
+			nn := leaf.tleaf.len * n
+			*leaf.sli = rbytes.ResizeF16(*leaf.sli, nn)
+			r.ReadArrayF16(*leaf.sli, leaf.elm)
 		} else {
-			copy(*leaf.sli, r.ReadFastArrayF16(leaf.tleaf.len, leaf.elm))
+			nn := leaf.tleaf.len
+			*leaf.sli = rbytes.ResizeF16(*leaf.sli, nn)
+			r.ReadArrayF16(*leaf.sli, leaf.elm)
 		}
 	}
 	return r.Err()
@@ -2231,9 +2235,13 @@ func (leaf *LeafD32) readFromBuffer(r *rbytes.RBuffer) error {
 			if n > max {
 				n = max
 			}
-			*leaf.sli = r.ReadFastArrayD32(leaf.tleaf.len*n, leaf.elm)
+			nn := leaf.tleaf.len * n
+			*leaf.sli = rbytes.ResizeD32(*leaf.sli, nn)
+			r.ReadArrayD32(*leaf.sli, leaf.elm)
 		} else {
-			copy(*leaf.sli, r.ReadFastArrayD32(leaf.tleaf.len, leaf.elm))
+			nn := leaf.tleaf.len
+			*leaf.sli = rbytes.ResizeD32(*leaf.sli, nn)
+			r.ReadArrayD32(*leaf.sli, leaf.elm)
 		}
 	}
 	return r.Err()

--- a/groot/rtree/leaf_gen.go
+++ b/groot/rtree/leaf_gen.go
@@ -131,10 +131,6 @@ func (leaf *LeafO) readFromBuffer(r *rbytes.RBuffer) error {
 		*leaf.ptr = r.ReadBool()
 	} else {
 		if leaf.count != nil {
-			entry := leaf.Branch().getReadEntry()
-			if leaf.count.Branch().getReadEntry() != entry {
-				leaf.count.Branch().getEntry(entry)
-			}
 			n := leaf.count.ivalue()
 			max := leaf.count.imax()
 			if n > max {
@@ -389,10 +385,6 @@ func (leaf *LeafB) readFromBuffer(r *rbytes.RBuffer) error {
 		*leaf.ptr = r.ReadI8()
 	} else {
 		if leaf.count != nil {
-			entry := leaf.Branch().getReadEntry()
-			if leaf.count.Branch().getReadEntry() != entry {
-				leaf.count.Branch().getEntry(entry)
-			}
 			n := leaf.count.ivalue()
 			max := leaf.count.imax()
 			if n > max {
@@ -673,10 +665,6 @@ func (leaf *LeafS) readFromBuffer(r *rbytes.RBuffer) error {
 		*leaf.ptr = r.ReadI16()
 	} else {
 		if leaf.count != nil {
-			entry := leaf.Branch().getReadEntry()
-			if leaf.count.Branch().getReadEntry() != entry {
-				leaf.count.Branch().getEntry(entry)
-			}
 			n := leaf.count.ivalue()
 			max := leaf.count.imax()
 			if n > max {
@@ -957,10 +945,6 @@ func (leaf *LeafI) readFromBuffer(r *rbytes.RBuffer) error {
 		*leaf.ptr = r.ReadI32()
 	} else {
 		if leaf.count != nil {
-			entry := leaf.Branch().getReadEntry()
-			if leaf.count.Branch().getReadEntry() != entry {
-				leaf.count.Branch().getEntry(entry)
-			}
 			n := leaf.count.ivalue()
 			max := leaf.count.imax()
 			if n > max {
@@ -1241,10 +1225,6 @@ func (leaf *LeafL) readFromBuffer(r *rbytes.RBuffer) error {
 		*leaf.ptr = r.ReadI64()
 	} else {
 		if leaf.count != nil {
-			entry := leaf.Branch().getReadEntry()
-			if leaf.count.Branch().getReadEntry() != entry {
-				leaf.count.Branch().getEntry(entry)
-			}
 			n := leaf.count.ivalue()
 			max := leaf.count.imax()
 			if n > max {
@@ -1508,10 +1488,6 @@ func (leaf *LeafF) readFromBuffer(r *rbytes.RBuffer) error {
 		*leaf.ptr = r.ReadF32()
 	} else {
 		if leaf.count != nil {
-			entry := leaf.Branch().getReadEntry()
-			if leaf.count.Branch().getReadEntry() != entry {
-				leaf.count.Branch().getEntry(entry)
-			}
 			n := leaf.count.ivalue()
 			max := leaf.count.imax()
 			if n > max {
@@ -1752,10 +1728,6 @@ func (leaf *LeafD) readFromBuffer(r *rbytes.RBuffer) error {
 		*leaf.ptr = r.ReadF64()
 	} else {
 		if leaf.count != nil {
-			entry := leaf.Branch().getReadEntry()
-			if leaf.count.Branch().getReadEntry() != entry {
-				leaf.count.Branch().getEntry(entry)
-			}
 			n := leaf.count.ivalue()
 			max := leaf.count.imax()
 			if n > max {
@@ -2007,10 +1979,6 @@ func (leaf *LeafF16) readFromBuffer(r *rbytes.RBuffer) error {
 		*leaf.ptr = r.ReadF16(leaf.elm)
 	} else {
 		if leaf.count != nil {
-			entry := leaf.Branch().getReadEntry()
-			if leaf.count.Branch().getReadEntry() != entry {
-				leaf.count.Branch().getEntry(entry)
-			}
 			n := leaf.count.ivalue()
 			max := leaf.count.imax()
 			if n > max {
@@ -2258,10 +2226,6 @@ func (leaf *LeafD32) readFromBuffer(r *rbytes.RBuffer) error {
 		*leaf.ptr = r.ReadD32(leaf.elm)
 	} else {
 		if leaf.count != nil {
-			entry := leaf.Branch().getReadEntry()
-			if leaf.count.Branch().getReadEntry() != entry {
-				leaf.count.Branch().getEntry(entry)
-			}
 			n := leaf.count.ivalue()
 			max := leaf.count.imax()
 			if n > max {
@@ -2498,10 +2462,6 @@ func (leaf *LeafC) readFromBuffer(r *rbytes.RBuffer) error {
 		*leaf.ptr = r.ReadString()
 	} else {
 		if leaf.count != nil {
-			entry := leaf.Branch().getReadEntry()
-			if leaf.count.Branch().getReadEntry() != entry {
-				leaf.count.Branch().getEntry(entry)
-			}
 			n := leaf.count.ivalue()
 			max := leaf.count.imax()
 			if n > max {

--- a/groot/rtree/rtree.go
+++ b/groot/rtree/rtree.go
@@ -42,8 +42,8 @@ type Branch interface {
 	Branch(name string) Branch
 	Leaf(name string) Leaf
 
-	setTree(Tree)
-	getTree() Tree
+	setTree(*ttree)
+	getTree() *ttree
 	loadEntry(i int64) error
 	getReadEntry() int64
 	getEntry(i int64)

--- a/groot/rtree/rw_test.go
+++ b/groot/rtree/rw_test.go
@@ -261,9 +261,11 @@ func TestBranchRW(t *testing.T) {
 				fname:          "foo.root",
 
 				//
-				readentry:   -1,
-				firstbasket: -1,
-				nextbasket:  -1,
+				ctx: basketCtx{
+					entry: -1,
+					first: -1,
+					next:  -1,
+				},
 			},
 		},
 		{
@@ -296,9 +298,11 @@ func TestBranchRW(t *testing.T) {
 				fname:       "foo.root",
 
 				//
-				readentry:   -1,
-				firstbasket: -1,
-				nextbasket:  -1,
+				ctx: basketCtx{
+					entry: -1,
+					first: -1,
+					next:  -1,
+				},
 			},
 		},
 		{
@@ -342,9 +346,11 @@ func TestBranchRW(t *testing.T) {
 				fname:       "foo.root",
 
 				//
-				readentry:   -1,
-				firstbasket: -1,
-				nextbasket:  -1,
+				ctx: basketCtx{
+					entry: -1,
+					first: -1,
+					next:  -1,
+				},
 			},
 		},
 		{
@@ -389,9 +395,11 @@ func TestBranchRW(t *testing.T) {
 					fname:       "foo.root",
 
 					//
-					readentry:   -1,
-					firstbasket: -1,
-					nextbasket:  -1,
+					ctx: basketCtx{
+						entry: -1,
+						first: -1,
+						next:  -1,
+					},
 				},
 				class:  "myclass",
 				parent: "parentclass",
@@ -447,9 +455,11 @@ func TestBranchRW(t *testing.T) {
 					fname:       "foo.root",
 
 					//
-					readentry:   -1,
-					firstbasket: -1,
-					nextbasket:  -1,
+					ctx: basketCtx{
+						entry: -1,
+						first: -1,
+						next:  -1,
+					},
 				},
 				class:  "myclass",
 				parent: "parentclass",
@@ -500,9 +510,11 @@ func TestBranchRW(t *testing.T) {
 						fname:       "foo.root",
 
 						//
-						readentry:   -1,
-						firstbasket: -1,
-						nextbasket:  -1,
+						ctx: basketCtx{
+							entry: -1,
+							first: -1,
+							next:  -1,
+						},
 					},
 					class:  "myotherclass",
 					parent: "parentclass",

--- a/groot/rtree/scanner.go
+++ b/groot/rtree/scanner.go
@@ -738,7 +738,8 @@ func (s *Scanner) Scan() error {
 		}
 	}
 
-	for _, br := range s.scan.ibr {
+	for i := range s.scan.ibr {
+		br := &s.scan.ibr[i]
 		if br.dup {
 			continue
 		}


### PR DESCRIPTION
a set of various optimisations that bring:

```
$> benchstat ref.txt new.txt
name                      old time/op    new time/op    delta
ReadTreeF64-4                483µs ± 3%     437µs ± 5%   -9.58%  (p=0.000 n=19+20)
ReadTreeSliF64/0-4           213µs ± 2%     154µs ± 2%  -27.57%  (p=0.000 n=20+19)
ReadTreeSliF64/1-4           213µs ± 1%     154µs ± 3%  -27.87%  (p=0.000 n=20+18)
ReadTreeSliF64/2-4           214µs ± 3%     156µs ± 4%  -27.31%  (p=0.000 n=20+20)
ReadTreeSliF64/4-4           214µs ± 3%     156µs ± 6%  -27.11%  (p=0.000 n=19+20)
ReadTreeSliF64/8-4           214µs ± 2%     155µs ± 5%  -27.50%  (p=0.000 n=18+20)
ReadTreeSliF64/16-4          214µs ± 3%     155µs ± 4%  -27.66%  (p=0.000 n=20+20)
ReadTreeSliF64/64-4          213µs ± 2%     155µs ± 3%  -27.14%  (p=0.000 n=20+20)
ReadTreeSliF64/128-4         216µs ± 4%     155µs ± 2%  -28.25%  (p=0.000 n=20+20)
ReadTreeSliF64/512-4         213µs ± 2%     157µs ± 3%  -26.34%  (p=0.000 n=19+19)
ReadTreeSliF64/1024-4        213µs ± 1%     155µs ± 1%  -27.43%  (p=0.000 n=17+16)
ReadTreeSliF64/1048576-4     213µs ± 2%     156µs ± 3%  -26.91%  (p=0.000 n=19+19)

name                      old alloc/op   new alloc/op   delta
ReadTreeF64-4                27.0B ± 0%     24.4B ± 6%   -9.47%  (p=0.000 n=15+18)
ReadTreeSliF64/0-4           10.0B ± 0%      7.3B ±10%  -27.00%  (p=0.000 n=14+20)
ReadTreeSliF64/1-4           10.0B ± 0%      7.0B ± 0%  -30.00%  (p=0.000 n=14+19)
ReadTreeSliF64/2-4           9.74B ± 8%     7.00B ± 0%  -28.11%  (p=0.000 n=19+20)
ReadTreeSliF64/4-4           10.0B ± 0%      7.0B ± 0%  -30.00%  (p=0.000 n=16+18)
ReadTreeSliF64/8-4           10.0B ± 0%      7.0B ± 0%  -30.00%  (p=0.000 n=14+19)
ReadTreeSliF64/16-4          10.0B ± 0%      7.0B ± 0%  -30.00%  (p=0.000 n=15+18)
ReadTreeSliF64/64-4          9.74B ± 8%     7.00B ± 0%  -28.11%  (p=0.000 n=19+18)
ReadTreeSliF64/128-4         10.0B ± 0%      7.0B ± 0%  -30.00%  (p=0.000 n=15+19)
ReadTreeSliF64/512-4         10.0B ± 0%      7.0B ± 0%  -30.00%  (p=0.000 n=16+19)
ReadTreeSliF64/1024-4        9.69B ± 7%     7.00B ± 0%  -27.74%  (p=0.000 n=16+17)
ReadTreeSliF64/1048576-4     10.0B ± 0%      7.0B ± 0%  -30.00%  (p=0.000 n=13+18)

name                      old allocs/op  new allocs/op  delta
ReadTreeF64-4                 0.00           0.00          ~     (all equal)
ReadTreeSliF64/0-4            0.00           0.00          ~     (all equal)
ReadTreeSliF64/1-4            0.00           0.00          ~     (all equal)
ReadTreeSliF64/2-4            0.00           0.00          ~     (all equal)
ReadTreeSliF64/4-4            0.00           0.00          ~     (all equal)
ReadTreeSliF64/8-4            0.00           0.00          ~     (all equal)
ReadTreeSliF64/16-4           0.00           0.00          ~     (all equal)
ReadTreeSliF64/64-4           0.00           0.00          ~     (all equal)
ReadTreeSliF64/128-4          0.00           0.00          ~     (all equal)
ReadTreeSliF64/512-4          0.00           0.00          ~     (all equal)
ReadTreeSliF64/1024-4         0.00           0.00          ~     (all equal)
ReadTreeSliF64/1048576-4      0.00           0.00          ~     (all equal)
```