### PR TITLE
groot/{riofs,rtree}: handle small/big file thresholds for long-running baskets

### DIFF
--- a/groot/riofs/dir.go
+++ b/groot/riofs/dir.go
@@ -284,7 +284,7 @@ func (dir *tdirectoryFile) close() error {
 		return nil
 	}
 
-	if dir.file != nil && dir.file.end > kStartBigFile {
+	if dir.file != nil && dir.file.IsBigFile() {
 		if dir.dir.rvers < 1000 {
 			dir.dir.rvers += 1000
 		}
@@ -616,7 +616,7 @@ func (dir *tdirectoryFile) writeKeys() error {
 		nbytes = int32(4) // space for n-keys
 	)
 
-	if dir.file.end > kStartBigFile {
+	if dir.file.IsBigFile() {
 		nbytes += 8
 	}
 	for i := range dir.Keys() {

--- a/groot/riofs/file.go
+++ b/groot/riofs/file.go
@@ -377,7 +377,7 @@ func (f *File) writeHeader() error {
 	}
 
 	version := f.version
-	if f.end > kStartBigFile ||
+	if f.IsBigFile() ||
 		f.seekfree > kStartBigFile ||
 		f.seekinfo > kStartBigFile {
 		if version < 1000000 {
@@ -728,7 +728,7 @@ func (f *File) writeFreeSegments() error {
 		return nil
 	}
 
-	isBigFile := f.end > kStartBigFile
+	isBigFile := f.IsBigFile()
 	if !isBigFile && f.end > kStartBigFile {
 		// the free block list is large enough to bring the file over the
 		// 2Gb limit.
@@ -986,6 +986,11 @@ func (f *File) Records(w io.Writer) error {
 	fmt.Fprintf(w, "seek-info: %d nbytes-info=%d\n", f.seekinfo, f.nbytesinfo)
 
 	return f.dir.records(w, 0)
+}
+
+// IsBigFile returns whether the file will need 64b offsets.
+func (f *File) IsBigFile() bool {
+	return f.end > kStartBigFile
 }
 
 var (

--- a/groot/riofs/key.go
+++ b/groot/riofs/key.go
@@ -167,7 +167,7 @@ func newKeyFrom(dir *tdirectoryFile, name, title, class string, obj root.Object,
 		otyp:     reflect.TypeOf(obj),
 		parent:   dir,
 	}
-	if f.end > kStartBigFile {
+	if f.IsBigFile() {
 		k.rvers += 1000
 	}
 
@@ -208,7 +208,7 @@ func newKeyFromBuf(dir *tdirectoryFile, name, title, class string, cycle int16, 
 		seekpdir: dir.seekdir,
 		parent:   dir,
 	}
-	if f.end > kStartBigFile {
+	if f.IsBigFile() {
 		k.rvers += 1000
 	}
 
@@ -257,7 +257,7 @@ func NewKeyForBasketInternal(dir Directory, name, title, class string, cycle int
 	}
 	k.keylen = k.sizeof()
 	k.nbytes = k.keylen
-	if f.end > kStartBigFile {
+	if f.IsBigFile() {
 		k.rvers += 1000
 	}
 


### PR DESCRIPTION
if a basket is created when a TFile is "small", but crosses over the
small/big file boundary, its "offsets" and "last" fields will be
inconsistent (by 8 bytes, ie: the number of bytes difference b/w
small/big TKeys).

This CL detects when such a case occurs and retro-actively adjusts these
fields.

Fixes go-hep/hep#826.