### PR TITLE
groot/internal/httpio: first import

### DIFF
--- a/groot/internal/httpio/httpio.go
+++ b/groot/internal/httpio/httpio.go
@@ -1,0 +1,78 @@
+// Copyright ©2022 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package httpio provides types for basic I/O interfaces over HTTP.
+package httpio // import "go-hep.org/x/hep/groot/internal/httpio"
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+)
+
+var (
+	defaultClient *http.Client
+
+	errAcceptRange = errors.New("httpio: accept-range not supported")
+)
+
+type config struct {
+	ctx  context.Context
+	cli  *http.Client
+	auth struct {
+		usr string
+		pwd string
+	}
+}
+
+func newConfig() *config {
+	return &config{
+		ctx: context.Background(),
+		cli: defaultClient,
+	}
+}
+
+type Option func(*config) error
+
+// WithClient sets up Reader to use a user-provided HTTP client.
+//
+// By default, Reader uses an httpio-local default client.
+func WithClient(cli *http.Client) Option {
+	return func(c *config) error {
+		c.cli = cli
+		return nil
+	}
+}
+
+// WithBasicAuth sets up a basic authentification scheme.
+func WithBasicAuth(usr, pwd string) Option {
+	return func(c *config) error {
+		c.auth.usr = usr
+		c.auth.pwd = pwd
+		return nil
+	}
+}
+
+// WithContext configures Reader to use a user-provided context.
+//
+// By default, Reader uses context.Background.
+func WithContext(ctx context.Context) Option {
+	return func(c *config) error {
+		c.ctx = ctx
+		return nil
+	}
+}
+
+func init() {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.MaxIdleConns = 100
+	t.MaxConnsPerHost = 100
+	t.MaxIdleConnsPerHost = 100
+
+	defaultClient = &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: t,
+	}
+}

--- a/groot/internal/httpio/reader.go
+++ b/groot/internal/httpio/reader.go
@@ -1,0 +1,150 @@
+// Copyright ©2022 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package httpio
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+)
+
+// Reader presents an HTTP resource as an io.Reader and io.ReaderAt.
+type Reader struct {
+	cli    *http.Client
+	req    *http.Request
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	r    *io.SectionReader
+	len  int64
+	etag string
+}
+
+// Open returns a Reader from the provided URL.
+func Open(uri string, opts ...Option) (r *Reader, err error) {
+	cfg := newConfig()
+	for _, opt := range opts {
+		err := opt(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("httpio: could not open %q: %w", uri, err)
+		}
+	}
+
+	r = &Reader{
+		cli: cfg.cli,
+	}
+	r.ctx, r.cancel = context.WithCancel(cfg.ctx)
+
+	req, err := http.NewRequestWithContext(r.ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		r.cancel()
+		return nil, fmt.Errorf("httpio: could not create HTTP request: %w", err)
+	}
+	if cfg.auth.usr != "" || cfg.auth.pwd != "" {
+		req.SetBasicAuth(cfg.auth.usr, cfg.auth.pwd)
+	}
+	r.req = req.Clone(r.ctx)
+
+	hdr, err := r.cli.Head(r.req.URL.String())
+	if err != nil {
+		r.cancel()
+		return nil, fmt.Errorf("httpio: could not send HEAD request: %w", err)
+	}
+	defer hdr.Body.Close()
+	_, _ = io.Copy(io.Discard, hdr.Body)
+
+	if hdr.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("httpio: invalid HEAD response code=%v", hdr.StatusCode)
+	}
+
+	if hdr.Header.Get("accept-ranges") != "bytes" {
+		return nil, fmt.Errorf("httpio: invalid HEAD response: %w", errAcceptRange)
+	}
+
+	r.len = hdr.ContentLength
+	r.etag = hdr.Header.Get("Etag")
+	r.r = io.NewSectionReader(r, 0, r.len)
+
+	return r, nil
+}
+
+// Size returns the number of bytes available for reading via ReadAt.
+func (r *Reader) Size() int64 {
+	return r.len
+}
+
+// Name returns the name of the file as presented to Open.
+func (r *Reader) Name() string {
+	return r.req.URL.String()
+}
+
+// Close implements the io.Closer interface.
+func (r *Reader) Close() error {
+	r.cancel()
+	r.cli = nil
+	r.req = nil
+	return nil
+}
+
+// Read implements the io.Reader interface.
+func (r *Reader) Read(p []byte) (int, error) {
+	return r.r.Read(p)
+}
+
+// Seek implements the io.Seeker interface.
+func (r *Reader) Seek(offset int64, whence int) (int64, error) {
+	return r.r.Seek(offset, whence)
+}
+
+// ReadAt implements the io.ReaderAt interface.
+func (r *Reader) ReadAt(p []byte, off int64) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	rng := rng(off, off+int64(len(p))-1)
+	req := r.req.Clone(r.ctx)
+	req.Header.Set("Range", rng)
+
+	resp, err := r.cli.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("httpio: could not send GET request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	n, _ := io.ReadFull(resp.Body, p)
+
+	if etag := resp.Header.Get("Etag"); etag != r.etag {
+		return n, fmt.Errorf("httpio: resource changed")
+	}
+
+	switch resp.StatusCode {
+	case http.StatusPartialContent:
+		// ok.
+	case http.StatusRequestedRangeNotSatisfiable:
+		return 0, io.EOF
+	default:
+		return n, fmt.Errorf("httpio: invalid GET response: code=%v", resp.StatusCode)
+	}
+
+	if int64(len(p)) > r.len {
+		return n, io.EOF
+	}
+
+	return n, nil
+}
+
+func rng(beg, end int64) string {
+	return "bytes=" + strconv.Itoa(int(beg)) + "-" + strconv.Itoa(int(end))
+}
+
+var (
+	_ io.Reader   = (*Reader)(nil)
+	_ io.Seeker   = (*Reader)(nil)
+	_ io.ReaderAt = (*Reader)(nil)
+	_ io.Closer   = (*Reader)(nil)
+)

--- a/groot/internal/httpio/reader_test.go
+++ b/groot/internal/httpio/reader_test.go
@@ -1,0 +1,153 @@
+// Copyright ©2022 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package httpio
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"testing/iotest"
+)
+
+func TestOpen(t *testing.T) {
+	srv := httptest.NewServer(http.FileServer(http.Dir("./testdata")))
+
+	for _, tc := range []struct {
+		url  string
+		opts []Option
+		err  error
+	}{
+		{
+			url: srv.URL + "/data.txt",
+			opts: []Option{
+				func(c *config) error { return fmt.Errorf("option error") },
+			},
+			err: fmt.Errorf("httpio: could not open %q: %w", srv.URL+"/data.txt", fmt.Errorf("option error")),
+		},
+		{
+			url: srv.URL + "xxx/not-there.txt",
+			err: fmt.Errorf("httpio: could not create HTTP request: "),
+		},
+		{
+			url: srv.URL + "000/not-there.txt",
+			err: fmt.Errorf("httpio: could not send HEAD request: "),
+		},
+		{
+			url: srv.URL + "/not-there.txt",
+			err: fmt.Errorf("httpio: invalid HEAD response code=404"),
+		},
+	} {
+		t.Run(tc.url, func(t *testing.T) {
+			_, err := Open(tc.url, tc.opts...)
+			switch {
+			case err == nil:
+				t.Fatalf("expected an error")
+			default:
+				if got, want := err.Error(), tc.err.Error(); !strings.HasPrefix(got, want) {
+					t.Fatalf("invalid error:\ngot= %s\nwant=%s", got, want)
+				}
+			}
+		})
+	}
+
+	t.Run("no-range", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("accept-range", "none")
+		}))
+
+		want := fmt.Errorf("httpio: invalid HEAD response: httpio: accept-range not supported")
+
+		_, err := Open(srv.URL)
+		if got, want := err.Error(), want.Error(); got != want {
+			t.Fatalf("invalid error:\ngot= %s\nwant=%s", got, want)
+		}
+	})
+}
+
+func TestReader(t *testing.T) {
+	dir := "./testdata"
+	srv := httptest.NewServer(http.FileServer(http.Dir(dir)))
+
+	want, err := os.ReadFile("./testdata/data.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Open(
+		srv.URL+"/data.txt",
+		WithBasicAuth("gopher", "s3cr3t"),
+		WithContext(context.Background()),
+		WithClient(http.DefaultClient),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	if got, want := r.Name(), srv.URL+"/data.txt"; got != want {
+		t.Fatalf("invalid name:\ngot= %q\nwant=%q", got, want)
+	}
+
+	if got, want := r.Size(), int64(len(want)); got != want {
+		t.Fatalf("invalid size: got=%d, want=%d", got, want)
+	}
+
+	got := make([]byte, len(want))
+	n, err := r.ReadAt(got, 0)
+	if err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("could not read-at: %+v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("invalid read-at:\ngot= %q\nwant=%q", got, want)
+	}
+	if len(want) != n {
+		t.Fatalf("invalid nbytes: got=%d, want=%d", n, len(want))
+	}
+
+	t.Run("iotest", func(t *testing.T) {
+		r, err := Open(srv.URL + "/data.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer r.Close()
+
+		err = iotest.TestReader(r, want)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("etag", func(t *testing.T) {
+		r, err := Open(srv.URL + "/data.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer r.Close()
+
+		// fake changing resource
+		r.etag += "XXX"
+
+		p := make([]byte, len(want))
+		n, err := r.ReadAt(p, 0)
+		switch {
+		case err == nil:
+			t.Fatalf("expected an Etag-related error")
+		default:
+			if got, want := err.Error(), "httpio: resource changed"; got != want {
+				t.Fatalf("invalid error:\ngot= %q\nwant=%q", got, want)
+			}
+		}
+		if n != len(want) {
+			t.Fatalf("invalid size: got=%d, want=%d", n, len(want))
+		}
+	})
+}

--- a/groot/internal/httpio/testdata/data.txt
+++ b/groot/internal/httpio/testdata/data.txt
@@ -1,0 +1,3 @@
+hello world!
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/groot/riofs/plugin/http/preader.go
+++ b/groot/riofs/plugin/http/preader.go
@@ -1,0 +1,98 @@
+// Copyright ©2022 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package http
+
+import (
+	"sync"
+
+	"go-hep.org/x/hep/groot/riofs"
+)
+
+type preader struct {
+	r reader
+	n int // number of workers
+}
+
+var (
+	_ riofs.Reader = (*preader)(nil)
+)
+
+const blkSize = 1 * 1024 * 1024 // TODO(sbinet): adjust size for multiple payloads?
+
+func (r *preader) Close() error {
+	return r.r.Close()
+}
+
+func (r *preader) Read(p []byte) (int, error) {
+	return r.r.Read(p)
+}
+
+func (r *preader) ReadAt(p []byte, off int64) (int, error) {
+	switch sz := len(p); {
+	default:
+		return r.r.ReadAt(p, off)
+	case sz > blkSize:
+		return r.pread(p, off)
+	}
+}
+
+func (r *preader) pread(p []byte, off int64) (int, error) {
+	nblks := len(p) / blkSize
+	sps := make([]span, 0, nblks+1)
+	beg := off
+	end := off + int64(len(p))
+	for beg < end {
+		len := int64(blkSize)
+		if beg+len > end {
+			len = end - beg
+		}
+		sps = append(sps, span{
+			off: beg,
+			len: len,
+		})
+		beg += blkSize
+	}
+	out := make([]pread, len(sps))
+	wrk := make(chan int, r.n)
+	go func() {
+		defer close(wrk)
+		for i := range sps {
+			wrk <- i
+		}
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(r.n)
+	for i := 0; i < r.n; i++ {
+		go func() {
+			defer wg.Done()
+			for i := range wrk {
+				spn := sps[i]
+				beg := int64(i) * blkSize
+				end := beg + spn.len
+				out[i].n, out[i].err = r.r.ReadAt(p[beg:end], spn.off)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	var (
+		n   int
+		err error
+	)
+	for _, o := range out {
+		n += o.n
+		if o.err != nil {
+			err = o.err
+		}
+	}
+	return n, err
+}
+
+type pread struct {
+	n   int
+	err error
+}

--- a/groot/riofs/plugin/http/rcache.go
+++ b/groot/riofs/plugin/http/rcache.go
@@ -1,0 +1,111 @@
+// Copyright ©2022 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package http
+
+import (
+	"io"
+	"os"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type reader interface {
+	io.Reader
+	io.ReaderAt
+	io.Closer
+}
+
+type store interface {
+	io.Reader
+	io.ReaderAt
+	io.Writer
+	io.WriterAt
+	io.Closer
+
+	Name() string
+}
+
+type rcache struct {
+	r reader
+	o store
+
+	mu  sync.RWMutex
+	sps spans
+}
+
+func rcacheOf(r reader) (*rcache, error) {
+	f, err := os.CreateTemp("", "riofs-remote-")
+	if err != nil {
+		return nil, err
+	}
+
+	return &rcache{r: r, o: f}, nil
+}
+
+func (r *rcache) Close() error {
+	e1 := r.r.Close()
+	e2 := r.o.Close()
+	_ = os.RemoveAll(r.o.Name())
+	if e1 != nil {
+		return e1
+	}
+	return e2
+}
+
+func (r *rcache) Read(p []byte) (int, error) {
+	return r.r.Read(p)
+}
+
+func (r *rcache) ReadAt(p []byte, off int64) (int, error) {
+	sp := span{off: off, len: int64(len(p))}
+	oo := r.split(sp)
+	if len(oo) == 0 {
+		return r.o.ReadAt(p, off)
+	}
+	var (
+		grp errgroup.Group
+		ii  int64
+	)
+	for i := range oo {
+		spa := oo[i]
+		beg := ii
+		end := ii + spa.len
+		ii = end
+		grp.Go(func() error {
+			return r.fetch(p[beg:end], spa)
+		})
+	}
+
+	err := grp.Wait()
+	if err != nil {
+		return 0, err
+	}
+
+	return r.o.ReadAt(p, off)
+}
+
+func (r *rcache) split(sp span) []span {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return split(sp, r.sps)
+}
+
+func (r *rcache) fetch(p []byte, sp span) error {
+	_, err := r.r.ReadAt(p, sp.off)
+	if err != nil {
+		return err
+	}
+	_, err = r.o.WriteAt(p, sp.off)
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.sps.add(sp)
+	return nil
+}

--- a/groot/riofs/plugin/http/span.go
+++ b/groot/riofs/plugin/http/span.go
@@ -1,0 +1,113 @@
+// Copyright ©2022 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package http
+
+import "sort"
+
+type span struct {
+	off int64
+	len int64
+}
+
+func split(sp span, sps []span) []span {
+	if len(sps) == 0 {
+		return []span{sp}
+	}
+
+	var o []span
+
+	for _, v := range sps {
+		b1 := v.off
+		e1 := v.off + v.len
+		b2 := sp.off
+		e2 := sp.off + sp.len
+		switch {
+		case e1 <= b2:
+			//  [ s1=v ]
+			//         [  s2=sp ]
+			continue
+		case e2 <= b1:
+			//         [ s1 ]
+			// [ s2=sp ]
+			o = append(o, sp)
+			sp.len = 0
+		case b2 < b1 && e1 <= e2:
+			//   [ s1=v ]
+			//  [  s2=sp ]
+			len := b1 - b2
+			o = append(o, span{
+				off: b2,
+				len: len,
+			})
+			sp.off = e1
+			sp.len -= v.len + len
+		case b2 < b1 && b1 < e2 && e2 < e1:
+			//   [ s1=v   ]
+			//  [  s2=sp ]
+			len := b1 - b2
+			o = append(o, span{
+				off: b2,
+				len: len,
+			})
+			sp.len = 0
+		case b1 <= b2 && e2 <= e1:
+			//  [  s1=v   ]
+			//    [s2=sp]
+			sp.len = 0
+		case b1 <= b2 && e1 < e2:
+			//  [  s1=v  ]
+			//    [s2=sp  ]
+			sp.off = e1
+			sp.len = e2 - e1
+		}
+		if sp.len == 0 {
+			break
+		}
+	}
+	if sp.len != 0 {
+		o = append(o, sp)
+	}
+
+	return o
+}
+
+type spans []span
+
+func (p *spans) consolidate() {
+	for i := len(*p) - 1; i >= 1; i-- {
+		ii := &(*p)[i]
+		jj := &(*p)[i-1]
+		jend := jj.off + jj.len
+		iend := ii.off + ii.len
+		if jend < ii.off {
+			continue
+		}
+		if iend >= jend {
+			jj.len += iend - jend
+		}
+		p.remove(i)
+	}
+}
+
+func (p *spans) remove(i int) {
+	list := *p
+	*p = append(list[:i], list[i+1:]...)
+}
+
+func (p *spans) add(sp span) {
+	*p = append(*p, sp)
+	sort.Slice(*p, func(i, j int) bool {
+		pi := (*p)[i]
+		pj := (*p)[j]
+		if pi.off < pj.off {
+			return true
+		}
+		if pi.off == pj.off {
+			return pi.off+pi.len < pj.off+pj.len
+		}
+		return false
+	})
+	p.consolidate()
+}

--- a/groot/riofs/plugin/http/span_test.go
+++ b/groot/riofs/plugin/http/span_test.go
@@ -1,0 +1,274 @@
+// Copyright ©2022 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package http
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSpanSplit(t *testing.T) {
+	mk := func(beg, end int64) span {
+		return span{
+			off: beg,
+			len: end - beg,
+		}
+	}
+	from := func(vs ...int64) []span {
+		if len(vs) == 0 {
+			return nil
+		}
+		o := make([]span, 0, len(vs)/2)
+		for i := 0; i < len(vs); i += 2 {
+			o = append(o, mk(vs[i], vs[i+1]))
+		}
+		return o
+	}
+	for _, tc := range []struct {
+		spans []span
+		sp    span
+		want  []span
+	}{
+		{
+			spans: from(),
+			sp:    span{0, 2},
+			want:  from(0, 2),
+		},
+		// 1-1 intersects
+		{
+			spans: from(2, 4),
+			sp:    mk(0, 3),
+			want:  from(0, 2),
+		},
+		{
+			spans: from(2, 4),
+			sp:    mk(3, 5),
+			want:  from(4, 5),
+		},
+		{
+			spans: from(2, 5),
+			sp:    mk(3, 4),
+			want:  from(),
+		},
+		{
+			spans: from(2, 4),
+			sp:    mk(0, 5),
+			want:  from(0, 2, 4, 5),
+		},
+		{
+			spans: from(2, 4),
+			sp:    mk(0, 4),
+			want:  from(0, 2),
+		},
+		{
+			spans: from(2, 4),
+			sp:    mk(2, 5),
+			want:  from(4, 5),
+		},
+		{
+			spans: from(2, 4),
+			sp:    mk(0, 2),
+			want:  from(0, 2),
+		},
+		{
+			spans: from(2, 4),
+			sp:    mk(0, 1),
+			want:  from(0, 1),
+		},
+		{
+			spans: from(2, 4),
+			sp:    mk(4, 6),
+			want:  from(4, 6),
+		},
+		{
+			spans: from(2, 4),
+			sp:    mk(5, 6),
+			want:  from(5, 6),
+		},
+		//
+		{
+			spans: from(0, 4, 5, 7),
+			sp:    mk(0, 7),
+			want:  from(4, 5),
+		},
+		{
+			spans: from(0, 4, 5, 7),
+			sp:    mk(0, 6),
+			want:  from(4, 5),
+		},
+		{
+			spans: from(0, 4, 5, 7),
+			sp:    mk(7, 9),
+			want:  from(7, 9),
+		},
+		// 2-1 intersects
+		{
+			spans: from(1, 4, 6, 8),
+			sp:    mk(3, 7),
+			want:  from(4, 6),
+		},
+		{
+			spans: from(1, 4, 6, 8),
+			sp:    mk(3, 10),
+			want:  from(4, 6, 8, 10),
+		},
+		{
+			spans: from(1, 4, 6, 8),
+			sp:    mk(3, 5),
+			want:  from(4, 5),
+		},
+		{
+			spans: from(1, 4, 6, 8),
+			sp:    mk(1, 5),
+			want:  from(4, 5),
+		},
+		{
+			spans: from(1, 4, 6, 8),
+			sp:    mk(1, 7),
+			want:  from(4, 6),
+		},
+		{
+			spans: from(1, 4, 6, 8),
+			sp:    mk(1, 10),
+			want:  from(4, 6, 8, 10),
+		},
+		{
+			spans: from(1, 4, 6, 8),
+			sp:    mk(0, 5),
+			want:  from(0, 1, 4, 5),
+		},
+		{
+			spans: from(1, 4, 6, 8),
+			sp:    mk(0, 7),
+			want:  from(0, 1, 4, 6),
+		},
+		{
+			spans: from(1, 4, 6, 8),
+			sp:    mk(0, 10),
+			want:  from(0, 1, 4, 6, 8, 10),
+		},
+		{
+			spans: from(1, 4, 6, 8),
+			sp:    mk(4, 5),
+			want:  from(4, 5),
+		},
+		{
+			spans: from(1, 4, 6, 8),
+			sp:    mk(4, 7),
+			want:  from(4, 6),
+		},
+		{
+			spans: from(1, 4, 6, 8),
+			sp:    mk(4, 10),
+			want:  from(4, 6, 8, 10),
+		},
+		{
+			spans: from(1, 4, 6, 8),
+			sp:    mk(1, 8),
+			want:  from(4, 6),
+		},
+		{
+			spans: from(1, 4, 6, 8),
+			sp:    mk(1, 4),
+			want:  from(),
+		},
+		{
+			spans: from(1, 4, 6, 8),
+			sp:    mk(1, 6),
+			want:  from(4, 6),
+		},
+		{
+			spans: from(1, 4, 6, 8),
+			sp:    mk(4, 6),
+			want:  from(4, 6),
+		},
+		{
+			spans: from(1, 4, 6, 8),
+			sp:    mk(4, 8),
+			want:  from(4, 6),
+		},
+		{
+			spans: from(1, 4, 6, 8),
+			sp:    mk(6, 8),
+			want:  from(),
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			got := split(tc.sp, tc.spans)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("invalid split:\ngot= %+v\nwant=%+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSpanAdd(t *testing.T) {
+	mk := func(beg, end int64) span {
+		return span{
+			off: beg,
+			len: end - beg,
+		}
+	}
+	from := func(vs ...int64) []span {
+		if len(vs) == 0 {
+			return nil
+		}
+		o := make([]span, 0, len(vs)/2)
+		for i := 0; i < len(vs); i += 2 {
+			o = append(o, mk(vs[i], vs[i+1]))
+		}
+		return o
+	}
+	for _, tc := range []struct {
+		spans []span
+		sp    span
+		want  []span
+	}{
+		{
+			spans: from(),
+			sp:    mk(0, 10),
+			want:  from(0, 10),
+		},
+		{
+			spans: from(),
+			sp:    mk(9, 10),
+			want:  from(9, 10),
+		},
+		{
+			spans: from(1, 3, 4, 6),
+			sp:    mk(3, 4),
+			want:  from(1, 6),
+		},
+		{
+			spans: from(1, 3, 4, 6),
+			sp:    mk(0, 1),
+			want:  from(0, 3, 4, 6),
+		},
+		{
+			spans: from(1, 3, 4, 6),
+			sp:    mk(6, 10),
+			want:  from(1, 3, 4, 10),
+		},
+		{
+			spans: from(1, 3, 4, 6),
+			sp:    mk(7, 10),
+			want:  from(1, 3, 4, 6, 7, 10),
+		},
+		{
+			spans: from(2, 3, 4, 6),
+			sp:    mk(0, 1),
+			want:  from(0, 1, 2, 3, 4, 6),
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			got := make(spans, len(tc.spans))
+			copy(got, tc.spans)
+			got.add(tc.sp)
+			if !reflect.DeepEqual(got, spans(tc.want)) {
+				t.Fatalf("invalid span-add:\ngot= %+v\nwant=%+v", got, tc.want)
+			}
+		})
+	}
+}

--- a/groot/riofs/plugin/plugin_test.go
+++ b/groot/riofs/plugin/plugin_test.go
@@ -1,0 +1,92 @@
+// Copyright ©2022 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package plugin_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go-hep.org/x/hep/groot"
+	"go-hep.org/x/hep/groot/riofs"
+	"go-hep.org/x/hep/groot/rtree"
+
+	_ "go-hep.org/x/hep/groot/riofs/plugin/http"
+)
+
+func BenchmarkDumpLocal(b *testing.B) {
+	// big-file.root is: rtests.XrdRemote("testdata/SMHiggsToZZTo4L.root")
+	benchDump(b, "../../testdata/big-file.root", "Events")
+}
+
+func BenchmarkDumpHTTP(b *testing.B) {
+	for _, i := range []time.Duration{
+		0,
+		5 * time.Millisecond,
+		10 * time.Millisecond,
+		100 * time.Millisecond,
+	} {
+		func(i time.Duration) {
+			srv := httptest.NewServer(server{delay: i, h: http.FileServer(http.Dir("../../testdata"))})
+			defer srv.Close()
+
+			b.Run(fmt.Sprintf("delay-%v", i), func(b *testing.B) {
+				// big-file.root is: rtests.XrdRemote("testdata/SMHiggsToZZTo4L.root")
+				benchDump(b, srv.URL+"/big-file.root", "Events")
+			})
+		}(i)
+	}
+}
+
+type server struct {
+	delay time.Duration
+	h     http.Handler
+}
+
+func (srv server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	time.Sleep(srv.delay)
+	srv.h.ServeHTTP(w, r)
+}
+
+func benchDump(b *testing.B, fname, tname string) {
+	f, err := groot.Open(fname)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer f.Close()
+
+	o, err := riofs.Dir(f).Get(tname)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	tree := o.(rtree.Tree)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := dump(tree)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func dump(tree rtree.Tree) (n int64, err error) {
+	r, err := rtree.NewReader(tree, rtree.NewReadVars(tree))
+	if err != nil {
+		return 0, err
+	}
+	defer r.Close()
+
+	err = r.Read(func(rctx rtree.RCtx) error {
+		_ = rctx.Entry
+		n++
+		return nil
+	})
+
+	return n, err
+}


### PR DESCRIPTION
old: reading remote file after having downloaded to a local one
new: reading remote file w/ httpio + sync.Pool

```
  name                    old time/op    new time/op    delta
  DumpHTTP/delay-0s-8        279ms ± 1%     287ms ± 2%   +3.09%  (p=0.000 n=27+29)
  DumpHTTP/delay-5ms-8       279ms ± 2%     288ms ± 2%   +3.06%  (p=0.000 n=29+29)
  DumpHTTP/delay-10ms-8      281ms ± 3%     287ms ± 1%   +2.24%  (p=0.000 n=26+30)
  DumpHTTP/delay-100ms-8     286ms ± 3%     288ms ± 1%   +0.45%  (p=0.032 n=25+29)

  name                    old alloc/op   new alloc/op   delta
  DumpHTTP/delay-0s-8        156MB ± 0%     159MB ± 0%   +1.93%  (p=0.000 n=29+30)
  DumpHTTP/delay-5ms-8       156MB ± 0%     159MB ± 0%   +1.95%  (p=0.000 n=30+30)
  DumpHTTP/delay-10ms-8      155MB ± 0%     159MB ± 0%   +1.95%  (p=0.000 n=30+30)
  DumpHTTP/delay-100ms-8     155MB ± 0%     159MB ± 0%   +1.99%  (p=0.000 n=30+28)

  name                    old allocs/op  new allocs/op  delta
  DumpHTTP/delay-0s-8        81.4k ± 0%    117.6k ± 0%  +44.46%  (p=0.000 n=30+30)
  DumpHTTP/delay-5ms-8       81.4k ± 0%    117.6k ± 0%  +44.48%  (p=0.000 n=30+30)
  DumpHTTP/delay-10ms-8      81.4k ± 0%    117.5k ± 0%  +44.48%  (p=0.000 n=29+30)
  DumpHTTP/delay-100ms-8     81.4k ± 0%    117.6k ± 0%  +44.51%  (p=0.000 n=30+29)
```

Fixes go-hep#142.