### PR TITLE
groot/riofs: export in-memory read-only RMemFile ROOT file

### DIFF
--- a/groot/riofs/memfile.go
+++ b/groot/riofs/memfile.go
@@ -6,6 +6,12 @@ package riofs
 
 import "bytes"
 
+// RMemFile creates a simple in-memory read-only ROOT file
+// from the provided slice of bytes.
+func RMemFile(p []byte) Reader {
+	return &memFile{bytes.NewReader(p)}
+}
+
 // memFile is a simple in-memory read-only ROOT file
 type memFile struct {
 	r *bytes.Reader

--- a/groot/riofs/memfile_test.go
+++ b/groot/riofs/memfile_test.go
@@ -5,7 +5,6 @@
 package riofs
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -53,7 +52,7 @@ func TestRMemFile(t *testing.T) {
 		t.Fatalf("error reading file: %v", err)
 	}
 
-	r, err := NewReader(&memFile{bytes.NewReader(raw)})
+	r, err := NewReader(RMemFile(raw))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This CL export RMemFile, that provides a simple way to create in-memory
read-only ROOT files.