### PR TITLE
Improve take function in f64s

### DIFF
--- a/sliceop/f64s/f64s.go
+++ b/sliceop/f64s/f64s.go
@@ -97,18 +97,21 @@ func Take(dst, src []float64, indices []int) []float64 {
 		return dst
 	}
 
-	dst[0] = src[indices[0]]
-	for i := 1; i < len(indices); i++ {
-		v0 := indices[i-1]
-		v1 := indices[i]
+  n := len(indices)-1
+  v0 := indices[0]
+	for i:=0; i<n; i++ {
+		v1 := indices[i+1]
 		switch {
+		case v0 < v1:
 		case v0 == v1:
 			panic(errDuplicateIndices)
 		case v0 > v1:
 			panic(errSortedIndices)
 		}
-		dst[i] = src[v1]
+		dst[i] = src[v0]
+		v0 = v1
 	}
+	dst[n] = src[v0]
 
 	return dst
 }


### PR DESCRIPTION
First PR, so sorry in advance if I forget something!

The PR contains improvements for f64s' Take function for medium sized slices (see https://github.com/go-hep/hep/issues/675). The new code passed tests and performance (shown below) looks the same as I described before.

```
go test -cpuprofile cpu.prof -memprofile mem.prof -bench .
goos: darwin
goarch: amd64
pkg: go-hep.org/x/hep/sliceop/f64s
cpu: Intel(R) Core(TM) i5-7360U CPU @ 2.30GHz
BenchmarkTake/Len=2-4         	217951602	         5.435 ns/op	       0 B/op	       0 allocs/op
BenchmarkTake/Len=4-4         	205542572	         5.833 ns/op	       0 B/op	       0 allocs/op
BenchmarkTake/Len=8-4         	194566117	         6.161 ns/op	       0 B/op	       0 allocs/op
BenchmarkTake/Len=128-4       	23259826	        51.79 ns/op	       0 B/op	       0 allocs/op
BenchmarkTake/Len=1024-4      	 3105024	       383.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkTake/Len=1048576-4   	    1497	    676428 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	go-hep.org/x/hep/sliceop/f64s	9.553s
```