### PR TITLE
sliceop/f64s: improve Take performances

### DIFF
--- a/sliceop/f64s/f64s.go
+++ b/sliceop/f64s/f64s.go
@@ -102,6 +102,8 @@ func Take(dst, src []float64, indices []int) []float64 {
 		v0 := indices[i-1]
 		v1 := indices[i]
 		switch {
+		case v0 < v1:
+			// ok.
 		case v0 == v1:
 			panic(errDuplicateIndices)
 		case v0 > v1:


### PR DESCRIPTION
```
name                old time/op    new time/op    delta
Take/Len=2-8          2.69ns ± 1%    2.71ns ± 2%   +0.75%  (p=0.043 n=18+18)
Take/Len=4-8          3.18ns ± 1%    3.23ns ± 3%   +1.27%  (p=0.005 n=19+20)
Take/Len=8-8          3.83ns ± 1%    3.73ns ± 1%   -2.69%  (p=0.000 n=20+19)
Take/Len=128-8        44.1ns ± 4%    35.9ns ± 2%  -18.61%  (p=0.000 n=20+20)
Take/Len=1024-8        337ns ± 2%     280ns ± 6%  -16.73%  (p=0.000 n=19+20)
Take/Len=1048576-8    1.37ms ± 3%    1.31ms ± 5%   -3.97%  (p=0.000 n=19+20)

name                old alloc/op   new alloc/op   delta
Take/Len=2-8           0.00B          0.00B          ~     (all equal)
Take/Len=4-8           0.00B          0.00B          ~     (all equal)
Take/Len=8-8           0.00B          0.00B          ~     (all equal)
Take/Len=128-8         0.00B          0.00B          ~     (all equal)
Take/Len=1024-8        0.00B          0.00B          ~     (all equal)
Take/Len=1048576-8     0.00B          0.00B          ~     (all equal)

name                old allocs/op  new allocs/op  delta
Take/Len=2-8            0.00           0.00          ~     (all equal)
Take/Len=4-8            0.00           0.00          ~     (all equal)
Take/Len=8-8            0.00           0.00          ~     (all equal)
Take/Len=128-8          0.00           0.00          ~     (all equal)
Take/Len=1024-8         0.00           0.00          ~     (all equal)
Take/Len=1048576-8      0.00           0.00          ~     (all equal)
```