### PR TITLE
xrootd: improve read performances 10-fold

### DIFF
--- a/xrootd/bench_test.go
+++ b/xrootd/bench_test.go
@@ -1,0 +1,53 @@
+// Copyright ©2022 The go-hep Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xrootd_test
+
+import (
+	"testing"
+
+	"go-hep.org/x/hep/groot"
+	_ "go-hep.org/x/hep/groot/riofs/plugin/xrootd"
+	"go-hep.org/x/hep/groot/rtree"
+)
+
+func BenchmarkRead(b *testing.B) {
+	const (
+		fname = "root://ccxrootdgotest.in2p3.fr:9001/tmp/rootio/testdata/SMHiggsToZZTo4L.root"
+		tname = "Events"
+	)
+
+	f, err := groot.Open(fname)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer f.Close()
+
+	o, err := f.Get(tname)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	tree := o.(rtree.Tree)
+	read := func(tree rtree.Tree) error {
+		r, err := rtree.NewReader(tree, rtree.NewReadVars(tree))
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer r.Close()
+
+		return r.Read(func(rctx rtree.RCtx) error {
+			_ = rctx.Entry
+			return nil
+		})
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := read(tree)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
This CL reduces the lock contention on xrootd.File operations.

```
  $> benchstat ./ref.txt ./new.txt
  name    old time/op    new time/op    delta
  Read-8     67.2s ± 1%      5.4s ± 7%  -91.93%  (p=0.000 n=9+28)

  name    old alloc/op   new alloc/op   delta
  Read-8     343MB ± 0%     341MB ± 0%   -0.78%  (p=0.000 n=8+30)

  name    old allocs/op  new allocs/op  delta
  Read-8      277k ± 0%      288k ± 0%   +3.84%  (p=0.000 n=7+29)
```

and now:
```
  $> time root-dump root://ccxrootdgotest.in2p3.fr:9001/tmp/rootio/testdata/SMHiggsToZZTo4L.root > /dev/null

  real	0m7.279s
  user	0m8.221s
  sys	0m1.256s
```

compared to:

```
  $> time root-dump https://cern.ch/binet/big-file.root > /dev/null

  real	0m5.454s
  user	0m6.156s
  sys	0m0.228s
```

Updates #920.