### PR TITLE
removes unreacheable statement

### DIFF
--- a/cmd/root2yoda/main.go
+++ b/cmd/root2yoda/main.go
@@ -90,7 +90,6 @@ options:
 		f, err := groot.Open(fname)
 		if err != nil {
 			log.Fatalf("failed to open [%s]: %v\n", fname, err)
-			os.Exit(1)
 		}
 		defer f.Close()
 		for _, k := range uniq(f.Keys()) {


### PR DESCRIPTION
`log.Fatal` already returns exit code 1

found with [revive](https://github.com/mgechev/revive) rule `unreachable-code`