### PR TITLE
cmd/root2npy: improve memory usage

### DIFF
--- a/cmd/root2npy/main_test.go
+++ b/cmd/root2npy/main_test.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -97,3 +98,29 @@ func TestProcess(t *testing.T) {
 type nilNamer struct{}
 
 func (nilNamer) Name() string { return "output.npz" }
+
+func BenchmarkProcess(b *testing.B) {
+	tmp, err := os.MkdirTemp("", "root2npy-")
+	if err != nil {
+		b.Fatalf("could not create tmp dir: %+v", err)
+	}
+	defer os.RemoveAll(tmp)
+
+	const (
+		fname = "../../groot/testdata/small-flat-tree.root"
+		tname = "tree"
+	)
+	itr := 0
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		oname := filepath.Join(tmp, fmt.Sprintf("o-%d.npz", itr))
+		itr++
+		b.StartTimer()
+		err := process(oname, fname, tname)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
This CL modifies root2npy to process Trees column by column so only 1
numpy buffer is materialized in-memory.

```
$> benchstat ./ref.txt ./new.txt
name       old time/op    new time/op    delta
Process-8    2.48ms ± 1%    2.39ms ± 2%   -3.44%  (p=0.000 n=28+29)

name       old alloc/op   new alloc/op   delta
Process-8    3.50MB ± 1%    2.64MB ± 2%  -24.63%  (p=0.000 n=30+29)

name       old allocs/op  new allocs/op  delta
Process-8     3.41k ± 0%     3.28k ± 0%   -3.60%  (p=0.000 n=30+30)
```