### PR TITLE
groot/rtree{,/rfunc}: introduce rfunc.Formula protocol

### DIFF
--- a/groot/rtree/example_reader_test.go
+++ b/groot/rtree/example_reader_test.go
@@ -10,6 +10,7 @@ import (
 
 	"go-hep.org/x/hep/groot"
 	"go-hep.org/x/hep/groot/rtree"
+	"go-hep.org/x/hep/groot/rtree/rfunc"
 )
 
 func ExampleReader() {
@@ -265,7 +266,7 @@ func ExampleReader_withFormulaFunc() {
 	err = r.Read(func(ctx rtree.RCtx) error {
 		v64 := f1()
 		str := f2()
-		fmt.Printf("evt[%d]: %v, %v, %v -> %g %g | %s\n", ctx.Entry, data.V1, data.V2, data.V3, f64.Eval(), v64, str)
+		fmt.Printf("evt[%d]: %v, %v, %v -> %g | %s\n", ctx.Entry, data.V1, data.V2, data.V3, v64, str)
 		return nil
 	})
 	if err != nil {
@@ -273,8 +274,143 @@ func ExampleReader_withFormulaFunc() {
 	}
 
 	// Output:
-	// evt[0]: 1, 1.1, uno -> 1311 1311 | "one": 1, "two": 1.1, "three": uno
-	// evt[1]: 2, 2.2, dos -> 2322 2322 | "one": 2, "two": 2.2, "three": dos
-	// evt[2]: 3, 3.3, tres -> 3433 3433 | "one": 3, "two": 3.3, "three": tres
-	// evt[3]: 4, 4.4, quatro -> 4644 4644 | "one": 4, "two": 4.4, "three": quatro
+	// evt[0]: 1, 1.1, uno -> 1311 | "one": 1, "two": 1.1, "three": uno
+	// evt[1]: 2, 2.2, dos -> 2322 | "one": 2, "two": 2.2, "three": dos
+	// evt[2]: 3, 3.3, tres -> 3433 | "one": 3, "two": 3.3, "three": tres
+	// evt[3]: 4, 4.4, quatro -> 4644 | "one": 4, "two": 4.4, "three": quatro
+}
+
+type UsrF64 struct {
+	rvars []string
+	v1    *int32
+	v2    *float32
+	v3    *string
+	fct   func(int32, float32, string) float64
+}
+
+var (
+	_ rfunc.Formula = (*UsrF64)(nil)
+)
+
+func (usr *UsrF64) RVars() []string { return usr.rvars }
+func (usr *UsrF64) Bind(args []interface{}) error {
+	if got, want := len(args), 3; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	usr.v1 = args[0].(*int32)
+	usr.v2 = args[1].(*float32)
+	usr.v3 = args[2].(*string)
+	return nil
+}
+
+func (usr *UsrF64) Func() interface{} {
+	return func() float64 {
+		return usr.fct(*usr.v1, *usr.v2, *usr.v3)
+	}
+}
+
+type UsrStr struct {
+	rvars []string
+	v1    *int32
+	v2    *float32
+	v3    *string
+	fct   func(int32, float32, string) string
+}
+
+var (
+	_ rfunc.Formula = (*UsrStr)(nil)
+)
+
+func (usr *UsrStr) RVars() []string { return usr.rvars }
+func (usr *UsrStr) Bind(args []interface{}) error {
+	if got, want := len(args), 3; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	usr.v1 = args[0].(*int32)
+	usr.v2 = args[1].(*float32)
+	usr.v3 = args[2].(*string)
+	return nil
+}
+
+func (usr *UsrStr) Func() interface{} {
+	return func() string {
+		return usr.fct(*usr.v1, *usr.v2, *usr.v3)
+	}
+}
+
+func ExampleReader_withFormulaFromUser() {
+	f, err := groot.Open("../testdata/simple.root")
+	if err != nil {
+		log.Fatalf("could not open ROOT file: %+v", err)
+	}
+	defer f.Close()
+
+	o, err := f.Get("tree")
+	if err != nil {
+		log.Fatalf("could not retrieve ROOT tree: %+v", err)
+	}
+	t := o.(rtree.Tree)
+
+	var (
+		data struct {
+			V1 int32   `groot:"one"`
+			V2 float32 `groot:"two"`
+			V3 string  `groot:"three"`
+		}
+		rvars = rtree.ReadVarsFromStruct(&data)
+	)
+
+	r, err := rtree.NewReader(t, rvars)
+	if err != nil {
+		log.Fatalf("could not create tree reader: %+v", err)
+	}
+	defer r.Close()
+
+	f64, err := r.Formula(&UsrF64{
+		rvars: []string{"one", "two", "three"},
+		fct: func(v1 int32, v2 float32, v3 string) float64 {
+			return float64(v2*10) + float64(1000*v1) + float64(100*len(v3))
+		},
+	})
+	if err != nil {
+		log.Fatalf("could not create formula: %+v", err)
+	}
+
+	fstr, err := r.Formula(&UsrStr{
+		rvars: []string{"one", "two", "three"},
+		fct: func(v1 int32, v2 float32, v3 string) string {
+			return fmt.Sprintf(
+				"%q: %v, %q: %v, %q: %v",
+				"one", v1, "two", v2, "three", v3,
+			)
+		},
+	})
+	if err != nil {
+		log.Fatalf("could not create formula: %+v", err)
+	}
+
+	f1 := f64.Func().(func() float64)
+	f2 := fstr.Func().(func() string)
+
+	err = r.Read(func(ctx rtree.RCtx) error {
+		v64 := f1()
+		str := f2()
+		fmt.Printf("evt[%d]: %v, %v, %v -> %g | %s\n", ctx.Entry, data.V1, data.V2, data.V3, v64, str)
+		return nil
+	})
+	if err != nil {
+		log.Fatalf("could not process tree: %+v", err)
+	}
+
+	// Output:
+	// evt[0]: 1, 1.1, uno -> 1311 | "one": 1, "two": 1.1, "three": uno
+	// evt[1]: 2, 2.2, dos -> 2322 | "one": 2, "two": 2.2, "three": dos
+	// evt[2]: 3, 3.3, tres -> 3433 | "one": 3, "two": 3.3, "three": tres
+	// evt[3]: 4, 4.4, quatro -> 4644 | "one": 4, "two": 4.4, "three": quatro
 }

--- a/groot/rtree/formula.go
+++ b/groot/rtree/formula.go
@@ -6,183 +6,27 @@ package rtree
 
 import (
 	"fmt"
-	"reflect"
 
-	"go-hep.org/x/hep/groot/root"
+	"go-hep.org/x/hep/groot/rtree/rfunc"
 )
 
-type FormulaFunc struct {
-	rvars []reflect.Value
-	args  []reflect.Value
-	out   []reflect.Value
-	rfct  reflect.Value // formula-created function to eval read-vars
-	ufct  reflect.Value // user-provided function
-}
-
-func newFormulaFunc(r *Reader, branches []string, fct interface{}) (*FormulaFunc, error) {
-	rv := reflect.ValueOf(fct)
-	if rv.Kind() != reflect.Func {
-		return nil, fmt.Errorf("rtree: FormulaFunc expects a func")
-	}
-
-	if len(branches) != rv.Type().NumIn() {
-		return nil, fmt.Errorf("rtree: num-branches/func-arity mismatch")
-	}
-
-	if rv.Type().NumOut() != 1 {
-		// FIXME(sbinet): allow any kind of function?
-		return nil, fmt.Errorf("rtree: invalid number of return values")
-	}
-
-	rvars, missing := formulaAutoLoad(r, branches)
-	if len(rvars) != len(branches) {
+func newFormula(r *Reader, f rfunc.Formula) (rfunc.Formula, error) {
+	names := f.RVars()
+	rvs, missing := formulaAutoLoad(r, names)
+	if len(rvs) != len(names) {
 		return nil, fmt.Errorf("rtree: could not find all needed ReadVars (missing: %v)", missing)
 	}
-
-	for i, rvar := range rvars {
-		btyp := reflect.TypeOf(rvar.Value).Elem()
-		atyp := rv.Type().In(i)
-		if btyp != atyp {
-			return nil, fmt.Errorf(
-				"rtree: argument type %d mismatch: func=%T, read-var[%s]=%T",
-				i,
-				reflect.New(atyp).Elem().Interface(),
-				rvar.Name,
-				reflect.New(btyp).Elem().Interface(),
-			)
-		}
+	args := make([]interface{}, len(rvs))
+	for i, rv := range rvs {
+		args[i] = rv.Value
+	}
+	err := f.Bind(args)
+	if err != nil {
+		return nil, fmt.Errorf("rtree: could not bind formula to rvars: %w", err)
 	}
 
-	form := &FormulaFunc{
-		rvars: make([]reflect.Value, len(rvars)),
-		args:  make([]reflect.Value, len(rvars)),
-		ufct:  rv,
-	}
-
-	for i := range form.rvars {
-		form.args[i] = reflect.New(rv.Type().In(i)).Elem()
-		form.rvars[i] = reflect.ValueOf(rvars[i].Value)
-	}
-
-	var rfct reflect.Value
-	switch reflect.New(rv.Type().Out(0)).Elem().Interface().(type) {
-	case bool:
-		ufct := func() bool {
-			form.eval()
-			return form.out[0].Interface().(bool)
-		}
-		rfct = reflect.ValueOf(ufct)
-	case uint8:
-		ufct := func() uint8 {
-			form.eval()
-			return form.out[0].Interface().(uint8)
-		}
-		rfct = reflect.ValueOf(ufct)
-	case uint16:
-		ufct := func() uint16 {
-			form.eval()
-			return form.out[0].Interface().(uint16)
-		}
-		rfct = reflect.ValueOf(ufct)
-	case uint32:
-		ufct := func() uint32 {
-			form.eval()
-			return form.out[0].Interface().(uint32)
-		}
-		rfct = reflect.ValueOf(ufct)
-	case uint64:
-		ufct := func() uint64 {
-			form.eval()
-			return form.out[0].Interface().(uint64)
-		}
-		rfct = reflect.ValueOf(ufct)
-	case int8:
-		ufct := func() int8 {
-			form.eval()
-			return form.out[0].Interface().(int8)
-		}
-		rfct = reflect.ValueOf(ufct)
-	case int16:
-		ufct := func() int16 {
-			form.eval()
-			return form.out[0].Interface().(int16)
-		}
-		rfct = reflect.ValueOf(ufct)
-	case int32:
-		ufct := func() int32 {
-			form.eval()
-			return form.out[0].Interface().(int32)
-		}
-		rfct = reflect.ValueOf(ufct)
-	case int64:
-		ufct := func() int64 {
-			form.eval()
-			return form.out[0].Interface().(int64)
-		}
-		rfct = reflect.ValueOf(ufct)
-	case string:
-		ufct := func() string {
-			form.eval()
-			return form.out[0].Interface().(string)
-		}
-		rfct = reflect.ValueOf(ufct)
-	case root.Float16:
-		ufct := func() root.Float16 {
-			form.eval()
-			return form.out[0].Interface().(root.Float16)
-		}
-		rfct = reflect.ValueOf(ufct)
-	case float32:
-		ufct := func() float32 {
-			form.eval()
-			return form.out[0].Interface().(float32)
-		}
-		rfct = reflect.ValueOf(ufct)
-	case root.Double32:
-		ufct := func() root.Double32 {
-			form.eval()
-			return form.out[0].Interface().(root.Double32)
-		}
-		rfct = reflect.ValueOf(ufct)
-	case float64:
-		ufct := func() float64 {
-			form.eval()
-			return form.out[0].Float()
-		}
-		rfct = reflect.ValueOf(ufct)
-	default:
-		rfct = reflect.MakeFunc(
-			reflect.FuncOf(nil, []reflect.Type{rv.Type().Out(0)}, false),
-			func(in []reflect.Value) []reflect.Value {
-				form.eval()
-				return form.out
-			},
-		)
-	}
-	form.rfct = rfct
-
-	return form, nil
+	return f, nil
 }
-
-func (form *FormulaFunc) eval() {
-	for i, rvar := range form.rvars {
-		form.args[i].Set(rvar.Elem())
-	}
-	form.out = form.ufct.Call(form.args)
-}
-
-func (form *FormulaFunc) Eval() interface{} {
-	form.eval()
-	return form.out[0].Interface()
-}
-
-func (form *FormulaFunc) Func() interface{} {
-	return form.rfct.Interface()
-}
-
-var (
-	_ formula = (*FormulaFunc)(nil)
-)
 
 func formulaAutoLoad(r *Reader, idents []string) ([]*ReadVar, []string) {
 	var (

--- a/groot/rtree/rfunc/gen-rfuncs.go
+++ b/groot/rtree/rfunc/gen-rfuncs.go
@@ -1,0 +1,379 @@
+// Copyright ©2020 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build ignore
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"text/template"
+
+	"go-hep.org/x/hep/groot/internal/genroot"
+)
+
+func main() {
+	genRFuncs()
+}
+
+func genRFuncs() {
+
+	for _, typ := range []struct {
+		N int
+		F Func
+	}{
+		{
+			N: 10,
+			F: Func{
+				Name:    "Bool",
+				InType:  "float64",
+				OutType: "bool",
+			},
+		},
+		{
+			N: 10,
+			F: Func{
+				Name:    "U32",
+				InType:  "uint32",
+				OutType: "uint32",
+			},
+		},
+		{
+			N: 10,
+			F: Func{
+				Name:    "U64",
+				InType:  "uint64",
+				OutType: "uint64",
+			},
+		},
+		{
+			N: 10,
+			F: Func{
+				Name:    "I32",
+				InType:  "int32",
+				OutType: "int32",
+			},
+		},
+		{
+			N: 10,
+			F: Func{
+				Name:    "I64",
+				InType:  "int64",
+				OutType: "int64",
+			},
+		},
+		{
+			N: 10,
+			F: Func{
+				Name:    "F32",
+				InType:  "float32",
+				OutType: "float32",
+			},
+		},
+		{
+			N: 10,
+			F: Func{
+				Name:    "F64",
+				InType:  "float64",
+				OutType: "float64",
+			},
+		},
+	} {
+		genRFunc(typ.N, typ.F)
+	}
+}
+
+func genRFunc(arity int, typ Func) {
+	genRFuncCode(arity, typ)
+	genRFuncTest(arity, typ)
+}
+
+func genRFuncCode(arity int, typ Func) {
+	f, err := os.Create("./rfunc_" + typ.OutType + "_gen.go")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	genroot.GenImports("rfunc", f,
+		"fmt",
+		"reflect",
+	)
+
+	for i := 0; i <= arity; i++ {
+		if i > 0 {
+			fmt.Fprintf(f, "\n")
+		}
+		fct := typ.gen(i)
+		tmpl := template.Must(template.New(fct.Name).Parse(rfuncCodeTmpl))
+		err = tmpl.Execute(f, fct)
+		if err != nil {
+			log.Fatalf("error executing template for %q: %v\n", fct.Name, err)
+		}
+	}
+
+	err = f.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
+	genroot.GoFmt(f)
+}
+
+func genRFuncTest(arity int, typ Func) {
+	f, err := os.Create("./rfunc_" + typ.OutType + "_gen_test.go")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	genroot.GenImports("rfunc", f,
+		"reflect",
+		"testing",
+	)
+
+	for i := 0; i <= arity; i++ {
+		if i > 0 {
+			fmt.Fprintf(f, "\n")
+		}
+		fct := typ.gen(i)
+		tmpl := template.Must(template.New(fct.Name).Parse(rfuncTestTmpl))
+		err = tmpl.Execute(f, fct)
+		if err != nil {
+			log.Fatalf("error executing template for %q: %v\n", fct.Name, err)
+		}
+	}
+
+	err = f.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
+	genroot.GoFmt(f)
+}
+
+type Func struct {
+	Name    string
+	InType  string
+	OutType string
+	In      []string
+	Out     []string
+}
+
+func (f Func) gen(arity int) Func {
+	ins := make([]string, arity)
+	for i := range ins {
+		ins[i] = f.InType
+	}
+	out := []string{f.OutType}
+	return Func{
+		Name:    f.Name,
+		InType:  f.InType,
+		OutType: f.OutType,
+		In:      ins,
+		Out:     out,
+	}
+}
+
+func (f Func) NumIn() int  { return len(f.In) }
+func (f Func) NumOut() int { return len(f.Out) }
+func (f Func) Type() string {
+	return fmt.Sprintf("funcAr%02d%s", f.NumIn(), f.Name)
+}
+
+func (f Func) Func() string {
+	sig := new(strings.Builder)
+	sig.WriteString("func(")
+	for i, typ := range f.In {
+		if i > 0 {
+			sig.WriteString(", ")
+		}
+		fmt.Fprintf(sig, "arg%02d %s", i, typ)
+	}
+	sig.WriteString(")")
+
+	sig.WriteString(f.Return())
+
+	return sig.String()
+}
+
+func (f Func) Return() string {
+	sig := new(strings.Builder)
+	switch len(f.Out) {
+	case 0:
+		// no-op
+	case 1:
+		sig.WriteString(" ")
+	default:
+		sig.WriteString(" (")
+	}
+	for i, typ := range f.Out {
+		if i > 0 {
+			sig.WriteString(", ")
+		}
+		sig.WriteString(typ)
+	}
+	switch len(f.Out) {
+	case 0, 1:
+		// no-op
+	default:
+		sig.WriteString(")")
+	}
+
+	return sig.String()
+}
+
+func (f Func) TestFunc() string {
+	switch f.OutType {
+	case "string":
+		return `"42"`
+	case "bool":
+		return "true"
+	default:
+		return "42"
+	}
+}
+
+func (f Func) ExportType() string {
+	return strings.Title(f.Type())
+}
+
+const rfuncCodeTmpl = `// {{.Type}} implements rfunc.Formula
+type {{.Type}} struct {
+{{- if gt .NumIn 0}}
+	rvars []string
+{{- end}}
+{{- range $i, $typ := .In}}
+	arg{{$i}} *{{$typ}}
+{{- end}}
+	fct {{.Func}}
+}
+
+func new{{.ExportType}}(rvars []string, fct interface{}) (Formula, error) {
+	return &{{.Type}}{
+{{- if gt .NumIn 0}}
+		rvars: rvars,
+{{- end}}
+		fct: fct.({{.Func}}),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf({{.Type}}{}.fct)] = new{{.ExportType}}
+}
+
+{{if gt .NumIn 0}}
+func (f *{{.Type}}) RVars() []string { return f.rvars }
+{{else}}
+func (f *{{.Type}}) RVars() []string { return nil }
+{{end}}
+
+func (f *{{.Type}}) Bind(args []interface{}) error {
+	if got, want := len(args), {{.NumIn}}; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+{{- range $i, $typ := .In}}
+	{
+		ptr, ok := args[{{$i}}].(*{{$typ}})
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type {{$i}} (name=%s) mismatch: got=%T, want=*{{$typ}}",
+				f.rvars[{{$i}}], args[{{$i}}],
+			)
+		}
+		f.arg{{$i}} = ptr
+	}
+{{- end}}
+	return nil
+}
+
+func (f *{{.Type}}) Func() interface{} {
+	return func() {{.Return}} {
+		return f.fct(
+{{- range $i, $typ := .In}}
+			*f.arg{{$i}},
+{{- end}}
+		)
+	}
+}
+
+var (
+	_ Formula = (*{{.Type}})(nil)
+)
+`
+
+const rfuncTestTmpl = `func Test{{.ExportType}}(t *testing.T) {
+{{if gt .NumIn 0}}
+	rvars := make([]string, {{.NumIn}})
+{{- else}}
+	var rvars []string
+{{- end}}
+{{- range $i, $typ := .In}}
+	rvars[{{$i}}] = "name-{{$i}}"
+{{- end}}
+
+	fct := {{.Func}} {
+		return {{.TestFunc}}
+	}
+
+	form, err := new{{.ExportType}}(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create {{.Type}} formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+{{if gt .NumIn 0}}
+	ptrs := make([]interface{}, {{.NumIn}})
+{{- range $i, $typ := .In}}
+	ptrs[{{$i}}] = new({{$typ}})
+{{- end}}
+{{else}}
+	var ptrs []interface{}
+{{- end}}
+
+{{if gt .NumIn 0}}
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs)-1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+{{- else}}
+	{
+		bad := make([]interface{}, 1)
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+{{- end}}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func () {{.Return}})()
+	if got, want := got, {{.OutType}}({{.TestFunc}}); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+`

--- a/groot/rtree/rfunc/rfunc.go
+++ b/groot/rtree/rfunc/rfunc.go
@@ -1,0 +1,147 @@
+// Copyright ©2020 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package rfunc provides types and funcs to implement user-provided formulae
+// evaluated on data exposed by ROOT trees.
+package rfunc // import "go-hep.org/x/hep/groot/rtree/rfunc"
+
+//go:generate go run ./gen-rfuncs.go
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Formula is the interface that describes the protocol between a user
+// provided function (that evaluates a value based on some data in a ROOT
+// tree) and the rtree.Reader (that presents data from a ROOT tree.)
+type Formula interface {
+	// RVars returns the names of the leaves that this formula needs.
+	// The returned slice must contain the names in the same order than the
+	// user formula function's arguments.
+	RVars() []string
+
+	// Bind provides the arguments to the user function.
+	// ptrs is a slice of pointers to the rtree.ReadVars, in the same order
+	// than requested by RVars.
+	Bind(ptrs []interface{}) error
+
+	// Func returns the user function closing on the bound pointer-to-arguments
+	// and returning the expected evaluated value.
+	Func() interface{}
+}
+
+type newFunc func(rvars []string, fct interface{}) (Formula, error)
+
+var (
+	funcs = make(map[reflect.Type]newFunc)
+)
+
+// New returns a new formula from the provided list of needed tree variables
+// and the provided user function.
+func New(rvars []string, fct interface{}) (Formula, error) {
+	typ := reflect.TypeOf(fct)
+	mk, ok := funcs[typ]
+	if ok {
+		return mk(rvars, fct)
+	}
+	return newGenericFormula(rvars, fct)
+}
+
+type genericFormula struct {
+	names []string
+	fct   interface{}
+
+	ptrs []reflect.Value
+	args []reflect.Value
+	out  []reflect.Value
+
+	rfct reflect.Value // formula-created function to eval read-vars
+	ufct reflect.Value // user-provided function
+}
+
+func newGenericFormula(names []string, fct interface{}) (*genericFormula, error) {
+	rv := reflect.ValueOf(fct)
+	if rv.Kind() != reflect.Func {
+		return nil, fmt.Errorf("rfunc: formula expects a func")
+	}
+
+	if len(names) != rv.Type().NumIn() {
+		return nil, fmt.Errorf("rfunc: num-branches/func-arity mismatch")
+	}
+
+	if rv.Type().NumOut() != 1 {
+		// FIXME(sbinet): allow any kind of function?
+		return nil, fmt.Errorf("rfunc: invalid number of return values")
+	}
+
+	args := make([]reflect.Value, len(names))
+	ptrs := make([]reflect.Value, len(names))
+	for i := range args {
+		args[i] = reflect.New(rv.Type().In(i)).Elem()
+	}
+
+	gen := &genericFormula{
+		names: names,
+		fct:   fct,
+
+		ptrs: ptrs,
+		args: args,
+		ufct: rv,
+	}
+
+	gen.rfct = reflect.MakeFunc(
+		reflect.FuncOf(nil, []reflect.Type{rv.Type().Out(0)}, false),
+		func(in []reflect.Value) []reflect.Value {
+			gen.eval()
+			return gen.out
+		},
+	)
+
+	return gen, nil
+}
+
+func (f *genericFormula) RVars() []string { return f.names }
+func (f *genericFormula) Bind(args []interface{}) error {
+	if got, want := len(args), len(f.ptrs); got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+
+	for i := range args {
+		var (
+			got  = reflect.TypeOf(args[i]).Elem()
+			want = f.args[i].Type()
+		)
+		if got != want {
+			return fmt.Errorf(
+				"rfunc: argument type %d (name=%s) mismatch: got=%T, want=%T",
+				i, f.names[i],
+				reflect.New(got).Elem().Interface(),
+				reflect.New(want).Elem().Interface(),
+			)
+		}
+		f.ptrs[i] = reflect.ValueOf(args[i])
+		f.args[i] = reflect.New(f.ptrs[i].Type().Elem()).Elem()
+	}
+
+	return nil
+}
+
+func (f *genericFormula) eval() {
+	for i := range f.ptrs {
+		f.args[i].Set(f.ptrs[i].Elem())
+	}
+	f.out = f.ufct.Call(f.args)
+}
+
+func (f *genericFormula) Func() interface{} {
+	return f.rfct.Interface()
+}
+
+var (
+	_ Formula = (*genericFormula)(nil)
+)

--- a/groot/rtree/rfunc/rfunc_bool_gen.go
+++ b/groot/rtree/rfunc/rfunc_bool_gen.go
@@ -1,0 +1,1109 @@
+// Copyright ©2020 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Automatically generated. DO NOT EDIT.
+
+package rfunc
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// funcAr00Bool implements rfunc.Formula
+type funcAr00Bool struct {
+	fct func() bool
+}
+
+func newFuncAr00Bool(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr00Bool{
+		fct: fct.(func() bool),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr00Bool{}.fct)] = newFuncAr00Bool
+}
+
+func (f *funcAr00Bool) RVars() []string { return nil }
+
+func (f *funcAr00Bool) Bind(args []interface{}) error {
+	if got, want := len(args), 0; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	return nil
+}
+
+func (f *funcAr00Bool) Func() interface{} {
+	return func() bool {
+		return f.fct()
+	}
+}
+
+var (
+	_ Formula = (*funcAr00Bool)(nil)
+)
+
+// funcAr01Bool implements rfunc.Formula
+type funcAr01Bool struct {
+	rvars []string
+	arg0  *float64
+	fct   func(arg00 float64) bool
+}
+
+func newFuncAr01Bool(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr01Bool{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float64) bool),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr01Bool{}.fct)] = newFuncAr01Bool
+}
+
+func (f *funcAr01Bool) RVars() []string { return f.rvars }
+
+func (f *funcAr01Bool) Bind(args []interface{}) error {
+	if got, want := len(args), 1; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr01Bool) Func() interface{} {
+	return func() bool {
+		return f.fct(
+			*f.arg0,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr01Bool)(nil)
+)
+
+// funcAr02Bool implements rfunc.Formula
+type funcAr02Bool struct {
+	rvars []string
+	arg0  *float64
+	arg1  *float64
+	fct   func(arg00 float64, arg01 float64) bool
+}
+
+func newFuncAr02Bool(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr02Bool{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float64, arg01 float64) bool),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr02Bool{}.fct)] = newFuncAr02Bool
+}
+
+func (f *funcAr02Bool) RVars() []string { return f.rvars }
+
+func (f *funcAr02Bool) Bind(args []interface{}) error {
+	if got, want := len(args), 2; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr02Bool) Func() interface{} {
+	return func() bool {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr02Bool)(nil)
+)
+
+// funcAr03Bool implements rfunc.Formula
+type funcAr03Bool struct {
+	rvars []string
+	arg0  *float64
+	arg1  *float64
+	arg2  *float64
+	fct   func(arg00 float64, arg01 float64, arg02 float64) bool
+}
+
+func newFuncAr03Bool(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr03Bool{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float64, arg01 float64, arg02 float64) bool),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr03Bool{}.fct)] = newFuncAr03Bool
+}
+
+func (f *funcAr03Bool) RVars() []string { return f.rvars }
+
+func (f *funcAr03Bool) Bind(args []interface{}) error {
+	if got, want := len(args), 3; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr03Bool) Func() interface{} {
+	return func() bool {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr03Bool)(nil)
+)
+
+// funcAr04Bool implements rfunc.Formula
+type funcAr04Bool struct {
+	rvars []string
+	arg0  *float64
+	arg1  *float64
+	arg2  *float64
+	arg3  *float64
+	fct   func(arg00 float64, arg01 float64, arg02 float64, arg03 float64) bool
+}
+
+func newFuncAr04Bool(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr04Bool{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float64, arg01 float64, arg02 float64, arg03 float64) bool),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr04Bool{}.fct)] = newFuncAr04Bool
+}
+
+func (f *funcAr04Bool) RVars() []string { return f.rvars }
+
+func (f *funcAr04Bool) Bind(args []interface{}) error {
+	if got, want := len(args), 4; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr04Bool) Func() interface{} {
+	return func() bool {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr04Bool)(nil)
+)
+
+// funcAr05Bool implements rfunc.Formula
+type funcAr05Bool struct {
+	rvars []string
+	arg0  *float64
+	arg1  *float64
+	arg2  *float64
+	arg3  *float64
+	arg4  *float64
+	fct   func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64) bool
+}
+
+func newFuncAr05Bool(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr05Bool{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64) bool),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr05Bool{}.fct)] = newFuncAr05Bool
+}
+
+func (f *funcAr05Bool) RVars() []string { return f.rvars }
+
+func (f *funcAr05Bool) Bind(args []interface{}) error {
+	if got, want := len(args), 5; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr05Bool) Func() interface{} {
+	return func() bool {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr05Bool)(nil)
+)
+
+// funcAr06Bool implements rfunc.Formula
+type funcAr06Bool struct {
+	rvars []string
+	arg0  *float64
+	arg1  *float64
+	arg2  *float64
+	arg3  *float64
+	arg4  *float64
+	arg5  *float64
+	fct   func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64) bool
+}
+
+func newFuncAr06Bool(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr06Bool{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64) bool),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr06Bool{}.fct)] = newFuncAr06Bool
+}
+
+func (f *funcAr06Bool) RVars() []string { return f.rvars }
+
+func (f *funcAr06Bool) Bind(args []interface{}) error {
+	if got, want := len(args), 6; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr06Bool) Func() interface{} {
+	return func() bool {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr06Bool)(nil)
+)
+
+// funcAr07Bool implements rfunc.Formula
+type funcAr07Bool struct {
+	rvars []string
+	arg0  *float64
+	arg1  *float64
+	arg2  *float64
+	arg3  *float64
+	arg4  *float64
+	arg5  *float64
+	arg6  *float64
+	fct   func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64) bool
+}
+
+func newFuncAr07Bool(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr07Bool{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64) bool),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr07Bool{}.fct)] = newFuncAr07Bool
+}
+
+func (f *funcAr07Bool) RVars() []string { return f.rvars }
+
+func (f *funcAr07Bool) Bind(args []interface{}) error {
+	if got, want := len(args), 7; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr07Bool) Func() interface{} {
+	return func() bool {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr07Bool)(nil)
+)
+
+// funcAr08Bool implements rfunc.Formula
+type funcAr08Bool struct {
+	rvars []string
+	arg0  *float64
+	arg1  *float64
+	arg2  *float64
+	arg3  *float64
+	arg4  *float64
+	arg5  *float64
+	arg6  *float64
+	arg7  *float64
+	fct   func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64, arg07 float64) bool
+}
+
+func newFuncAr08Bool(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr08Bool{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64, arg07 float64) bool),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr08Bool{}.fct)] = newFuncAr08Bool
+}
+
+func (f *funcAr08Bool) RVars() []string { return f.rvars }
+
+func (f *funcAr08Bool) Bind(args []interface{}) error {
+	if got, want := len(args), 8; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr08Bool) Func() interface{} {
+	return func() bool {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr08Bool)(nil)
+)
+
+// funcAr09Bool implements rfunc.Formula
+type funcAr09Bool struct {
+	rvars []string
+	arg0  *float64
+	arg1  *float64
+	arg2  *float64
+	arg3  *float64
+	arg4  *float64
+	arg5  *float64
+	arg6  *float64
+	arg7  *float64
+	arg8  *float64
+	fct   func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64, arg07 float64, arg08 float64) bool
+}
+
+func newFuncAr09Bool(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr09Bool{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64, arg07 float64, arg08 float64) bool),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr09Bool{}.fct)] = newFuncAr09Bool
+}
+
+func (f *funcAr09Bool) RVars() []string { return f.rvars }
+
+func (f *funcAr09Bool) Bind(args []interface{}) error {
+	if got, want := len(args), 9; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	{
+		ptr, ok := args[8].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 8 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[8], args[8],
+			)
+		}
+		f.arg8 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr09Bool) Func() interface{} {
+	return func() bool {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+			*f.arg8,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr09Bool)(nil)
+)
+
+// funcAr10Bool implements rfunc.Formula
+type funcAr10Bool struct {
+	rvars []string
+	arg0  *float64
+	arg1  *float64
+	arg2  *float64
+	arg3  *float64
+	arg4  *float64
+	arg5  *float64
+	arg6  *float64
+	arg7  *float64
+	arg8  *float64
+	arg9  *float64
+	fct   func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64, arg07 float64, arg08 float64, arg09 float64) bool
+}
+
+func newFuncAr10Bool(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr10Bool{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64, arg07 float64, arg08 float64, arg09 float64) bool),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr10Bool{}.fct)] = newFuncAr10Bool
+}
+
+func (f *funcAr10Bool) RVars() []string { return f.rvars }
+
+func (f *funcAr10Bool) Bind(args []interface{}) error {
+	if got, want := len(args), 10; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	{
+		ptr, ok := args[8].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 8 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[8], args[8],
+			)
+		}
+		f.arg8 = ptr
+	}
+	{
+		ptr, ok := args[9].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 9 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[9], args[9],
+			)
+		}
+		f.arg9 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr10Bool) Func() interface{} {
+	return func() bool {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+			*f.arg8,
+			*f.arg9,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr10Bool)(nil)
+)

--- a/groot/rtree/rfunc/rfunc_bool_gen_test.go
+++ b/groot/rtree/rfunc/rfunc_bool_gen_test.go
@@ -1,0 +1,630 @@
+// Copyright ©2020 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Automatically generated. DO NOT EDIT.
+
+package rfunc
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFuncAr00Bool(t *testing.T) {
+
+	var rvars []string
+
+	fct := func() bool {
+		return true
+	}
+
+	form, err := newFuncAr00Bool(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr00Bool formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	var ptrs []interface{}
+
+	{
+		bad := make([]interface{}, 1)
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() bool)()
+	if got, want := got, bool(true); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr01Bool(t *testing.T) {
+
+	rvars := make([]string, 1)
+	rvars[0] = "name-0"
+
+	fct := func(arg00 float64) bool {
+		return true
+	}
+
+	form, err := newFuncAr01Bool(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr01Bool formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 1)
+	ptrs[0] = new(float64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() bool)()
+	if got, want := got, bool(true); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr02Bool(t *testing.T) {
+
+	rvars := make([]string, 2)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+
+	fct := func(arg00 float64, arg01 float64) bool {
+		return true
+	}
+
+	form, err := newFuncAr02Bool(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr02Bool formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 2)
+	ptrs[0] = new(float64)
+	ptrs[1] = new(float64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() bool)()
+	if got, want := got, bool(true); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr03Bool(t *testing.T) {
+
+	rvars := make([]string, 3)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+
+	fct := func(arg00 float64, arg01 float64, arg02 float64) bool {
+		return true
+	}
+
+	form, err := newFuncAr03Bool(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr03Bool formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 3)
+	ptrs[0] = new(float64)
+	ptrs[1] = new(float64)
+	ptrs[2] = new(float64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() bool)()
+	if got, want := got, bool(true); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr04Bool(t *testing.T) {
+
+	rvars := make([]string, 4)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+
+	fct := func(arg00 float64, arg01 float64, arg02 float64, arg03 float64) bool {
+		return true
+	}
+
+	form, err := newFuncAr04Bool(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr04Bool formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 4)
+	ptrs[0] = new(float64)
+	ptrs[1] = new(float64)
+	ptrs[2] = new(float64)
+	ptrs[3] = new(float64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() bool)()
+	if got, want := got, bool(true); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr05Bool(t *testing.T) {
+
+	rvars := make([]string, 5)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+
+	fct := func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64) bool {
+		return true
+	}
+
+	form, err := newFuncAr05Bool(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr05Bool formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 5)
+	ptrs[0] = new(float64)
+	ptrs[1] = new(float64)
+	ptrs[2] = new(float64)
+	ptrs[3] = new(float64)
+	ptrs[4] = new(float64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() bool)()
+	if got, want := got, bool(true); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr06Bool(t *testing.T) {
+
+	rvars := make([]string, 6)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+
+	fct := func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64) bool {
+		return true
+	}
+
+	form, err := newFuncAr06Bool(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr06Bool formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 6)
+	ptrs[0] = new(float64)
+	ptrs[1] = new(float64)
+	ptrs[2] = new(float64)
+	ptrs[3] = new(float64)
+	ptrs[4] = new(float64)
+	ptrs[5] = new(float64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() bool)()
+	if got, want := got, bool(true); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr07Bool(t *testing.T) {
+
+	rvars := make([]string, 7)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+
+	fct := func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64) bool {
+		return true
+	}
+
+	form, err := newFuncAr07Bool(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr07Bool formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 7)
+	ptrs[0] = new(float64)
+	ptrs[1] = new(float64)
+	ptrs[2] = new(float64)
+	ptrs[3] = new(float64)
+	ptrs[4] = new(float64)
+	ptrs[5] = new(float64)
+	ptrs[6] = new(float64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() bool)()
+	if got, want := got, bool(true); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr08Bool(t *testing.T) {
+
+	rvars := make([]string, 8)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+
+	fct := func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64, arg07 float64) bool {
+		return true
+	}
+
+	form, err := newFuncAr08Bool(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr08Bool formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 8)
+	ptrs[0] = new(float64)
+	ptrs[1] = new(float64)
+	ptrs[2] = new(float64)
+	ptrs[3] = new(float64)
+	ptrs[4] = new(float64)
+	ptrs[5] = new(float64)
+	ptrs[6] = new(float64)
+	ptrs[7] = new(float64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() bool)()
+	if got, want := got, bool(true); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr09Bool(t *testing.T) {
+
+	rvars := make([]string, 9)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+	rvars[8] = "name-8"
+
+	fct := func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64, arg07 float64, arg08 float64) bool {
+		return true
+	}
+
+	form, err := newFuncAr09Bool(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr09Bool formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 9)
+	ptrs[0] = new(float64)
+	ptrs[1] = new(float64)
+	ptrs[2] = new(float64)
+	ptrs[3] = new(float64)
+	ptrs[4] = new(float64)
+	ptrs[5] = new(float64)
+	ptrs[6] = new(float64)
+	ptrs[7] = new(float64)
+	ptrs[8] = new(float64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() bool)()
+	if got, want := got, bool(true); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr10Bool(t *testing.T) {
+
+	rvars := make([]string, 10)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+	rvars[8] = "name-8"
+	rvars[9] = "name-9"
+
+	fct := func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64, arg07 float64, arg08 float64, arg09 float64) bool {
+		return true
+	}
+
+	form, err := newFuncAr10Bool(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr10Bool formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 10)
+	ptrs[0] = new(float64)
+	ptrs[1] = new(float64)
+	ptrs[2] = new(float64)
+	ptrs[3] = new(float64)
+	ptrs[4] = new(float64)
+	ptrs[5] = new(float64)
+	ptrs[6] = new(float64)
+	ptrs[7] = new(float64)
+	ptrs[8] = new(float64)
+	ptrs[9] = new(float64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() bool)()
+	if got, want := got, bool(true); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}

--- a/groot/rtree/rfunc/rfunc_float32_gen.go
+++ b/groot/rtree/rfunc/rfunc_float32_gen.go
@@ -1,0 +1,1109 @@
+// Copyright ©2020 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Automatically generated. DO NOT EDIT.
+
+package rfunc
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// funcAr00F32 implements rfunc.Formula
+type funcAr00F32 struct {
+	fct func() float32
+}
+
+func newFuncAr00F32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr00F32{
+		fct: fct.(func() float32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr00F32{}.fct)] = newFuncAr00F32
+}
+
+func (f *funcAr00F32) RVars() []string { return nil }
+
+func (f *funcAr00F32) Bind(args []interface{}) error {
+	if got, want := len(args), 0; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	return nil
+}
+
+func (f *funcAr00F32) Func() interface{} {
+	return func() float32 {
+		return f.fct()
+	}
+}
+
+var (
+	_ Formula = (*funcAr00F32)(nil)
+)
+
+// funcAr01F32 implements rfunc.Formula
+type funcAr01F32 struct {
+	rvars []string
+	arg0  *float32
+	fct   func(arg00 float32) float32
+}
+
+func newFuncAr01F32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr01F32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float32) float32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr01F32{}.fct)] = newFuncAr01F32
+}
+
+func (f *funcAr01F32) RVars() []string { return f.rvars }
+
+func (f *funcAr01F32) Bind(args []interface{}) error {
+	if got, want := len(args), 1; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr01F32) Func() interface{} {
+	return func() float32 {
+		return f.fct(
+			*f.arg0,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr01F32)(nil)
+)
+
+// funcAr02F32 implements rfunc.Formula
+type funcAr02F32 struct {
+	rvars []string
+	arg0  *float32
+	arg1  *float32
+	fct   func(arg00 float32, arg01 float32) float32
+}
+
+func newFuncAr02F32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr02F32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float32, arg01 float32) float32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr02F32{}.fct)] = newFuncAr02F32
+}
+
+func (f *funcAr02F32) RVars() []string { return f.rvars }
+
+func (f *funcAr02F32) Bind(args []interface{}) error {
+	if got, want := len(args), 2; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr02F32) Func() interface{} {
+	return func() float32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr02F32)(nil)
+)
+
+// funcAr03F32 implements rfunc.Formula
+type funcAr03F32 struct {
+	rvars []string
+	arg0  *float32
+	arg1  *float32
+	arg2  *float32
+	fct   func(arg00 float32, arg01 float32, arg02 float32) float32
+}
+
+func newFuncAr03F32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr03F32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float32, arg01 float32, arg02 float32) float32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr03F32{}.fct)] = newFuncAr03F32
+}
+
+func (f *funcAr03F32) RVars() []string { return f.rvars }
+
+func (f *funcAr03F32) Bind(args []interface{}) error {
+	if got, want := len(args), 3; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr03F32) Func() interface{} {
+	return func() float32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr03F32)(nil)
+)
+
+// funcAr04F32 implements rfunc.Formula
+type funcAr04F32 struct {
+	rvars []string
+	arg0  *float32
+	arg1  *float32
+	arg2  *float32
+	arg3  *float32
+	fct   func(arg00 float32, arg01 float32, arg02 float32, arg03 float32) float32
+}
+
+func newFuncAr04F32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr04F32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float32, arg01 float32, arg02 float32, arg03 float32) float32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr04F32{}.fct)] = newFuncAr04F32
+}
+
+func (f *funcAr04F32) RVars() []string { return f.rvars }
+
+func (f *funcAr04F32) Bind(args []interface{}) error {
+	if got, want := len(args), 4; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr04F32) Func() interface{} {
+	return func() float32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr04F32)(nil)
+)
+
+// funcAr05F32 implements rfunc.Formula
+type funcAr05F32 struct {
+	rvars []string
+	arg0  *float32
+	arg1  *float32
+	arg2  *float32
+	arg3  *float32
+	arg4  *float32
+	fct   func(arg00 float32, arg01 float32, arg02 float32, arg03 float32, arg04 float32) float32
+}
+
+func newFuncAr05F32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr05F32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float32, arg01 float32, arg02 float32, arg03 float32, arg04 float32) float32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr05F32{}.fct)] = newFuncAr05F32
+}
+
+func (f *funcAr05F32) RVars() []string { return f.rvars }
+
+func (f *funcAr05F32) Bind(args []interface{}) error {
+	if got, want := len(args), 5; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr05F32) Func() interface{} {
+	return func() float32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr05F32)(nil)
+)
+
+// funcAr06F32 implements rfunc.Formula
+type funcAr06F32 struct {
+	rvars []string
+	arg0  *float32
+	arg1  *float32
+	arg2  *float32
+	arg3  *float32
+	arg4  *float32
+	arg5  *float32
+	fct   func(arg00 float32, arg01 float32, arg02 float32, arg03 float32, arg04 float32, arg05 float32) float32
+}
+
+func newFuncAr06F32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr06F32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float32, arg01 float32, arg02 float32, arg03 float32, arg04 float32, arg05 float32) float32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr06F32{}.fct)] = newFuncAr06F32
+}
+
+func (f *funcAr06F32) RVars() []string { return f.rvars }
+
+func (f *funcAr06F32) Bind(args []interface{}) error {
+	if got, want := len(args), 6; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr06F32) Func() interface{} {
+	return func() float32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr06F32)(nil)
+)
+
+// funcAr07F32 implements rfunc.Formula
+type funcAr07F32 struct {
+	rvars []string
+	arg0  *float32
+	arg1  *float32
+	arg2  *float32
+	arg3  *float32
+	arg4  *float32
+	arg5  *float32
+	arg6  *float32
+	fct   func(arg00 float32, arg01 float32, arg02 float32, arg03 float32, arg04 float32, arg05 float32, arg06 float32) float32
+}
+
+func newFuncAr07F32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr07F32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float32, arg01 float32, arg02 float32, arg03 float32, arg04 float32, arg05 float32, arg06 float32) float32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr07F32{}.fct)] = newFuncAr07F32
+}
+
+func (f *funcAr07F32) RVars() []string { return f.rvars }
+
+func (f *funcAr07F32) Bind(args []interface{}) error {
+	if got, want := len(args), 7; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr07F32) Func() interface{} {
+	return func() float32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr07F32)(nil)
+)
+
+// funcAr08F32 implements rfunc.Formula
+type funcAr08F32 struct {
+	rvars []string
+	arg0  *float32
+	arg1  *float32
+	arg2  *float32
+	arg3  *float32
+	arg4  *float32
+	arg5  *float32
+	arg6  *float32
+	arg7  *float32
+	fct   func(arg00 float32, arg01 float32, arg02 float32, arg03 float32, arg04 float32, arg05 float32, arg06 float32, arg07 float32) float32
+}
+
+func newFuncAr08F32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr08F32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float32, arg01 float32, arg02 float32, arg03 float32, arg04 float32, arg05 float32, arg06 float32, arg07 float32) float32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr08F32{}.fct)] = newFuncAr08F32
+}
+
+func (f *funcAr08F32) RVars() []string { return f.rvars }
+
+func (f *funcAr08F32) Bind(args []interface{}) error {
+	if got, want := len(args), 8; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr08F32) Func() interface{} {
+	return func() float32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr08F32)(nil)
+)
+
+// funcAr09F32 implements rfunc.Formula
+type funcAr09F32 struct {
+	rvars []string
+	arg0  *float32
+	arg1  *float32
+	arg2  *float32
+	arg3  *float32
+	arg4  *float32
+	arg5  *float32
+	arg6  *float32
+	arg7  *float32
+	arg8  *float32
+	fct   func(arg00 float32, arg01 float32, arg02 float32, arg03 float32, arg04 float32, arg05 float32, arg06 float32, arg07 float32, arg08 float32) float32
+}
+
+func newFuncAr09F32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr09F32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float32, arg01 float32, arg02 float32, arg03 float32, arg04 float32, arg05 float32, arg06 float32, arg07 float32, arg08 float32) float32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr09F32{}.fct)] = newFuncAr09F32
+}
+
+func (f *funcAr09F32) RVars() []string { return f.rvars }
+
+func (f *funcAr09F32) Bind(args []interface{}) error {
+	if got, want := len(args), 9; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	{
+		ptr, ok := args[8].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 8 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[8], args[8],
+			)
+		}
+		f.arg8 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr09F32) Func() interface{} {
+	return func() float32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+			*f.arg8,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr09F32)(nil)
+)
+
+// funcAr10F32 implements rfunc.Formula
+type funcAr10F32 struct {
+	rvars []string
+	arg0  *float32
+	arg1  *float32
+	arg2  *float32
+	arg3  *float32
+	arg4  *float32
+	arg5  *float32
+	arg6  *float32
+	arg7  *float32
+	arg8  *float32
+	arg9  *float32
+	fct   func(arg00 float32, arg01 float32, arg02 float32, arg03 float32, arg04 float32, arg05 float32, arg06 float32, arg07 float32, arg08 float32, arg09 float32) float32
+}
+
+func newFuncAr10F32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr10F32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float32, arg01 float32, arg02 float32, arg03 float32, arg04 float32, arg05 float32, arg06 float32, arg07 float32, arg08 float32, arg09 float32) float32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr10F32{}.fct)] = newFuncAr10F32
+}
+
+func (f *funcAr10F32) RVars() []string { return f.rvars }
+
+func (f *funcAr10F32) Bind(args []interface{}) error {
+	if got, want := len(args), 10; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	{
+		ptr, ok := args[8].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 8 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[8], args[8],
+			)
+		}
+		f.arg8 = ptr
+	}
+	{
+		ptr, ok := args[9].(*float32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 9 (name=%s) mismatch: got=%T, want=*float32",
+				f.rvars[9], args[9],
+			)
+		}
+		f.arg9 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr10F32) Func() interface{} {
+	return func() float32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+			*f.arg8,
+			*f.arg9,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr10F32)(nil)
+)

--- a/groot/rtree/rfunc/rfunc_float32_gen_test.go
+++ b/groot/rtree/rfunc/rfunc_float32_gen_test.go
@@ -1,0 +1,630 @@
+// Copyright ©2020 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Automatically generated. DO NOT EDIT.
+
+package rfunc
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFuncAr00F32(t *testing.T) {
+
+	var rvars []string
+
+	fct := func() float32 {
+		return 42
+	}
+
+	form, err := newFuncAr00F32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr00F32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	var ptrs []interface{}
+
+	{
+		bad := make([]interface{}, 1)
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float32)()
+	if got, want := got, float32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr01F32(t *testing.T) {
+
+	rvars := make([]string, 1)
+	rvars[0] = "name-0"
+
+	fct := func(arg00 float32) float32 {
+		return 42
+	}
+
+	form, err := newFuncAr01F32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr01F32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 1)
+	ptrs[0] = new(float32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float32)()
+	if got, want := got, float32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr02F32(t *testing.T) {
+
+	rvars := make([]string, 2)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+
+	fct := func(arg00 float32, arg01 float32) float32 {
+		return 42
+	}
+
+	form, err := newFuncAr02F32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr02F32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 2)
+	ptrs[0] = new(float32)
+	ptrs[1] = new(float32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float32)()
+	if got, want := got, float32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr03F32(t *testing.T) {
+
+	rvars := make([]string, 3)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+
+	fct := func(arg00 float32, arg01 float32, arg02 float32) float32 {
+		return 42
+	}
+
+	form, err := newFuncAr03F32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr03F32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 3)
+	ptrs[0] = new(float32)
+	ptrs[1] = new(float32)
+	ptrs[2] = new(float32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float32)()
+	if got, want := got, float32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr04F32(t *testing.T) {
+
+	rvars := make([]string, 4)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+
+	fct := func(arg00 float32, arg01 float32, arg02 float32, arg03 float32) float32 {
+		return 42
+	}
+
+	form, err := newFuncAr04F32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr04F32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 4)
+	ptrs[0] = new(float32)
+	ptrs[1] = new(float32)
+	ptrs[2] = new(float32)
+	ptrs[3] = new(float32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float32)()
+	if got, want := got, float32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr05F32(t *testing.T) {
+
+	rvars := make([]string, 5)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+
+	fct := func(arg00 float32, arg01 float32, arg02 float32, arg03 float32, arg04 float32) float32 {
+		return 42
+	}
+
+	form, err := newFuncAr05F32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr05F32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 5)
+	ptrs[0] = new(float32)
+	ptrs[1] = new(float32)
+	ptrs[2] = new(float32)
+	ptrs[3] = new(float32)
+	ptrs[4] = new(float32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float32)()
+	if got, want := got, float32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr06F32(t *testing.T) {
+
+	rvars := make([]string, 6)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+
+	fct := func(arg00 float32, arg01 float32, arg02 float32, arg03 float32, arg04 float32, arg05 float32) float32 {
+		return 42
+	}
+
+	form, err := newFuncAr06F32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr06F32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 6)
+	ptrs[0] = new(float32)
+	ptrs[1] = new(float32)
+	ptrs[2] = new(float32)
+	ptrs[3] = new(float32)
+	ptrs[4] = new(float32)
+	ptrs[5] = new(float32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float32)()
+	if got, want := got, float32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr07F32(t *testing.T) {
+
+	rvars := make([]string, 7)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+
+	fct := func(arg00 float32, arg01 float32, arg02 float32, arg03 float32, arg04 float32, arg05 float32, arg06 float32) float32 {
+		return 42
+	}
+
+	form, err := newFuncAr07F32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr07F32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 7)
+	ptrs[0] = new(float32)
+	ptrs[1] = new(float32)
+	ptrs[2] = new(float32)
+	ptrs[3] = new(float32)
+	ptrs[4] = new(float32)
+	ptrs[5] = new(float32)
+	ptrs[6] = new(float32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float32)()
+	if got, want := got, float32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr08F32(t *testing.T) {
+
+	rvars := make([]string, 8)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+
+	fct := func(arg00 float32, arg01 float32, arg02 float32, arg03 float32, arg04 float32, arg05 float32, arg06 float32, arg07 float32) float32 {
+		return 42
+	}
+
+	form, err := newFuncAr08F32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr08F32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 8)
+	ptrs[0] = new(float32)
+	ptrs[1] = new(float32)
+	ptrs[2] = new(float32)
+	ptrs[3] = new(float32)
+	ptrs[4] = new(float32)
+	ptrs[5] = new(float32)
+	ptrs[6] = new(float32)
+	ptrs[7] = new(float32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float32)()
+	if got, want := got, float32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr09F32(t *testing.T) {
+
+	rvars := make([]string, 9)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+	rvars[8] = "name-8"
+
+	fct := func(arg00 float32, arg01 float32, arg02 float32, arg03 float32, arg04 float32, arg05 float32, arg06 float32, arg07 float32, arg08 float32) float32 {
+		return 42
+	}
+
+	form, err := newFuncAr09F32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr09F32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 9)
+	ptrs[0] = new(float32)
+	ptrs[1] = new(float32)
+	ptrs[2] = new(float32)
+	ptrs[3] = new(float32)
+	ptrs[4] = new(float32)
+	ptrs[5] = new(float32)
+	ptrs[6] = new(float32)
+	ptrs[7] = new(float32)
+	ptrs[8] = new(float32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float32)()
+	if got, want := got, float32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr10F32(t *testing.T) {
+
+	rvars := make([]string, 10)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+	rvars[8] = "name-8"
+	rvars[9] = "name-9"
+
+	fct := func(arg00 float32, arg01 float32, arg02 float32, arg03 float32, arg04 float32, arg05 float32, arg06 float32, arg07 float32, arg08 float32, arg09 float32) float32 {
+		return 42
+	}
+
+	form, err := newFuncAr10F32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr10F32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 10)
+	ptrs[0] = new(float32)
+	ptrs[1] = new(float32)
+	ptrs[2] = new(float32)
+	ptrs[3] = new(float32)
+	ptrs[4] = new(float32)
+	ptrs[5] = new(float32)
+	ptrs[6] = new(float32)
+	ptrs[7] = new(float32)
+	ptrs[8] = new(float32)
+	ptrs[9] = new(float32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float32)()
+	if got, want := got, float32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}

--- a/groot/rtree/rfunc/rfunc_float64_gen.go
+++ b/groot/rtree/rfunc/rfunc_float64_gen.go
@@ -1,0 +1,1109 @@
+// Copyright ©2020 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Automatically generated. DO NOT EDIT.
+
+package rfunc
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// funcAr00F64 implements rfunc.Formula
+type funcAr00F64 struct {
+	fct func() float64
+}
+
+func newFuncAr00F64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr00F64{
+		fct: fct.(func() float64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr00F64{}.fct)] = newFuncAr00F64
+}
+
+func (f *funcAr00F64) RVars() []string { return nil }
+
+func (f *funcAr00F64) Bind(args []interface{}) error {
+	if got, want := len(args), 0; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	return nil
+}
+
+func (f *funcAr00F64) Func() interface{} {
+	return func() float64 {
+		return f.fct()
+	}
+}
+
+var (
+	_ Formula = (*funcAr00F64)(nil)
+)
+
+// funcAr01F64 implements rfunc.Formula
+type funcAr01F64 struct {
+	rvars []string
+	arg0  *float64
+	fct   func(arg00 float64) float64
+}
+
+func newFuncAr01F64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr01F64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float64) float64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr01F64{}.fct)] = newFuncAr01F64
+}
+
+func (f *funcAr01F64) RVars() []string { return f.rvars }
+
+func (f *funcAr01F64) Bind(args []interface{}) error {
+	if got, want := len(args), 1; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr01F64) Func() interface{} {
+	return func() float64 {
+		return f.fct(
+			*f.arg0,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr01F64)(nil)
+)
+
+// funcAr02F64 implements rfunc.Formula
+type funcAr02F64 struct {
+	rvars []string
+	arg0  *float64
+	arg1  *float64
+	fct   func(arg00 float64, arg01 float64) float64
+}
+
+func newFuncAr02F64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr02F64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float64, arg01 float64) float64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr02F64{}.fct)] = newFuncAr02F64
+}
+
+func (f *funcAr02F64) RVars() []string { return f.rvars }
+
+func (f *funcAr02F64) Bind(args []interface{}) error {
+	if got, want := len(args), 2; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr02F64) Func() interface{} {
+	return func() float64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr02F64)(nil)
+)
+
+// funcAr03F64 implements rfunc.Formula
+type funcAr03F64 struct {
+	rvars []string
+	arg0  *float64
+	arg1  *float64
+	arg2  *float64
+	fct   func(arg00 float64, arg01 float64, arg02 float64) float64
+}
+
+func newFuncAr03F64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr03F64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float64, arg01 float64, arg02 float64) float64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr03F64{}.fct)] = newFuncAr03F64
+}
+
+func (f *funcAr03F64) RVars() []string { return f.rvars }
+
+func (f *funcAr03F64) Bind(args []interface{}) error {
+	if got, want := len(args), 3; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr03F64) Func() interface{} {
+	return func() float64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr03F64)(nil)
+)
+
+// funcAr04F64 implements rfunc.Formula
+type funcAr04F64 struct {
+	rvars []string
+	arg0  *float64
+	arg1  *float64
+	arg2  *float64
+	arg3  *float64
+	fct   func(arg00 float64, arg01 float64, arg02 float64, arg03 float64) float64
+}
+
+func newFuncAr04F64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr04F64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float64, arg01 float64, arg02 float64, arg03 float64) float64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr04F64{}.fct)] = newFuncAr04F64
+}
+
+func (f *funcAr04F64) RVars() []string { return f.rvars }
+
+func (f *funcAr04F64) Bind(args []interface{}) error {
+	if got, want := len(args), 4; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr04F64) Func() interface{} {
+	return func() float64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr04F64)(nil)
+)
+
+// funcAr05F64 implements rfunc.Formula
+type funcAr05F64 struct {
+	rvars []string
+	arg0  *float64
+	arg1  *float64
+	arg2  *float64
+	arg3  *float64
+	arg4  *float64
+	fct   func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64) float64
+}
+
+func newFuncAr05F64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr05F64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64) float64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr05F64{}.fct)] = newFuncAr05F64
+}
+
+func (f *funcAr05F64) RVars() []string { return f.rvars }
+
+func (f *funcAr05F64) Bind(args []interface{}) error {
+	if got, want := len(args), 5; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr05F64) Func() interface{} {
+	return func() float64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr05F64)(nil)
+)
+
+// funcAr06F64 implements rfunc.Formula
+type funcAr06F64 struct {
+	rvars []string
+	arg0  *float64
+	arg1  *float64
+	arg2  *float64
+	arg3  *float64
+	arg4  *float64
+	arg5  *float64
+	fct   func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64) float64
+}
+
+func newFuncAr06F64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr06F64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64) float64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr06F64{}.fct)] = newFuncAr06F64
+}
+
+func (f *funcAr06F64) RVars() []string { return f.rvars }
+
+func (f *funcAr06F64) Bind(args []interface{}) error {
+	if got, want := len(args), 6; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr06F64) Func() interface{} {
+	return func() float64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr06F64)(nil)
+)
+
+// funcAr07F64 implements rfunc.Formula
+type funcAr07F64 struct {
+	rvars []string
+	arg0  *float64
+	arg1  *float64
+	arg2  *float64
+	arg3  *float64
+	arg4  *float64
+	arg5  *float64
+	arg6  *float64
+	fct   func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64) float64
+}
+
+func newFuncAr07F64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr07F64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64) float64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr07F64{}.fct)] = newFuncAr07F64
+}
+
+func (f *funcAr07F64) RVars() []string { return f.rvars }
+
+func (f *funcAr07F64) Bind(args []interface{}) error {
+	if got, want := len(args), 7; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr07F64) Func() interface{} {
+	return func() float64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr07F64)(nil)
+)
+
+// funcAr08F64 implements rfunc.Formula
+type funcAr08F64 struct {
+	rvars []string
+	arg0  *float64
+	arg1  *float64
+	arg2  *float64
+	arg3  *float64
+	arg4  *float64
+	arg5  *float64
+	arg6  *float64
+	arg7  *float64
+	fct   func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64, arg07 float64) float64
+}
+
+func newFuncAr08F64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr08F64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64, arg07 float64) float64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr08F64{}.fct)] = newFuncAr08F64
+}
+
+func (f *funcAr08F64) RVars() []string { return f.rvars }
+
+func (f *funcAr08F64) Bind(args []interface{}) error {
+	if got, want := len(args), 8; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr08F64) Func() interface{} {
+	return func() float64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr08F64)(nil)
+)
+
+// funcAr09F64 implements rfunc.Formula
+type funcAr09F64 struct {
+	rvars []string
+	arg0  *float64
+	arg1  *float64
+	arg2  *float64
+	arg3  *float64
+	arg4  *float64
+	arg5  *float64
+	arg6  *float64
+	arg7  *float64
+	arg8  *float64
+	fct   func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64, arg07 float64, arg08 float64) float64
+}
+
+func newFuncAr09F64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr09F64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64, arg07 float64, arg08 float64) float64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr09F64{}.fct)] = newFuncAr09F64
+}
+
+func (f *funcAr09F64) RVars() []string { return f.rvars }
+
+func (f *funcAr09F64) Bind(args []interface{}) error {
+	if got, want := len(args), 9; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	{
+		ptr, ok := args[8].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 8 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[8], args[8],
+			)
+		}
+		f.arg8 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr09F64) Func() interface{} {
+	return func() float64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+			*f.arg8,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr09F64)(nil)
+)
+
+// funcAr10F64 implements rfunc.Formula
+type funcAr10F64 struct {
+	rvars []string
+	arg0  *float64
+	arg1  *float64
+	arg2  *float64
+	arg3  *float64
+	arg4  *float64
+	arg5  *float64
+	arg6  *float64
+	arg7  *float64
+	arg8  *float64
+	arg9  *float64
+	fct   func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64, arg07 float64, arg08 float64, arg09 float64) float64
+}
+
+func newFuncAr10F64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr10F64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64, arg07 float64, arg08 float64, arg09 float64) float64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr10F64{}.fct)] = newFuncAr10F64
+}
+
+func (f *funcAr10F64) RVars() []string { return f.rvars }
+
+func (f *funcAr10F64) Bind(args []interface{}) error {
+	if got, want := len(args), 10; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	{
+		ptr, ok := args[8].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 8 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[8], args[8],
+			)
+		}
+		f.arg8 = ptr
+	}
+	{
+		ptr, ok := args[9].(*float64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 9 (name=%s) mismatch: got=%T, want=*float64",
+				f.rvars[9], args[9],
+			)
+		}
+		f.arg9 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr10F64) Func() interface{} {
+	return func() float64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+			*f.arg8,
+			*f.arg9,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr10F64)(nil)
+)

--- a/groot/rtree/rfunc/rfunc_float64_gen_test.go
+++ b/groot/rtree/rfunc/rfunc_float64_gen_test.go
@@ -1,0 +1,630 @@
+// Copyright ©2020 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Automatically generated. DO NOT EDIT.
+
+package rfunc
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFuncAr00F64(t *testing.T) {
+
+	var rvars []string
+
+	fct := func() float64 {
+		return 42
+	}
+
+	form, err := newFuncAr00F64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr00F64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	var ptrs []interface{}
+
+	{
+		bad := make([]interface{}, 1)
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float64)()
+	if got, want := got, float64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr01F64(t *testing.T) {
+
+	rvars := make([]string, 1)
+	rvars[0] = "name-0"
+
+	fct := func(arg00 float64) float64 {
+		return 42
+	}
+
+	form, err := newFuncAr01F64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr01F64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 1)
+	ptrs[0] = new(float64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float64)()
+	if got, want := got, float64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr02F64(t *testing.T) {
+
+	rvars := make([]string, 2)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+
+	fct := func(arg00 float64, arg01 float64) float64 {
+		return 42
+	}
+
+	form, err := newFuncAr02F64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr02F64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 2)
+	ptrs[0] = new(float64)
+	ptrs[1] = new(float64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float64)()
+	if got, want := got, float64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr03F64(t *testing.T) {
+
+	rvars := make([]string, 3)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+
+	fct := func(arg00 float64, arg01 float64, arg02 float64) float64 {
+		return 42
+	}
+
+	form, err := newFuncAr03F64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr03F64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 3)
+	ptrs[0] = new(float64)
+	ptrs[1] = new(float64)
+	ptrs[2] = new(float64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float64)()
+	if got, want := got, float64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr04F64(t *testing.T) {
+
+	rvars := make([]string, 4)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+
+	fct := func(arg00 float64, arg01 float64, arg02 float64, arg03 float64) float64 {
+		return 42
+	}
+
+	form, err := newFuncAr04F64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr04F64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 4)
+	ptrs[0] = new(float64)
+	ptrs[1] = new(float64)
+	ptrs[2] = new(float64)
+	ptrs[3] = new(float64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float64)()
+	if got, want := got, float64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr05F64(t *testing.T) {
+
+	rvars := make([]string, 5)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+
+	fct := func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64) float64 {
+		return 42
+	}
+
+	form, err := newFuncAr05F64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr05F64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 5)
+	ptrs[0] = new(float64)
+	ptrs[1] = new(float64)
+	ptrs[2] = new(float64)
+	ptrs[3] = new(float64)
+	ptrs[4] = new(float64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float64)()
+	if got, want := got, float64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr06F64(t *testing.T) {
+
+	rvars := make([]string, 6)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+
+	fct := func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64) float64 {
+		return 42
+	}
+
+	form, err := newFuncAr06F64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr06F64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 6)
+	ptrs[0] = new(float64)
+	ptrs[1] = new(float64)
+	ptrs[2] = new(float64)
+	ptrs[3] = new(float64)
+	ptrs[4] = new(float64)
+	ptrs[5] = new(float64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float64)()
+	if got, want := got, float64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr07F64(t *testing.T) {
+
+	rvars := make([]string, 7)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+
+	fct := func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64) float64 {
+		return 42
+	}
+
+	form, err := newFuncAr07F64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr07F64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 7)
+	ptrs[0] = new(float64)
+	ptrs[1] = new(float64)
+	ptrs[2] = new(float64)
+	ptrs[3] = new(float64)
+	ptrs[4] = new(float64)
+	ptrs[5] = new(float64)
+	ptrs[6] = new(float64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float64)()
+	if got, want := got, float64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr08F64(t *testing.T) {
+
+	rvars := make([]string, 8)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+
+	fct := func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64, arg07 float64) float64 {
+		return 42
+	}
+
+	form, err := newFuncAr08F64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr08F64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 8)
+	ptrs[0] = new(float64)
+	ptrs[1] = new(float64)
+	ptrs[2] = new(float64)
+	ptrs[3] = new(float64)
+	ptrs[4] = new(float64)
+	ptrs[5] = new(float64)
+	ptrs[6] = new(float64)
+	ptrs[7] = new(float64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float64)()
+	if got, want := got, float64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr09F64(t *testing.T) {
+
+	rvars := make([]string, 9)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+	rvars[8] = "name-8"
+
+	fct := func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64, arg07 float64, arg08 float64) float64 {
+		return 42
+	}
+
+	form, err := newFuncAr09F64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr09F64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 9)
+	ptrs[0] = new(float64)
+	ptrs[1] = new(float64)
+	ptrs[2] = new(float64)
+	ptrs[3] = new(float64)
+	ptrs[4] = new(float64)
+	ptrs[5] = new(float64)
+	ptrs[6] = new(float64)
+	ptrs[7] = new(float64)
+	ptrs[8] = new(float64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float64)()
+	if got, want := got, float64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr10F64(t *testing.T) {
+
+	rvars := make([]string, 10)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+	rvars[8] = "name-8"
+	rvars[9] = "name-9"
+
+	fct := func(arg00 float64, arg01 float64, arg02 float64, arg03 float64, arg04 float64, arg05 float64, arg06 float64, arg07 float64, arg08 float64, arg09 float64) float64 {
+		return 42
+	}
+
+	form, err := newFuncAr10F64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr10F64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 10)
+	ptrs[0] = new(float64)
+	ptrs[1] = new(float64)
+	ptrs[2] = new(float64)
+	ptrs[3] = new(float64)
+	ptrs[4] = new(float64)
+	ptrs[5] = new(float64)
+	ptrs[6] = new(float64)
+	ptrs[7] = new(float64)
+	ptrs[8] = new(float64)
+	ptrs[9] = new(float64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() float64)()
+	if got, want := got, float64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}

--- a/groot/rtree/rfunc/rfunc_int32_gen.go
+++ b/groot/rtree/rfunc/rfunc_int32_gen.go
@@ -1,0 +1,1109 @@
+// Copyright ©2020 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Automatically generated. DO NOT EDIT.
+
+package rfunc
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// funcAr00I32 implements rfunc.Formula
+type funcAr00I32 struct {
+	fct func() int32
+}
+
+func newFuncAr00I32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr00I32{
+		fct: fct.(func() int32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr00I32{}.fct)] = newFuncAr00I32
+}
+
+func (f *funcAr00I32) RVars() []string { return nil }
+
+func (f *funcAr00I32) Bind(args []interface{}) error {
+	if got, want := len(args), 0; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	return nil
+}
+
+func (f *funcAr00I32) Func() interface{} {
+	return func() int32 {
+		return f.fct()
+	}
+}
+
+var (
+	_ Formula = (*funcAr00I32)(nil)
+)
+
+// funcAr01I32 implements rfunc.Formula
+type funcAr01I32 struct {
+	rvars []string
+	arg0  *int32
+	fct   func(arg00 int32) int32
+}
+
+func newFuncAr01I32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr01I32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 int32) int32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr01I32{}.fct)] = newFuncAr01I32
+}
+
+func (f *funcAr01I32) RVars() []string { return f.rvars }
+
+func (f *funcAr01I32) Bind(args []interface{}) error {
+	if got, want := len(args), 1; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr01I32) Func() interface{} {
+	return func() int32 {
+		return f.fct(
+			*f.arg0,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr01I32)(nil)
+)
+
+// funcAr02I32 implements rfunc.Formula
+type funcAr02I32 struct {
+	rvars []string
+	arg0  *int32
+	arg1  *int32
+	fct   func(arg00 int32, arg01 int32) int32
+}
+
+func newFuncAr02I32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr02I32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 int32, arg01 int32) int32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr02I32{}.fct)] = newFuncAr02I32
+}
+
+func (f *funcAr02I32) RVars() []string { return f.rvars }
+
+func (f *funcAr02I32) Bind(args []interface{}) error {
+	if got, want := len(args), 2; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr02I32) Func() interface{} {
+	return func() int32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr02I32)(nil)
+)
+
+// funcAr03I32 implements rfunc.Formula
+type funcAr03I32 struct {
+	rvars []string
+	arg0  *int32
+	arg1  *int32
+	arg2  *int32
+	fct   func(arg00 int32, arg01 int32, arg02 int32) int32
+}
+
+func newFuncAr03I32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr03I32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 int32, arg01 int32, arg02 int32) int32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr03I32{}.fct)] = newFuncAr03I32
+}
+
+func (f *funcAr03I32) RVars() []string { return f.rvars }
+
+func (f *funcAr03I32) Bind(args []interface{}) error {
+	if got, want := len(args), 3; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr03I32) Func() interface{} {
+	return func() int32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr03I32)(nil)
+)
+
+// funcAr04I32 implements rfunc.Formula
+type funcAr04I32 struct {
+	rvars []string
+	arg0  *int32
+	arg1  *int32
+	arg2  *int32
+	arg3  *int32
+	fct   func(arg00 int32, arg01 int32, arg02 int32, arg03 int32) int32
+}
+
+func newFuncAr04I32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr04I32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 int32, arg01 int32, arg02 int32, arg03 int32) int32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr04I32{}.fct)] = newFuncAr04I32
+}
+
+func (f *funcAr04I32) RVars() []string { return f.rvars }
+
+func (f *funcAr04I32) Bind(args []interface{}) error {
+	if got, want := len(args), 4; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr04I32) Func() interface{} {
+	return func() int32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr04I32)(nil)
+)
+
+// funcAr05I32 implements rfunc.Formula
+type funcAr05I32 struct {
+	rvars []string
+	arg0  *int32
+	arg1  *int32
+	arg2  *int32
+	arg3  *int32
+	arg4  *int32
+	fct   func(arg00 int32, arg01 int32, arg02 int32, arg03 int32, arg04 int32) int32
+}
+
+func newFuncAr05I32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr05I32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 int32, arg01 int32, arg02 int32, arg03 int32, arg04 int32) int32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr05I32{}.fct)] = newFuncAr05I32
+}
+
+func (f *funcAr05I32) RVars() []string { return f.rvars }
+
+func (f *funcAr05I32) Bind(args []interface{}) error {
+	if got, want := len(args), 5; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr05I32) Func() interface{} {
+	return func() int32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr05I32)(nil)
+)
+
+// funcAr06I32 implements rfunc.Formula
+type funcAr06I32 struct {
+	rvars []string
+	arg0  *int32
+	arg1  *int32
+	arg2  *int32
+	arg3  *int32
+	arg4  *int32
+	arg5  *int32
+	fct   func(arg00 int32, arg01 int32, arg02 int32, arg03 int32, arg04 int32, arg05 int32) int32
+}
+
+func newFuncAr06I32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr06I32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 int32, arg01 int32, arg02 int32, arg03 int32, arg04 int32, arg05 int32) int32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr06I32{}.fct)] = newFuncAr06I32
+}
+
+func (f *funcAr06I32) RVars() []string { return f.rvars }
+
+func (f *funcAr06I32) Bind(args []interface{}) error {
+	if got, want := len(args), 6; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr06I32) Func() interface{} {
+	return func() int32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr06I32)(nil)
+)
+
+// funcAr07I32 implements rfunc.Formula
+type funcAr07I32 struct {
+	rvars []string
+	arg0  *int32
+	arg1  *int32
+	arg2  *int32
+	arg3  *int32
+	arg4  *int32
+	arg5  *int32
+	arg6  *int32
+	fct   func(arg00 int32, arg01 int32, arg02 int32, arg03 int32, arg04 int32, arg05 int32, arg06 int32) int32
+}
+
+func newFuncAr07I32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr07I32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 int32, arg01 int32, arg02 int32, arg03 int32, arg04 int32, arg05 int32, arg06 int32) int32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr07I32{}.fct)] = newFuncAr07I32
+}
+
+func (f *funcAr07I32) RVars() []string { return f.rvars }
+
+func (f *funcAr07I32) Bind(args []interface{}) error {
+	if got, want := len(args), 7; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr07I32) Func() interface{} {
+	return func() int32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr07I32)(nil)
+)
+
+// funcAr08I32 implements rfunc.Formula
+type funcAr08I32 struct {
+	rvars []string
+	arg0  *int32
+	arg1  *int32
+	arg2  *int32
+	arg3  *int32
+	arg4  *int32
+	arg5  *int32
+	arg6  *int32
+	arg7  *int32
+	fct   func(arg00 int32, arg01 int32, arg02 int32, arg03 int32, arg04 int32, arg05 int32, arg06 int32, arg07 int32) int32
+}
+
+func newFuncAr08I32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr08I32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 int32, arg01 int32, arg02 int32, arg03 int32, arg04 int32, arg05 int32, arg06 int32, arg07 int32) int32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr08I32{}.fct)] = newFuncAr08I32
+}
+
+func (f *funcAr08I32) RVars() []string { return f.rvars }
+
+func (f *funcAr08I32) Bind(args []interface{}) error {
+	if got, want := len(args), 8; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr08I32) Func() interface{} {
+	return func() int32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr08I32)(nil)
+)
+
+// funcAr09I32 implements rfunc.Formula
+type funcAr09I32 struct {
+	rvars []string
+	arg0  *int32
+	arg1  *int32
+	arg2  *int32
+	arg3  *int32
+	arg4  *int32
+	arg5  *int32
+	arg6  *int32
+	arg7  *int32
+	arg8  *int32
+	fct   func(arg00 int32, arg01 int32, arg02 int32, arg03 int32, arg04 int32, arg05 int32, arg06 int32, arg07 int32, arg08 int32) int32
+}
+
+func newFuncAr09I32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr09I32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 int32, arg01 int32, arg02 int32, arg03 int32, arg04 int32, arg05 int32, arg06 int32, arg07 int32, arg08 int32) int32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr09I32{}.fct)] = newFuncAr09I32
+}
+
+func (f *funcAr09I32) RVars() []string { return f.rvars }
+
+func (f *funcAr09I32) Bind(args []interface{}) error {
+	if got, want := len(args), 9; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	{
+		ptr, ok := args[8].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 8 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[8], args[8],
+			)
+		}
+		f.arg8 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr09I32) Func() interface{} {
+	return func() int32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+			*f.arg8,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr09I32)(nil)
+)
+
+// funcAr10I32 implements rfunc.Formula
+type funcAr10I32 struct {
+	rvars []string
+	arg0  *int32
+	arg1  *int32
+	arg2  *int32
+	arg3  *int32
+	arg4  *int32
+	arg5  *int32
+	arg6  *int32
+	arg7  *int32
+	arg8  *int32
+	arg9  *int32
+	fct   func(arg00 int32, arg01 int32, arg02 int32, arg03 int32, arg04 int32, arg05 int32, arg06 int32, arg07 int32, arg08 int32, arg09 int32) int32
+}
+
+func newFuncAr10I32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr10I32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 int32, arg01 int32, arg02 int32, arg03 int32, arg04 int32, arg05 int32, arg06 int32, arg07 int32, arg08 int32, arg09 int32) int32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr10I32{}.fct)] = newFuncAr10I32
+}
+
+func (f *funcAr10I32) RVars() []string { return f.rvars }
+
+func (f *funcAr10I32) Bind(args []interface{}) error {
+	if got, want := len(args), 10; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	{
+		ptr, ok := args[8].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 8 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[8], args[8],
+			)
+		}
+		f.arg8 = ptr
+	}
+	{
+		ptr, ok := args[9].(*int32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 9 (name=%s) mismatch: got=%T, want=*int32",
+				f.rvars[9], args[9],
+			)
+		}
+		f.arg9 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr10I32) Func() interface{} {
+	return func() int32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+			*f.arg8,
+			*f.arg9,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr10I32)(nil)
+)

--- a/groot/rtree/rfunc/rfunc_int32_gen_test.go
+++ b/groot/rtree/rfunc/rfunc_int32_gen_test.go
@@ -1,0 +1,630 @@
+// Copyright ©2020 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Automatically generated. DO NOT EDIT.
+
+package rfunc
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFuncAr00I32(t *testing.T) {
+
+	var rvars []string
+
+	fct := func() int32 {
+		return 42
+	}
+
+	form, err := newFuncAr00I32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr00I32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	var ptrs []interface{}
+
+	{
+		bad := make([]interface{}, 1)
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int32)()
+	if got, want := got, int32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr01I32(t *testing.T) {
+
+	rvars := make([]string, 1)
+	rvars[0] = "name-0"
+
+	fct := func(arg00 int32) int32 {
+		return 42
+	}
+
+	form, err := newFuncAr01I32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr01I32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 1)
+	ptrs[0] = new(int32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int32)()
+	if got, want := got, int32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr02I32(t *testing.T) {
+
+	rvars := make([]string, 2)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+
+	fct := func(arg00 int32, arg01 int32) int32 {
+		return 42
+	}
+
+	form, err := newFuncAr02I32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr02I32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 2)
+	ptrs[0] = new(int32)
+	ptrs[1] = new(int32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int32)()
+	if got, want := got, int32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr03I32(t *testing.T) {
+
+	rvars := make([]string, 3)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+
+	fct := func(arg00 int32, arg01 int32, arg02 int32) int32 {
+		return 42
+	}
+
+	form, err := newFuncAr03I32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr03I32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 3)
+	ptrs[0] = new(int32)
+	ptrs[1] = new(int32)
+	ptrs[2] = new(int32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int32)()
+	if got, want := got, int32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr04I32(t *testing.T) {
+
+	rvars := make([]string, 4)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+
+	fct := func(arg00 int32, arg01 int32, arg02 int32, arg03 int32) int32 {
+		return 42
+	}
+
+	form, err := newFuncAr04I32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr04I32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 4)
+	ptrs[0] = new(int32)
+	ptrs[1] = new(int32)
+	ptrs[2] = new(int32)
+	ptrs[3] = new(int32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int32)()
+	if got, want := got, int32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr05I32(t *testing.T) {
+
+	rvars := make([]string, 5)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+
+	fct := func(arg00 int32, arg01 int32, arg02 int32, arg03 int32, arg04 int32) int32 {
+		return 42
+	}
+
+	form, err := newFuncAr05I32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr05I32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 5)
+	ptrs[0] = new(int32)
+	ptrs[1] = new(int32)
+	ptrs[2] = new(int32)
+	ptrs[3] = new(int32)
+	ptrs[4] = new(int32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int32)()
+	if got, want := got, int32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr06I32(t *testing.T) {
+
+	rvars := make([]string, 6)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+
+	fct := func(arg00 int32, arg01 int32, arg02 int32, arg03 int32, arg04 int32, arg05 int32) int32 {
+		return 42
+	}
+
+	form, err := newFuncAr06I32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr06I32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 6)
+	ptrs[0] = new(int32)
+	ptrs[1] = new(int32)
+	ptrs[2] = new(int32)
+	ptrs[3] = new(int32)
+	ptrs[4] = new(int32)
+	ptrs[5] = new(int32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int32)()
+	if got, want := got, int32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr07I32(t *testing.T) {
+
+	rvars := make([]string, 7)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+
+	fct := func(arg00 int32, arg01 int32, arg02 int32, arg03 int32, arg04 int32, arg05 int32, arg06 int32) int32 {
+		return 42
+	}
+
+	form, err := newFuncAr07I32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr07I32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 7)
+	ptrs[0] = new(int32)
+	ptrs[1] = new(int32)
+	ptrs[2] = new(int32)
+	ptrs[3] = new(int32)
+	ptrs[4] = new(int32)
+	ptrs[5] = new(int32)
+	ptrs[6] = new(int32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int32)()
+	if got, want := got, int32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr08I32(t *testing.T) {
+
+	rvars := make([]string, 8)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+
+	fct := func(arg00 int32, arg01 int32, arg02 int32, arg03 int32, arg04 int32, arg05 int32, arg06 int32, arg07 int32) int32 {
+		return 42
+	}
+
+	form, err := newFuncAr08I32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr08I32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 8)
+	ptrs[0] = new(int32)
+	ptrs[1] = new(int32)
+	ptrs[2] = new(int32)
+	ptrs[3] = new(int32)
+	ptrs[4] = new(int32)
+	ptrs[5] = new(int32)
+	ptrs[6] = new(int32)
+	ptrs[7] = new(int32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int32)()
+	if got, want := got, int32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr09I32(t *testing.T) {
+
+	rvars := make([]string, 9)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+	rvars[8] = "name-8"
+
+	fct := func(arg00 int32, arg01 int32, arg02 int32, arg03 int32, arg04 int32, arg05 int32, arg06 int32, arg07 int32, arg08 int32) int32 {
+		return 42
+	}
+
+	form, err := newFuncAr09I32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr09I32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 9)
+	ptrs[0] = new(int32)
+	ptrs[1] = new(int32)
+	ptrs[2] = new(int32)
+	ptrs[3] = new(int32)
+	ptrs[4] = new(int32)
+	ptrs[5] = new(int32)
+	ptrs[6] = new(int32)
+	ptrs[7] = new(int32)
+	ptrs[8] = new(int32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int32)()
+	if got, want := got, int32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr10I32(t *testing.T) {
+
+	rvars := make([]string, 10)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+	rvars[8] = "name-8"
+	rvars[9] = "name-9"
+
+	fct := func(arg00 int32, arg01 int32, arg02 int32, arg03 int32, arg04 int32, arg05 int32, arg06 int32, arg07 int32, arg08 int32, arg09 int32) int32 {
+		return 42
+	}
+
+	form, err := newFuncAr10I32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr10I32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 10)
+	ptrs[0] = new(int32)
+	ptrs[1] = new(int32)
+	ptrs[2] = new(int32)
+	ptrs[3] = new(int32)
+	ptrs[4] = new(int32)
+	ptrs[5] = new(int32)
+	ptrs[6] = new(int32)
+	ptrs[7] = new(int32)
+	ptrs[8] = new(int32)
+	ptrs[9] = new(int32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int32)()
+	if got, want := got, int32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}

--- a/groot/rtree/rfunc/rfunc_int64_gen.go
+++ b/groot/rtree/rfunc/rfunc_int64_gen.go
@@ -1,0 +1,1109 @@
+// Copyright ©2020 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Automatically generated. DO NOT EDIT.
+
+package rfunc
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// funcAr00I64 implements rfunc.Formula
+type funcAr00I64 struct {
+	fct func() int64
+}
+
+func newFuncAr00I64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr00I64{
+		fct: fct.(func() int64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr00I64{}.fct)] = newFuncAr00I64
+}
+
+func (f *funcAr00I64) RVars() []string { return nil }
+
+func (f *funcAr00I64) Bind(args []interface{}) error {
+	if got, want := len(args), 0; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	return nil
+}
+
+func (f *funcAr00I64) Func() interface{} {
+	return func() int64 {
+		return f.fct()
+	}
+}
+
+var (
+	_ Formula = (*funcAr00I64)(nil)
+)
+
+// funcAr01I64 implements rfunc.Formula
+type funcAr01I64 struct {
+	rvars []string
+	arg0  *int64
+	fct   func(arg00 int64) int64
+}
+
+func newFuncAr01I64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr01I64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 int64) int64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr01I64{}.fct)] = newFuncAr01I64
+}
+
+func (f *funcAr01I64) RVars() []string { return f.rvars }
+
+func (f *funcAr01I64) Bind(args []interface{}) error {
+	if got, want := len(args), 1; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr01I64) Func() interface{} {
+	return func() int64 {
+		return f.fct(
+			*f.arg0,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr01I64)(nil)
+)
+
+// funcAr02I64 implements rfunc.Formula
+type funcAr02I64 struct {
+	rvars []string
+	arg0  *int64
+	arg1  *int64
+	fct   func(arg00 int64, arg01 int64) int64
+}
+
+func newFuncAr02I64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr02I64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 int64, arg01 int64) int64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr02I64{}.fct)] = newFuncAr02I64
+}
+
+func (f *funcAr02I64) RVars() []string { return f.rvars }
+
+func (f *funcAr02I64) Bind(args []interface{}) error {
+	if got, want := len(args), 2; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr02I64) Func() interface{} {
+	return func() int64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr02I64)(nil)
+)
+
+// funcAr03I64 implements rfunc.Formula
+type funcAr03I64 struct {
+	rvars []string
+	arg0  *int64
+	arg1  *int64
+	arg2  *int64
+	fct   func(arg00 int64, arg01 int64, arg02 int64) int64
+}
+
+func newFuncAr03I64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr03I64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 int64, arg01 int64, arg02 int64) int64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr03I64{}.fct)] = newFuncAr03I64
+}
+
+func (f *funcAr03I64) RVars() []string { return f.rvars }
+
+func (f *funcAr03I64) Bind(args []interface{}) error {
+	if got, want := len(args), 3; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr03I64) Func() interface{} {
+	return func() int64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr03I64)(nil)
+)
+
+// funcAr04I64 implements rfunc.Formula
+type funcAr04I64 struct {
+	rvars []string
+	arg0  *int64
+	arg1  *int64
+	arg2  *int64
+	arg3  *int64
+	fct   func(arg00 int64, arg01 int64, arg02 int64, arg03 int64) int64
+}
+
+func newFuncAr04I64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr04I64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 int64, arg01 int64, arg02 int64, arg03 int64) int64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr04I64{}.fct)] = newFuncAr04I64
+}
+
+func (f *funcAr04I64) RVars() []string { return f.rvars }
+
+func (f *funcAr04I64) Bind(args []interface{}) error {
+	if got, want := len(args), 4; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr04I64) Func() interface{} {
+	return func() int64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr04I64)(nil)
+)
+
+// funcAr05I64 implements rfunc.Formula
+type funcAr05I64 struct {
+	rvars []string
+	arg0  *int64
+	arg1  *int64
+	arg2  *int64
+	arg3  *int64
+	arg4  *int64
+	fct   func(arg00 int64, arg01 int64, arg02 int64, arg03 int64, arg04 int64) int64
+}
+
+func newFuncAr05I64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr05I64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 int64, arg01 int64, arg02 int64, arg03 int64, arg04 int64) int64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr05I64{}.fct)] = newFuncAr05I64
+}
+
+func (f *funcAr05I64) RVars() []string { return f.rvars }
+
+func (f *funcAr05I64) Bind(args []interface{}) error {
+	if got, want := len(args), 5; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr05I64) Func() interface{} {
+	return func() int64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr05I64)(nil)
+)
+
+// funcAr06I64 implements rfunc.Formula
+type funcAr06I64 struct {
+	rvars []string
+	arg0  *int64
+	arg1  *int64
+	arg2  *int64
+	arg3  *int64
+	arg4  *int64
+	arg5  *int64
+	fct   func(arg00 int64, arg01 int64, arg02 int64, arg03 int64, arg04 int64, arg05 int64) int64
+}
+
+func newFuncAr06I64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr06I64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 int64, arg01 int64, arg02 int64, arg03 int64, arg04 int64, arg05 int64) int64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr06I64{}.fct)] = newFuncAr06I64
+}
+
+func (f *funcAr06I64) RVars() []string { return f.rvars }
+
+func (f *funcAr06I64) Bind(args []interface{}) error {
+	if got, want := len(args), 6; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr06I64) Func() interface{} {
+	return func() int64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr06I64)(nil)
+)
+
+// funcAr07I64 implements rfunc.Formula
+type funcAr07I64 struct {
+	rvars []string
+	arg0  *int64
+	arg1  *int64
+	arg2  *int64
+	arg3  *int64
+	arg4  *int64
+	arg5  *int64
+	arg6  *int64
+	fct   func(arg00 int64, arg01 int64, arg02 int64, arg03 int64, arg04 int64, arg05 int64, arg06 int64) int64
+}
+
+func newFuncAr07I64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr07I64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 int64, arg01 int64, arg02 int64, arg03 int64, arg04 int64, arg05 int64, arg06 int64) int64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr07I64{}.fct)] = newFuncAr07I64
+}
+
+func (f *funcAr07I64) RVars() []string { return f.rvars }
+
+func (f *funcAr07I64) Bind(args []interface{}) error {
+	if got, want := len(args), 7; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr07I64) Func() interface{} {
+	return func() int64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr07I64)(nil)
+)
+
+// funcAr08I64 implements rfunc.Formula
+type funcAr08I64 struct {
+	rvars []string
+	arg0  *int64
+	arg1  *int64
+	arg2  *int64
+	arg3  *int64
+	arg4  *int64
+	arg5  *int64
+	arg6  *int64
+	arg7  *int64
+	fct   func(arg00 int64, arg01 int64, arg02 int64, arg03 int64, arg04 int64, arg05 int64, arg06 int64, arg07 int64) int64
+}
+
+func newFuncAr08I64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr08I64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 int64, arg01 int64, arg02 int64, arg03 int64, arg04 int64, arg05 int64, arg06 int64, arg07 int64) int64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr08I64{}.fct)] = newFuncAr08I64
+}
+
+func (f *funcAr08I64) RVars() []string { return f.rvars }
+
+func (f *funcAr08I64) Bind(args []interface{}) error {
+	if got, want := len(args), 8; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr08I64) Func() interface{} {
+	return func() int64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr08I64)(nil)
+)
+
+// funcAr09I64 implements rfunc.Formula
+type funcAr09I64 struct {
+	rvars []string
+	arg0  *int64
+	arg1  *int64
+	arg2  *int64
+	arg3  *int64
+	arg4  *int64
+	arg5  *int64
+	arg6  *int64
+	arg7  *int64
+	arg8  *int64
+	fct   func(arg00 int64, arg01 int64, arg02 int64, arg03 int64, arg04 int64, arg05 int64, arg06 int64, arg07 int64, arg08 int64) int64
+}
+
+func newFuncAr09I64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr09I64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 int64, arg01 int64, arg02 int64, arg03 int64, arg04 int64, arg05 int64, arg06 int64, arg07 int64, arg08 int64) int64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr09I64{}.fct)] = newFuncAr09I64
+}
+
+func (f *funcAr09I64) RVars() []string { return f.rvars }
+
+func (f *funcAr09I64) Bind(args []interface{}) error {
+	if got, want := len(args), 9; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	{
+		ptr, ok := args[8].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 8 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[8], args[8],
+			)
+		}
+		f.arg8 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr09I64) Func() interface{} {
+	return func() int64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+			*f.arg8,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr09I64)(nil)
+)
+
+// funcAr10I64 implements rfunc.Formula
+type funcAr10I64 struct {
+	rvars []string
+	arg0  *int64
+	arg1  *int64
+	arg2  *int64
+	arg3  *int64
+	arg4  *int64
+	arg5  *int64
+	arg6  *int64
+	arg7  *int64
+	arg8  *int64
+	arg9  *int64
+	fct   func(arg00 int64, arg01 int64, arg02 int64, arg03 int64, arg04 int64, arg05 int64, arg06 int64, arg07 int64, arg08 int64, arg09 int64) int64
+}
+
+func newFuncAr10I64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr10I64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 int64, arg01 int64, arg02 int64, arg03 int64, arg04 int64, arg05 int64, arg06 int64, arg07 int64, arg08 int64, arg09 int64) int64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr10I64{}.fct)] = newFuncAr10I64
+}
+
+func (f *funcAr10I64) RVars() []string { return f.rvars }
+
+func (f *funcAr10I64) Bind(args []interface{}) error {
+	if got, want := len(args), 10; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	{
+		ptr, ok := args[8].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 8 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[8], args[8],
+			)
+		}
+		f.arg8 = ptr
+	}
+	{
+		ptr, ok := args[9].(*int64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 9 (name=%s) mismatch: got=%T, want=*int64",
+				f.rvars[9], args[9],
+			)
+		}
+		f.arg9 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr10I64) Func() interface{} {
+	return func() int64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+			*f.arg8,
+			*f.arg9,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr10I64)(nil)
+)

--- a/groot/rtree/rfunc/rfunc_int64_gen_test.go
+++ b/groot/rtree/rfunc/rfunc_int64_gen_test.go
@@ -1,0 +1,630 @@
+// Copyright ©2020 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Automatically generated. DO NOT EDIT.
+
+package rfunc
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFuncAr00I64(t *testing.T) {
+
+	var rvars []string
+
+	fct := func() int64 {
+		return 42
+	}
+
+	form, err := newFuncAr00I64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr00I64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	var ptrs []interface{}
+
+	{
+		bad := make([]interface{}, 1)
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int64)()
+	if got, want := got, int64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr01I64(t *testing.T) {
+
+	rvars := make([]string, 1)
+	rvars[0] = "name-0"
+
+	fct := func(arg00 int64) int64 {
+		return 42
+	}
+
+	form, err := newFuncAr01I64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr01I64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 1)
+	ptrs[0] = new(int64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int64)()
+	if got, want := got, int64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr02I64(t *testing.T) {
+
+	rvars := make([]string, 2)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+
+	fct := func(arg00 int64, arg01 int64) int64 {
+		return 42
+	}
+
+	form, err := newFuncAr02I64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr02I64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 2)
+	ptrs[0] = new(int64)
+	ptrs[1] = new(int64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int64)()
+	if got, want := got, int64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr03I64(t *testing.T) {
+
+	rvars := make([]string, 3)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+
+	fct := func(arg00 int64, arg01 int64, arg02 int64) int64 {
+		return 42
+	}
+
+	form, err := newFuncAr03I64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr03I64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 3)
+	ptrs[0] = new(int64)
+	ptrs[1] = new(int64)
+	ptrs[2] = new(int64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int64)()
+	if got, want := got, int64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr04I64(t *testing.T) {
+
+	rvars := make([]string, 4)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+
+	fct := func(arg00 int64, arg01 int64, arg02 int64, arg03 int64) int64 {
+		return 42
+	}
+
+	form, err := newFuncAr04I64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr04I64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 4)
+	ptrs[0] = new(int64)
+	ptrs[1] = new(int64)
+	ptrs[2] = new(int64)
+	ptrs[3] = new(int64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int64)()
+	if got, want := got, int64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr05I64(t *testing.T) {
+
+	rvars := make([]string, 5)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+
+	fct := func(arg00 int64, arg01 int64, arg02 int64, arg03 int64, arg04 int64) int64 {
+		return 42
+	}
+
+	form, err := newFuncAr05I64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr05I64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 5)
+	ptrs[0] = new(int64)
+	ptrs[1] = new(int64)
+	ptrs[2] = new(int64)
+	ptrs[3] = new(int64)
+	ptrs[4] = new(int64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int64)()
+	if got, want := got, int64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr06I64(t *testing.T) {
+
+	rvars := make([]string, 6)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+
+	fct := func(arg00 int64, arg01 int64, arg02 int64, arg03 int64, arg04 int64, arg05 int64) int64 {
+		return 42
+	}
+
+	form, err := newFuncAr06I64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr06I64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 6)
+	ptrs[0] = new(int64)
+	ptrs[1] = new(int64)
+	ptrs[2] = new(int64)
+	ptrs[3] = new(int64)
+	ptrs[4] = new(int64)
+	ptrs[5] = new(int64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int64)()
+	if got, want := got, int64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr07I64(t *testing.T) {
+
+	rvars := make([]string, 7)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+
+	fct := func(arg00 int64, arg01 int64, arg02 int64, arg03 int64, arg04 int64, arg05 int64, arg06 int64) int64 {
+		return 42
+	}
+
+	form, err := newFuncAr07I64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr07I64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 7)
+	ptrs[0] = new(int64)
+	ptrs[1] = new(int64)
+	ptrs[2] = new(int64)
+	ptrs[3] = new(int64)
+	ptrs[4] = new(int64)
+	ptrs[5] = new(int64)
+	ptrs[6] = new(int64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int64)()
+	if got, want := got, int64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr08I64(t *testing.T) {
+
+	rvars := make([]string, 8)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+
+	fct := func(arg00 int64, arg01 int64, arg02 int64, arg03 int64, arg04 int64, arg05 int64, arg06 int64, arg07 int64) int64 {
+		return 42
+	}
+
+	form, err := newFuncAr08I64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr08I64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 8)
+	ptrs[0] = new(int64)
+	ptrs[1] = new(int64)
+	ptrs[2] = new(int64)
+	ptrs[3] = new(int64)
+	ptrs[4] = new(int64)
+	ptrs[5] = new(int64)
+	ptrs[6] = new(int64)
+	ptrs[7] = new(int64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int64)()
+	if got, want := got, int64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr09I64(t *testing.T) {
+
+	rvars := make([]string, 9)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+	rvars[8] = "name-8"
+
+	fct := func(arg00 int64, arg01 int64, arg02 int64, arg03 int64, arg04 int64, arg05 int64, arg06 int64, arg07 int64, arg08 int64) int64 {
+		return 42
+	}
+
+	form, err := newFuncAr09I64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr09I64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 9)
+	ptrs[0] = new(int64)
+	ptrs[1] = new(int64)
+	ptrs[2] = new(int64)
+	ptrs[3] = new(int64)
+	ptrs[4] = new(int64)
+	ptrs[5] = new(int64)
+	ptrs[6] = new(int64)
+	ptrs[7] = new(int64)
+	ptrs[8] = new(int64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int64)()
+	if got, want := got, int64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr10I64(t *testing.T) {
+
+	rvars := make([]string, 10)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+	rvars[8] = "name-8"
+	rvars[9] = "name-9"
+
+	fct := func(arg00 int64, arg01 int64, arg02 int64, arg03 int64, arg04 int64, arg05 int64, arg06 int64, arg07 int64, arg08 int64, arg09 int64) int64 {
+		return 42
+	}
+
+	form, err := newFuncAr10I64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr10I64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 10)
+	ptrs[0] = new(int64)
+	ptrs[1] = new(int64)
+	ptrs[2] = new(int64)
+	ptrs[3] = new(int64)
+	ptrs[4] = new(int64)
+	ptrs[5] = new(int64)
+	ptrs[6] = new(int64)
+	ptrs[7] = new(int64)
+	ptrs[8] = new(int64)
+	ptrs[9] = new(int64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() int64)()
+	if got, want := got, int64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}

--- a/groot/rtree/rfunc/rfunc_uint32_gen.go
+++ b/groot/rtree/rfunc/rfunc_uint32_gen.go
@@ -1,0 +1,1109 @@
+// Copyright ©2020 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Automatically generated. DO NOT EDIT.
+
+package rfunc
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// funcAr00U32 implements rfunc.Formula
+type funcAr00U32 struct {
+	fct func() uint32
+}
+
+func newFuncAr00U32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr00U32{
+		fct: fct.(func() uint32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr00U32{}.fct)] = newFuncAr00U32
+}
+
+func (f *funcAr00U32) RVars() []string { return nil }
+
+func (f *funcAr00U32) Bind(args []interface{}) error {
+	if got, want := len(args), 0; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	return nil
+}
+
+func (f *funcAr00U32) Func() interface{} {
+	return func() uint32 {
+		return f.fct()
+	}
+}
+
+var (
+	_ Formula = (*funcAr00U32)(nil)
+)
+
+// funcAr01U32 implements rfunc.Formula
+type funcAr01U32 struct {
+	rvars []string
+	arg0  *uint32
+	fct   func(arg00 uint32) uint32
+}
+
+func newFuncAr01U32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr01U32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 uint32) uint32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr01U32{}.fct)] = newFuncAr01U32
+}
+
+func (f *funcAr01U32) RVars() []string { return f.rvars }
+
+func (f *funcAr01U32) Bind(args []interface{}) error {
+	if got, want := len(args), 1; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr01U32) Func() interface{} {
+	return func() uint32 {
+		return f.fct(
+			*f.arg0,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr01U32)(nil)
+)
+
+// funcAr02U32 implements rfunc.Formula
+type funcAr02U32 struct {
+	rvars []string
+	arg0  *uint32
+	arg1  *uint32
+	fct   func(arg00 uint32, arg01 uint32) uint32
+}
+
+func newFuncAr02U32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr02U32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 uint32, arg01 uint32) uint32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr02U32{}.fct)] = newFuncAr02U32
+}
+
+func (f *funcAr02U32) RVars() []string { return f.rvars }
+
+func (f *funcAr02U32) Bind(args []interface{}) error {
+	if got, want := len(args), 2; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr02U32) Func() interface{} {
+	return func() uint32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr02U32)(nil)
+)
+
+// funcAr03U32 implements rfunc.Formula
+type funcAr03U32 struct {
+	rvars []string
+	arg0  *uint32
+	arg1  *uint32
+	arg2  *uint32
+	fct   func(arg00 uint32, arg01 uint32, arg02 uint32) uint32
+}
+
+func newFuncAr03U32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr03U32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 uint32, arg01 uint32, arg02 uint32) uint32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr03U32{}.fct)] = newFuncAr03U32
+}
+
+func (f *funcAr03U32) RVars() []string { return f.rvars }
+
+func (f *funcAr03U32) Bind(args []interface{}) error {
+	if got, want := len(args), 3; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr03U32) Func() interface{} {
+	return func() uint32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr03U32)(nil)
+)
+
+// funcAr04U32 implements rfunc.Formula
+type funcAr04U32 struct {
+	rvars []string
+	arg0  *uint32
+	arg1  *uint32
+	arg2  *uint32
+	arg3  *uint32
+	fct   func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32) uint32
+}
+
+func newFuncAr04U32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr04U32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32) uint32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr04U32{}.fct)] = newFuncAr04U32
+}
+
+func (f *funcAr04U32) RVars() []string { return f.rvars }
+
+func (f *funcAr04U32) Bind(args []interface{}) error {
+	if got, want := len(args), 4; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr04U32) Func() interface{} {
+	return func() uint32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr04U32)(nil)
+)
+
+// funcAr05U32 implements rfunc.Formula
+type funcAr05U32 struct {
+	rvars []string
+	arg0  *uint32
+	arg1  *uint32
+	arg2  *uint32
+	arg3  *uint32
+	arg4  *uint32
+	fct   func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32, arg04 uint32) uint32
+}
+
+func newFuncAr05U32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr05U32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32, arg04 uint32) uint32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr05U32{}.fct)] = newFuncAr05U32
+}
+
+func (f *funcAr05U32) RVars() []string { return f.rvars }
+
+func (f *funcAr05U32) Bind(args []interface{}) error {
+	if got, want := len(args), 5; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr05U32) Func() interface{} {
+	return func() uint32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr05U32)(nil)
+)
+
+// funcAr06U32 implements rfunc.Formula
+type funcAr06U32 struct {
+	rvars []string
+	arg0  *uint32
+	arg1  *uint32
+	arg2  *uint32
+	arg3  *uint32
+	arg4  *uint32
+	arg5  *uint32
+	fct   func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32, arg04 uint32, arg05 uint32) uint32
+}
+
+func newFuncAr06U32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr06U32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32, arg04 uint32, arg05 uint32) uint32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr06U32{}.fct)] = newFuncAr06U32
+}
+
+func (f *funcAr06U32) RVars() []string { return f.rvars }
+
+func (f *funcAr06U32) Bind(args []interface{}) error {
+	if got, want := len(args), 6; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr06U32) Func() interface{} {
+	return func() uint32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr06U32)(nil)
+)
+
+// funcAr07U32 implements rfunc.Formula
+type funcAr07U32 struct {
+	rvars []string
+	arg0  *uint32
+	arg1  *uint32
+	arg2  *uint32
+	arg3  *uint32
+	arg4  *uint32
+	arg5  *uint32
+	arg6  *uint32
+	fct   func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32, arg04 uint32, arg05 uint32, arg06 uint32) uint32
+}
+
+func newFuncAr07U32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr07U32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32, arg04 uint32, arg05 uint32, arg06 uint32) uint32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr07U32{}.fct)] = newFuncAr07U32
+}
+
+func (f *funcAr07U32) RVars() []string { return f.rvars }
+
+func (f *funcAr07U32) Bind(args []interface{}) error {
+	if got, want := len(args), 7; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr07U32) Func() interface{} {
+	return func() uint32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr07U32)(nil)
+)
+
+// funcAr08U32 implements rfunc.Formula
+type funcAr08U32 struct {
+	rvars []string
+	arg0  *uint32
+	arg1  *uint32
+	arg2  *uint32
+	arg3  *uint32
+	arg4  *uint32
+	arg5  *uint32
+	arg6  *uint32
+	arg7  *uint32
+	fct   func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32, arg04 uint32, arg05 uint32, arg06 uint32, arg07 uint32) uint32
+}
+
+func newFuncAr08U32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr08U32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32, arg04 uint32, arg05 uint32, arg06 uint32, arg07 uint32) uint32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr08U32{}.fct)] = newFuncAr08U32
+}
+
+func (f *funcAr08U32) RVars() []string { return f.rvars }
+
+func (f *funcAr08U32) Bind(args []interface{}) error {
+	if got, want := len(args), 8; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr08U32) Func() interface{} {
+	return func() uint32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr08U32)(nil)
+)
+
+// funcAr09U32 implements rfunc.Formula
+type funcAr09U32 struct {
+	rvars []string
+	arg0  *uint32
+	arg1  *uint32
+	arg2  *uint32
+	arg3  *uint32
+	arg4  *uint32
+	arg5  *uint32
+	arg6  *uint32
+	arg7  *uint32
+	arg8  *uint32
+	fct   func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32, arg04 uint32, arg05 uint32, arg06 uint32, arg07 uint32, arg08 uint32) uint32
+}
+
+func newFuncAr09U32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr09U32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32, arg04 uint32, arg05 uint32, arg06 uint32, arg07 uint32, arg08 uint32) uint32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr09U32{}.fct)] = newFuncAr09U32
+}
+
+func (f *funcAr09U32) RVars() []string { return f.rvars }
+
+func (f *funcAr09U32) Bind(args []interface{}) error {
+	if got, want := len(args), 9; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	{
+		ptr, ok := args[8].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 8 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[8], args[8],
+			)
+		}
+		f.arg8 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr09U32) Func() interface{} {
+	return func() uint32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+			*f.arg8,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr09U32)(nil)
+)
+
+// funcAr10U32 implements rfunc.Formula
+type funcAr10U32 struct {
+	rvars []string
+	arg0  *uint32
+	arg1  *uint32
+	arg2  *uint32
+	arg3  *uint32
+	arg4  *uint32
+	arg5  *uint32
+	arg6  *uint32
+	arg7  *uint32
+	arg8  *uint32
+	arg9  *uint32
+	fct   func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32, arg04 uint32, arg05 uint32, arg06 uint32, arg07 uint32, arg08 uint32, arg09 uint32) uint32
+}
+
+func newFuncAr10U32(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr10U32{
+		rvars: rvars,
+		fct:   fct.(func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32, arg04 uint32, arg05 uint32, arg06 uint32, arg07 uint32, arg08 uint32, arg09 uint32) uint32),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr10U32{}.fct)] = newFuncAr10U32
+}
+
+func (f *funcAr10U32) RVars() []string { return f.rvars }
+
+func (f *funcAr10U32) Bind(args []interface{}) error {
+	if got, want := len(args), 10; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	{
+		ptr, ok := args[8].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 8 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[8], args[8],
+			)
+		}
+		f.arg8 = ptr
+	}
+	{
+		ptr, ok := args[9].(*uint32)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 9 (name=%s) mismatch: got=%T, want=*uint32",
+				f.rvars[9], args[9],
+			)
+		}
+		f.arg9 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr10U32) Func() interface{} {
+	return func() uint32 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+			*f.arg8,
+			*f.arg9,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr10U32)(nil)
+)

--- a/groot/rtree/rfunc/rfunc_uint32_gen_test.go
+++ b/groot/rtree/rfunc/rfunc_uint32_gen_test.go
@@ -1,0 +1,630 @@
+// Copyright ©2020 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Automatically generated. DO NOT EDIT.
+
+package rfunc
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFuncAr00U32(t *testing.T) {
+
+	var rvars []string
+
+	fct := func() uint32 {
+		return 42
+	}
+
+	form, err := newFuncAr00U32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr00U32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	var ptrs []interface{}
+
+	{
+		bad := make([]interface{}, 1)
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint32)()
+	if got, want := got, uint32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr01U32(t *testing.T) {
+
+	rvars := make([]string, 1)
+	rvars[0] = "name-0"
+
+	fct := func(arg00 uint32) uint32 {
+		return 42
+	}
+
+	form, err := newFuncAr01U32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr01U32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 1)
+	ptrs[0] = new(uint32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint32)()
+	if got, want := got, uint32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr02U32(t *testing.T) {
+
+	rvars := make([]string, 2)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+
+	fct := func(arg00 uint32, arg01 uint32) uint32 {
+		return 42
+	}
+
+	form, err := newFuncAr02U32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr02U32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 2)
+	ptrs[0] = new(uint32)
+	ptrs[1] = new(uint32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint32)()
+	if got, want := got, uint32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr03U32(t *testing.T) {
+
+	rvars := make([]string, 3)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+
+	fct := func(arg00 uint32, arg01 uint32, arg02 uint32) uint32 {
+		return 42
+	}
+
+	form, err := newFuncAr03U32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr03U32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 3)
+	ptrs[0] = new(uint32)
+	ptrs[1] = new(uint32)
+	ptrs[2] = new(uint32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint32)()
+	if got, want := got, uint32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr04U32(t *testing.T) {
+
+	rvars := make([]string, 4)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+
+	fct := func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32) uint32 {
+		return 42
+	}
+
+	form, err := newFuncAr04U32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr04U32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 4)
+	ptrs[0] = new(uint32)
+	ptrs[1] = new(uint32)
+	ptrs[2] = new(uint32)
+	ptrs[3] = new(uint32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint32)()
+	if got, want := got, uint32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr05U32(t *testing.T) {
+
+	rvars := make([]string, 5)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+
+	fct := func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32, arg04 uint32) uint32 {
+		return 42
+	}
+
+	form, err := newFuncAr05U32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr05U32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 5)
+	ptrs[0] = new(uint32)
+	ptrs[1] = new(uint32)
+	ptrs[2] = new(uint32)
+	ptrs[3] = new(uint32)
+	ptrs[4] = new(uint32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint32)()
+	if got, want := got, uint32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr06U32(t *testing.T) {
+
+	rvars := make([]string, 6)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+
+	fct := func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32, arg04 uint32, arg05 uint32) uint32 {
+		return 42
+	}
+
+	form, err := newFuncAr06U32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr06U32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 6)
+	ptrs[0] = new(uint32)
+	ptrs[1] = new(uint32)
+	ptrs[2] = new(uint32)
+	ptrs[3] = new(uint32)
+	ptrs[4] = new(uint32)
+	ptrs[5] = new(uint32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint32)()
+	if got, want := got, uint32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr07U32(t *testing.T) {
+
+	rvars := make([]string, 7)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+
+	fct := func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32, arg04 uint32, arg05 uint32, arg06 uint32) uint32 {
+		return 42
+	}
+
+	form, err := newFuncAr07U32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr07U32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 7)
+	ptrs[0] = new(uint32)
+	ptrs[1] = new(uint32)
+	ptrs[2] = new(uint32)
+	ptrs[3] = new(uint32)
+	ptrs[4] = new(uint32)
+	ptrs[5] = new(uint32)
+	ptrs[6] = new(uint32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint32)()
+	if got, want := got, uint32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr08U32(t *testing.T) {
+
+	rvars := make([]string, 8)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+
+	fct := func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32, arg04 uint32, arg05 uint32, arg06 uint32, arg07 uint32) uint32 {
+		return 42
+	}
+
+	form, err := newFuncAr08U32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr08U32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 8)
+	ptrs[0] = new(uint32)
+	ptrs[1] = new(uint32)
+	ptrs[2] = new(uint32)
+	ptrs[3] = new(uint32)
+	ptrs[4] = new(uint32)
+	ptrs[5] = new(uint32)
+	ptrs[6] = new(uint32)
+	ptrs[7] = new(uint32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint32)()
+	if got, want := got, uint32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr09U32(t *testing.T) {
+
+	rvars := make([]string, 9)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+	rvars[8] = "name-8"
+
+	fct := func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32, arg04 uint32, arg05 uint32, arg06 uint32, arg07 uint32, arg08 uint32) uint32 {
+		return 42
+	}
+
+	form, err := newFuncAr09U32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr09U32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 9)
+	ptrs[0] = new(uint32)
+	ptrs[1] = new(uint32)
+	ptrs[2] = new(uint32)
+	ptrs[3] = new(uint32)
+	ptrs[4] = new(uint32)
+	ptrs[5] = new(uint32)
+	ptrs[6] = new(uint32)
+	ptrs[7] = new(uint32)
+	ptrs[8] = new(uint32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint32)()
+	if got, want := got, uint32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr10U32(t *testing.T) {
+
+	rvars := make([]string, 10)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+	rvars[8] = "name-8"
+	rvars[9] = "name-9"
+
+	fct := func(arg00 uint32, arg01 uint32, arg02 uint32, arg03 uint32, arg04 uint32, arg05 uint32, arg06 uint32, arg07 uint32, arg08 uint32, arg09 uint32) uint32 {
+		return 42
+	}
+
+	form, err := newFuncAr10U32(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr10U32 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 10)
+	ptrs[0] = new(uint32)
+	ptrs[1] = new(uint32)
+	ptrs[2] = new(uint32)
+	ptrs[3] = new(uint32)
+	ptrs[4] = new(uint32)
+	ptrs[5] = new(uint32)
+	ptrs[6] = new(uint32)
+	ptrs[7] = new(uint32)
+	ptrs[8] = new(uint32)
+	ptrs[9] = new(uint32)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint32)()
+	if got, want := got, uint32(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}

--- a/groot/rtree/rfunc/rfunc_uint64_gen.go
+++ b/groot/rtree/rfunc/rfunc_uint64_gen.go
@@ -1,0 +1,1109 @@
+// Copyright ©2020 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Automatically generated. DO NOT EDIT.
+
+package rfunc
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// funcAr00U64 implements rfunc.Formula
+type funcAr00U64 struct {
+	fct func() uint64
+}
+
+func newFuncAr00U64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr00U64{
+		fct: fct.(func() uint64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr00U64{}.fct)] = newFuncAr00U64
+}
+
+func (f *funcAr00U64) RVars() []string { return nil }
+
+func (f *funcAr00U64) Bind(args []interface{}) error {
+	if got, want := len(args), 0; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	return nil
+}
+
+func (f *funcAr00U64) Func() interface{} {
+	return func() uint64 {
+		return f.fct()
+	}
+}
+
+var (
+	_ Formula = (*funcAr00U64)(nil)
+)
+
+// funcAr01U64 implements rfunc.Formula
+type funcAr01U64 struct {
+	rvars []string
+	arg0  *uint64
+	fct   func(arg00 uint64) uint64
+}
+
+func newFuncAr01U64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr01U64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 uint64) uint64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr01U64{}.fct)] = newFuncAr01U64
+}
+
+func (f *funcAr01U64) RVars() []string { return f.rvars }
+
+func (f *funcAr01U64) Bind(args []interface{}) error {
+	if got, want := len(args), 1; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr01U64) Func() interface{} {
+	return func() uint64 {
+		return f.fct(
+			*f.arg0,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr01U64)(nil)
+)
+
+// funcAr02U64 implements rfunc.Formula
+type funcAr02U64 struct {
+	rvars []string
+	arg0  *uint64
+	arg1  *uint64
+	fct   func(arg00 uint64, arg01 uint64) uint64
+}
+
+func newFuncAr02U64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr02U64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 uint64, arg01 uint64) uint64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr02U64{}.fct)] = newFuncAr02U64
+}
+
+func (f *funcAr02U64) RVars() []string { return f.rvars }
+
+func (f *funcAr02U64) Bind(args []interface{}) error {
+	if got, want := len(args), 2; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr02U64) Func() interface{} {
+	return func() uint64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr02U64)(nil)
+)
+
+// funcAr03U64 implements rfunc.Formula
+type funcAr03U64 struct {
+	rvars []string
+	arg0  *uint64
+	arg1  *uint64
+	arg2  *uint64
+	fct   func(arg00 uint64, arg01 uint64, arg02 uint64) uint64
+}
+
+func newFuncAr03U64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr03U64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 uint64, arg01 uint64, arg02 uint64) uint64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr03U64{}.fct)] = newFuncAr03U64
+}
+
+func (f *funcAr03U64) RVars() []string { return f.rvars }
+
+func (f *funcAr03U64) Bind(args []interface{}) error {
+	if got, want := len(args), 3; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr03U64) Func() interface{} {
+	return func() uint64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr03U64)(nil)
+)
+
+// funcAr04U64 implements rfunc.Formula
+type funcAr04U64 struct {
+	rvars []string
+	arg0  *uint64
+	arg1  *uint64
+	arg2  *uint64
+	arg3  *uint64
+	fct   func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64) uint64
+}
+
+func newFuncAr04U64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr04U64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64) uint64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr04U64{}.fct)] = newFuncAr04U64
+}
+
+func (f *funcAr04U64) RVars() []string { return f.rvars }
+
+func (f *funcAr04U64) Bind(args []interface{}) error {
+	if got, want := len(args), 4; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr04U64) Func() interface{} {
+	return func() uint64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr04U64)(nil)
+)
+
+// funcAr05U64 implements rfunc.Formula
+type funcAr05U64 struct {
+	rvars []string
+	arg0  *uint64
+	arg1  *uint64
+	arg2  *uint64
+	arg3  *uint64
+	arg4  *uint64
+	fct   func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64, arg04 uint64) uint64
+}
+
+func newFuncAr05U64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr05U64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64, arg04 uint64) uint64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr05U64{}.fct)] = newFuncAr05U64
+}
+
+func (f *funcAr05U64) RVars() []string { return f.rvars }
+
+func (f *funcAr05U64) Bind(args []interface{}) error {
+	if got, want := len(args), 5; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr05U64) Func() interface{} {
+	return func() uint64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr05U64)(nil)
+)
+
+// funcAr06U64 implements rfunc.Formula
+type funcAr06U64 struct {
+	rvars []string
+	arg0  *uint64
+	arg1  *uint64
+	arg2  *uint64
+	arg3  *uint64
+	arg4  *uint64
+	arg5  *uint64
+	fct   func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64, arg04 uint64, arg05 uint64) uint64
+}
+
+func newFuncAr06U64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr06U64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64, arg04 uint64, arg05 uint64) uint64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr06U64{}.fct)] = newFuncAr06U64
+}
+
+func (f *funcAr06U64) RVars() []string { return f.rvars }
+
+func (f *funcAr06U64) Bind(args []interface{}) error {
+	if got, want := len(args), 6; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr06U64) Func() interface{} {
+	return func() uint64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr06U64)(nil)
+)
+
+// funcAr07U64 implements rfunc.Formula
+type funcAr07U64 struct {
+	rvars []string
+	arg0  *uint64
+	arg1  *uint64
+	arg2  *uint64
+	arg3  *uint64
+	arg4  *uint64
+	arg5  *uint64
+	arg6  *uint64
+	fct   func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64, arg04 uint64, arg05 uint64, arg06 uint64) uint64
+}
+
+func newFuncAr07U64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr07U64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64, arg04 uint64, arg05 uint64, arg06 uint64) uint64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr07U64{}.fct)] = newFuncAr07U64
+}
+
+func (f *funcAr07U64) RVars() []string { return f.rvars }
+
+func (f *funcAr07U64) Bind(args []interface{}) error {
+	if got, want := len(args), 7; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr07U64) Func() interface{} {
+	return func() uint64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr07U64)(nil)
+)
+
+// funcAr08U64 implements rfunc.Formula
+type funcAr08U64 struct {
+	rvars []string
+	arg0  *uint64
+	arg1  *uint64
+	arg2  *uint64
+	arg3  *uint64
+	arg4  *uint64
+	arg5  *uint64
+	arg6  *uint64
+	arg7  *uint64
+	fct   func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64, arg04 uint64, arg05 uint64, arg06 uint64, arg07 uint64) uint64
+}
+
+func newFuncAr08U64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr08U64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64, arg04 uint64, arg05 uint64, arg06 uint64, arg07 uint64) uint64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr08U64{}.fct)] = newFuncAr08U64
+}
+
+func (f *funcAr08U64) RVars() []string { return f.rvars }
+
+func (f *funcAr08U64) Bind(args []interface{}) error {
+	if got, want := len(args), 8; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr08U64) Func() interface{} {
+	return func() uint64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr08U64)(nil)
+)
+
+// funcAr09U64 implements rfunc.Formula
+type funcAr09U64 struct {
+	rvars []string
+	arg0  *uint64
+	arg1  *uint64
+	arg2  *uint64
+	arg3  *uint64
+	arg4  *uint64
+	arg5  *uint64
+	arg6  *uint64
+	arg7  *uint64
+	arg8  *uint64
+	fct   func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64, arg04 uint64, arg05 uint64, arg06 uint64, arg07 uint64, arg08 uint64) uint64
+}
+
+func newFuncAr09U64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr09U64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64, arg04 uint64, arg05 uint64, arg06 uint64, arg07 uint64, arg08 uint64) uint64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr09U64{}.fct)] = newFuncAr09U64
+}
+
+func (f *funcAr09U64) RVars() []string { return f.rvars }
+
+func (f *funcAr09U64) Bind(args []interface{}) error {
+	if got, want := len(args), 9; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	{
+		ptr, ok := args[8].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 8 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[8], args[8],
+			)
+		}
+		f.arg8 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr09U64) Func() interface{} {
+	return func() uint64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+			*f.arg8,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr09U64)(nil)
+)
+
+// funcAr10U64 implements rfunc.Formula
+type funcAr10U64 struct {
+	rvars []string
+	arg0  *uint64
+	arg1  *uint64
+	arg2  *uint64
+	arg3  *uint64
+	arg4  *uint64
+	arg5  *uint64
+	arg6  *uint64
+	arg7  *uint64
+	arg8  *uint64
+	arg9  *uint64
+	fct   func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64, arg04 uint64, arg05 uint64, arg06 uint64, arg07 uint64, arg08 uint64, arg09 uint64) uint64
+}
+
+func newFuncAr10U64(rvars []string, fct interface{}) (Formula, error) {
+	return &funcAr10U64{
+		rvars: rvars,
+		fct:   fct.(func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64, arg04 uint64, arg05 uint64, arg06 uint64, arg07 uint64, arg08 uint64, arg09 uint64) uint64),
+	}, nil
+}
+
+func init() {
+	funcs[reflect.TypeOf(funcAr10U64{}.fct)] = newFuncAr10U64
+}
+
+func (f *funcAr10U64) RVars() []string { return f.rvars }
+
+func (f *funcAr10U64) Bind(args []interface{}) error {
+	if got, want := len(args), 10; got != want {
+		return fmt.Errorf(
+			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
+			got, want,
+		)
+	}
+	{
+		ptr, ok := args[0].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 0 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[0], args[0],
+			)
+		}
+		f.arg0 = ptr
+	}
+	{
+		ptr, ok := args[1].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 1 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[1], args[1],
+			)
+		}
+		f.arg1 = ptr
+	}
+	{
+		ptr, ok := args[2].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 2 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[2], args[2],
+			)
+		}
+		f.arg2 = ptr
+	}
+	{
+		ptr, ok := args[3].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 3 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[3], args[3],
+			)
+		}
+		f.arg3 = ptr
+	}
+	{
+		ptr, ok := args[4].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 4 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[4], args[4],
+			)
+		}
+		f.arg4 = ptr
+	}
+	{
+		ptr, ok := args[5].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 5 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[5], args[5],
+			)
+		}
+		f.arg5 = ptr
+	}
+	{
+		ptr, ok := args[6].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 6 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[6], args[6],
+			)
+		}
+		f.arg6 = ptr
+	}
+	{
+		ptr, ok := args[7].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 7 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[7], args[7],
+			)
+		}
+		f.arg7 = ptr
+	}
+	{
+		ptr, ok := args[8].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 8 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[8], args[8],
+			)
+		}
+		f.arg8 = ptr
+	}
+	{
+		ptr, ok := args[9].(*uint64)
+		if !ok {
+			return fmt.Errorf(
+				"rfunc: argument type 9 (name=%s) mismatch: got=%T, want=*uint64",
+				f.rvars[9], args[9],
+			)
+		}
+		f.arg9 = ptr
+	}
+	return nil
+}
+
+func (f *funcAr10U64) Func() interface{} {
+	return func() uint64 {
+		return f.fct(
+			*f.arg0,
+			*f.arg1,
+			*f.arg2,
+			*f.arg3,
+			*f.arg4,
+			*f.arg5,
+			*f.arg6,
+			*f.arg7,
+			*f.arg8,
+			*f.arg9,
+		)
+	}
+}
+
+var (
+	_ Formula = (*funcAr10U64)(nil)
+)

--- a/groot/rtree/rfunc/rfunc_uint64_gen_test.go
+++ b/groot/rtree/rfunc/rfunc_uint64_gen_test.go
@@ -1,0 +1,630 @@
+// Copyright ©2020 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Automatically generated. DO NOT EDIT.
+
+package rfunc
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFuncAr00U64(t *testing.T) {
+
+	var rvars []string
+
+	fct := func() uint64 {
+		return 42
+	}
+
+	form, err := newFuncAr00U64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr00U64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	var ptrs []interface{}
+
+	{
+		bad := make([]interface{}, 1)
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint64)()
+	if got, want := got, uint64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr01U64(t *testing.T) {
+
+	rvars := make([]string, 1)
+	rvars[0] = "name-0"
+
+	fct := func(arg00 uint64) uint64 {
+		return 42
+	}
+
+	form, err := newFuncAr01U64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr01U64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 1)
+	ptrs[0] = new(uint64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint64)()
+	if got, want := got, uint64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr02U64(t *testing.T) {
+
+	rvars := make([]string, 2)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+
+	fct := func(arg00 uint64, arg01 uint64) uint64 {
+		return 42
+	}
+
+	form, err := newFuncAr02U64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr02U64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 2)
+	ptrs[0] = new(uint64)
+	ptrs[1] = new(uint64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint64)()
+	if got, want := got, uint64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr03U64(t *testing.T) {
+
+	rvars := make([]string, 3)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+
+	fct := func(arg00 uint64, arg01 uint64, arg02 uint64) uint64 {
+		return 42
+	}
+
+	form, err := newFuncAr03U64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr03U64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 3)
+	ptrs[0] = new(uint64)
+	ptrs[1] = new(uint64)
+	ptrs[2] = new(uint64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint64)()
+	if got, want := got, uint64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr04U64(t *testing.T) {
+
+	rvars := make([]string, 4)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+
+	fct := func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64) uint64 {
+		return 42
+	}
+
+	form, err := newFuncAr04U64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr04U64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 4)
+	ptrs[0] = new(uint64)
+	ptrs[1] = new(uint64)
+	ptrs[2] = new(uint64)
+	ptrs[3] = new(uint64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint64)()
+	if got, want := got, uint64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr05U64(t *testing.T) {
+
+	rvars := make([]string, 5)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+
+	fct := func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64, arg04 uint64) uint64 {
+		return 42
+	}
+
+	form, err := newFuncAr05U64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr05U64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 5)
+	ptrs[0] = new(uint64)
+	ptrs[1] = new(uint64)
+	ptrs[2] = new(uint64)
+	ptrs[3] = new(uint64)
+	ptrs[4] = new(uint64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint64)()
+	if got, want := got, uint64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr06U64(t *testing.T) {
+
+	rvars := make([]string, 6)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+
+	fct := func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64, arg04 uint64, arg05 uint64) uint64 {
+		return 42
+	}
+
+	form, err := newFuncAr06U64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr06U64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 6)
+	ptrs[0] = new(uint64)
+	ptrs[1] = new(uint64)
+	ptrs[2] = new(uint64)
+	ptrs[3] = new(uint64)
+	ptrs[4] = new(uint64)
+	ptrs[5] = new(uint64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint64)()
+	if got, want := got, uint64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr07U64(t *testing.T) {
+
+	rvars := make([]string, 7)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+
+	fct := func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64, arg04 uint64, arg05 uint64, arg06 uint64) uint64 {
+		return 42
+	}
+
+	form, err := newFuncAr07U64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr07U64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 7)
+	ptrs[0] = new(uint64)
+	ptrs[1] = new(uint64)
+	ptrs[2] = new(uint64)
+	ptrs[3] = new(uint64)
+	ptrs[4] = new(uint64)
+	ptrs[5] = new(uint64)
+	ptrs[6] = new(uint64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint64)()
+	if got, want := got, uint64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr08U64(t *testing.T) {
+
+	rvars := make([]string, 8)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+
+	fct := func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64, arg04 uint64, arg05 uint64, arg06 uint64, arg07 uint64) uint64 {
+		return 42
+	}
+
+	form, err := newFuncAr08U64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr08U64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 8)
+	ptrs[0] = new(uint64)
+	ptrs[1] = new(uint64)
+	ptrs[2] = new(uint64)
+	ptrs[3] = new(uint64)
+	ptrs[4] = new(uint64)
+	ptrs[5] = new(uint64)
+	ptrs[6] = new(uint64)
+	ptrs[7] = new(uint64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint64)()
+	if got, want := got, uint64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr09U64(t *testing.T) {
+
+	rvars := make([]string, 9)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+	rvars[8] = "name-8"
+
+	fct := func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64, arg04 uint64, arg05 uint64, arg06 uint64, arg07 uint64, arg08 uint64) uint64 {
+		return 42
+	}
+
+	form, err := newFuncAr09U64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr09U64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 9)
+	ptrs[0] = new(uint64)
+	ptrs[1] = new(uint64)
+	ptrs[2] = new(uint64)
+	ptrs[3] = new(uint64)
+	ptrs[4] = new(uint64)
+	ptrs[5] = new(uint64)
+	ptrs[6] = new(uint64)
+	ptrs[7] = new(uint64)
+	ptrs[8] = new(uint64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint64)()
+	if got, want := got, uint64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}
+
+func TestFuncAr10U64(t *testing.T) {
+
+	rvars := make([]string, 10)
+	rvars[0] = "name-0"
+	rvars[1] = "name-1"
+	rvars[2] = "name-2"
+	rvars[3] = "name-3"
+	rvars[4] = "name-4"
+	rvars[5] = "name-5"
+	rvars[6] = "name-6"
+	rvars[7] = "name-7"
+	rvars[8] = "name-8"
+	rvars[9] = "name-9"
+
+	fct := func(arg00 uint64, arg01 uint64, arg02 uint64, arg03 uint64, arg04 uint64, arg05 uint64, arg06 uint64, arg07 uint64, arg08 uint64, arg09 uint64) uint64 {
+		return 42
+	}
+
+	form, err := newFuncAr10U64(rvars, fct)
+	if err != nil {
+		t.Fatalf("could not create funcAr10U64 formula: %+v", err)
+	}
+
+	if got, want := form.RVars(), rvars; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
+	}
+
+	ptrs := make([]interface{}, 10)
+	ptrs[0] = new(uint64)
+	ptrs[1] = new(uint64)
+	ptrs[2] = new(uint64)
+	ptrs[3] = new(uint64)
+	ptrs[4] = new(uint64)
+	ptrs[5] = new(uint64)
+	ptrs[6] = new(uint64)
+	ptrs[7] = new(uint64)
+	ptrs[8] = new(uint64)
+	ptrs[9] = new(uint64)
+
+	{
+		bad := make([]interface{}, len(ptrs))
+		copy(bad, ptrs)
+		for i := len(ptrs) - 1; i >= 0; i-- {
+			bad[i] = interface{}(nil)
+			err := form.Bind(bad)
+			if err == nil {
+				t.Fatalf("expected an error for empty iface")
+			}
+		}
+		bad = append(bad, interface{}(nil))
+		err := form.Bind(bad)
+		if err == nil {
+			t.Fatalf("expected an error for invalid args length")
+		}
+	}
+
+	err = form.Bind(ptrs)
+	if err != nil {
+		t.Fatalf("could not bind formula: %+v", err)
+	}
+
+	got := form.Func().(func() uint64)()
+	if got, want := got, uint64(42); got != want {
+		t.Fatalf("invalid output:\ngot= %v (%T)\nwant=%v (%T)", got, got, want, want)
+	}
+}


### PR DESCRIPTION
introducing the rfunc.Formula protocol brings this kind of performance
improvements:

```
$> benchstat ref.txt new-rfunc.txt
name                   old time/op    new time/op    delta
FormulaFunc/f0/Func-4     238ns ± 3%       4ns ± 1%   -98.20%  (p=0.000 n=20+16)
FormulaFunc/f1/Func-4     313ns ± 2%       5ns ± 5%   -98.39%  (p=0.000 n=20+19)
FormulaFunc/f2/Func-4     313ns ± 4%       5ns ± 3%   -98.31%  (p=0.000 n=20+20)
FormulaFunc/f3/Func-4     313ns ± 2%       5ns ± 4%   -98.32%  (p=0.000 n=18+20)

name                   old alloc/op   new alloc/op   delta
FormulaFunc/f0/Func-4     40.0B ± 0%      0.0B       -100.00%  (p=0.000 n=20+20)
FormulaFunc/f1/Func-4     48.0B ± 0%      0.0B       -100.00%  (p=0.000 n=20+20)
FormulaFunc/f2/Func-4     48.0B ± 0%      0.0B       -100.00%  (p=0.000 n=20+20)
FormulaFunc/f3/Func-4     48.0B ± 0%      0.0B       -100.00%  (p=0.000 n=20+20)

name                   old allocs/op  new allocs/op  delta
FormulaFunc/f0/Func-4      2.00 ± 0%      0.00       -100.00%  (p=0.000 n=20+20)
FormulaFunc/f1/Func-4      2.00 ± 0%      0.00       -100.00%  (p=0.000 n=20+20)
FormulaFunc/f2/Func-4      2.00 ± 0%      0.00       -100.00%  (p=0.000 n=20+20)
FormulaFunc/f3/Func-4      2.00 ± 0%      0.00       -100.00%  (p=0.000 n=20+20)
```

Fixes go-hep/hep#719.