### PR TITLE
groot/rtree: flush branches bound to empty slices

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,10 +17,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -qq pkg-config fuse libgles2-mesa-dev libxkbcommon-dev libxkbcommon-x11-dev
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must
           # be specified without a patch version:
           # we always use the latest patch version.
-          version: v1.28
+          version: v1.29
           args: --timeout=10m

--- a/groot/rtree/branch.go
+++ b/groot/rtree/branch.go
@@ -737,7 +737,10 @@ func (b *tbranch) write() (int, error) {
 	}
 
 	// FIXME(sbinet): harmonize or drive via "auto-flush" ?
-	if szNew+int64(n) >= int64(b.basketSize) {
+	if szNew+int64(n) >= int64(b.basketSize) ||
+		// handle case where branch is a slice, empty, for "too long"
+		// see: go-hep/hep#821.
+		len(b.ctx.bk.offsets) > b.basketSize {
 		err = b.flush()
 		if err != nil {
 			return n, fmt.Errorf("could not flush branch (auto-flush): %w", err)


### PR DESCRIPTION
Branches bound to empty slices for too long will overflow.
As an empty slice is... empty, nothing is written out, but the offsets slice keeps
growing.

Detect when the offsets slice will overflow and flush.

Fixes go-hep/hep#821.