### PR TITLE
cmd/root2{arrow,csv,npy}: use riofs.Dir to retrieve trees

### DIFF
--- a/cmd/root2arrow/main.go
+++ b/cmd/root2arrow/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/apache/arrow/go/arrow/memory"
 	"go-hep.org/x/hep/groot"
 	"go-hep.org/x/hep/groot/rarrow"
+	"go-hep.org/x/hep/groot/riofs"
 	_ "go-hep.org/x/hep/groot/riofs/plugin/http"
 	_ "go-hep.org/x/hep/groot/riofs/plugin/xrootd"
 	"go-hep.org/x/hep/groot/rtree"
@@ -77,7 +78,7 @@ func process(oname, fname, tname string, stream bool) error {
 	}
 	defer f.Close()
 
-	obj, err := f.Get(tname)
+	obj, err := riofs.Dir(f).Get(tname)
 	if err != nil {
 		return err
 	}

--- a/cmd/root2csv/main.go
+++ b/cmd/root2csv/main.go
@@ -41,6 +41,7 @@ import (
 
 	"go-hep.org/x/hep/csvutil"
 	"go-hep.org/x/hep/groot"
+	"go-hep.org/x/hep/groot/riofs"
 	_ "go-hep.org/x/hep/groot/riofs/plugin/http"
 	_ "go-hep.org/x/hep/groot/riofs/plugin/xrootd"
 	"go-hep.org/x/hep/groot/rtree"
@@ -75,7 +76,7 @@ func process(oname, fname, tname string) error {
 	}
 	defer f.Close()
 
-	obj, err := f.Get(tname)
+	obj, err := riofs.Dir(f).Get(tname)
 	if err != nil {
 		return fmt.Errorf("could not get ROOT object: %w", err)
 	}

--- a/cmd/root2npy/main.go
+++ b/cmd/root2npy/main.go
@@ -137,6 +137,7 @@ import (
 	"github.com/sbinet/npyio"
 
 	"go-hep.org/x/hep/groot"
+	"go-hep.org/x/hep/groot/riofs"
 	_ "go-hep.org/x/hep/groot/riofs/plugin/http"
 	_ "go-hep.org/x/hep/groot/riofs/plugin/xrootd"
 	"go-hep.org/x/hep/groot/rtree"
@@ -170,7 +171,7 @@ func process(oname, fname, tname string) error {
 	}
 	defer f.Close()
 
-	obj, err := f.Get(tname)
+	obj, err := riofs.Dir(f).Get(tname)
 	if err != nil {
 		return fmt.Errorf("%w", err)
 	}


### PR DESCRIPTION
This CL uses riofs.Dir to be able to retrieve possibly deeply nested
trees from a ROOT file's hierarchy.

Signed-off-by: Sebastien Binet <binet@cern.ch>