### PR TITLE
groot/riofs: use go-mmap@v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/apache/arrow/go/arrow v0.0.0-20200603085845-24b352135a5b
 	github.com/astrogo/fitsio v0.1.0
 	github.com/campoy/embedmd v1.0.0
-	github.com/go-mmap/mmap v0.1.0
+	github.com/go-mmap/mmap v0.2.0
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
 	github.com/gonuts/binary v0.2.0
 	github.com/gonuts/commander v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4 h1:WtGNWLvXpe
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-mmap/mmap v0.1.0 h1:zZlfzrY/IG6ZBB9ryWDyn5+e51rrhPZ02lsfZ9LbKDc=
 github.com/go-mmap/mmap v0.1.0/go.mod h1:OefKwIBur8gVp5uxa6XL9/A9epUiKPxXK9POtWGbo5M=
+github.com/go-mmap/mmap v0.2.0 h1:OF41qHWJBcs4WsBg10aWrdqlnpeGayvnUsP+TxNu3ow=
+github.com/go-mmap/mmap v0.2.0/go.mod h1:OefKwIBur8gVp5uxa6XL9/A9epUiKPxXK9POtWGbo5M=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=


### PR DESCRIPTION
go-mmap v0.2.0 exposes types that have an os.File.Stat()-like method.
this is useful for e.g. root-fuse (in go-hep.org/x/exp)