### PR TITLE
groot/rcmd: improve Dump tree performances

### DIFF
--- a/groot/rcmd/dump_test.go
+++ b/groot/rcmd/dump_test.go
@@ -343,3 +343,18 @@ key[004]: tree;1 "my tree title" (TTree)
 		})
 	}
 }
+
+func BenchmarkDump(b *testing.B) {
+	const deep = true
+	out := new(strings.Builder)
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		out.Reset()
+		b.StartTimer()
+		// big-file.root is: rtests.XrdRemote("testdata/SMHiggsToZZTo4L.root")
+		err := rcmd.Dump(out, "../testdata/big-file.root", deep, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
```
 name    old time/op    new time/op    delta
 Dump-8     5.02s ± 2%     3.98s ± 2%  -20.83%  (p=0.000 n=29+29)

 name    old alloc/op   new alloc/op   delta
 Dump-8    2.50GB ± 0%    2.40GB ± 0%   -3.82%  (p=0.000 n=29+30)

 name    old allocs/op  new allocs/op  delta
 Dump-8     38.8M ± 0%     29.3M ± 0%  -24.69%  (p=0.000 n=30+29)
```