### PR TITLE
lhef: reduce number of allocs in Decoder

### DIFF
--- a/lhef/reader.go
+++ b/lhef/reader.go
@@ -122,12 +122,17 @@ Loop:
 		return nil, err
 	}
 
-	d.Run.XSECUP = make([]float64, int(d.Run.NPRUP))
-	d.Run.XERRUP = make([]float64, int(d.Run.NPRUP))
-	d.Run.XMAXUP = make([]float64, int(d.Run.NPRUP))
-	d.Run.LPRUP = make([]int32, int(d.Run.NPRUP))
+	n := int(d.Run.NPRUP)
+	if n < 0 {
+		return nil, fmt.Errorf("lhef.Decoder: invalid NPRUP (%d)", d.Run.NPRUP)
+	}
+	f64 := make([]float64, 3*n)
+	d.Run.XSECUP = f64[:n:n]
+	d.Run.XERRUP = f64[n : 2*n : 2*n]
+	d.Run.XMAXUP = f64[2*n:]
+	d.Run.LPRUP = make([]int32, n)
 
-	for i := 0; i < int(d.Run.NPRUP); i++ {
+	for i := 0; i < n; i++ {
 		_, err = fmt.Fscanf(
 			buf,
 			"%f %f %f %d\n",

--- a/lhef/reader.go
+++ b/lhef/reader.go
@@ -250,11 +250,13 @@ func (d *Decoder) Decode() (*HEPEUP, error) {
 	n := int(evt.NUP)
 	evt.IDUP = make([]int64, n)
 	evt.ISTUP = make([]int32, n)
-	evt.MOTHUP = make([][2]int32, n)
-	evt.ICOLUP = make([][2]int32, n)
+	n2 := make([][2]int32, 2*n)
+	evt.MOTHUP = n2[:n:n]
+	evt.ICOLUP = n2[n:]
 	evt.PUP = make([][5]float64, n)
-	evt.VTIMUP = make([]float64, n)
-	evt.SPINUP = make([]float64, n)
+	f64 := make([]float64, 2*n)
+	evt.VTIMUP = f64[:n:n]
+	evt.SPINUP = f64[n:]
 	for i := 0; i < n; i++ {
 		_, err = fmt.Fscanf(
 			buf,

--- a/lhef/reader_test.go
+++ b/lhef/reader_test.go
@@ -27,6 +27,20 @@ func TestLhefReading(t *testing.T) {
 		t.Error(err)
 	}
 
+	n := int(dec.Run.NPRUP)
+	if len(dec.Run.XSECUP) != n || cap(dec.Run.XSECUP) != n {
+		t.Errorf("invalid XSECUP len")
+	}
+	if len(dec.Run.XERRUP) != n || cap(dec.Run.XERRUP) != n {
+		t.Errorf("invalid XRERUP len")
+	}
+	if len(dec.Run.XMAXUP) != n || cap(dec.Run.XMAXUP) != n {
+		t.Errorf("invalid XMAXUP len")
+	}
+	if len(dec.Run.LPRUP) != n || cap(dec.Run.LPRUP) != n {
+		t.Errorf("invalid LPRUP len")
+	}
+
 	for i := 0; ; i++ {
 		if r_debug {
 			fmt.Printf("===[%d]===\n", i)


### PR DESCRIPTION
In the `lhef.Decoder`, allocate slices using sliced bigger chunks in order to reduce the number of allocations.

Example:
```
a := make([]int32, n)
b := make([]int32, n)
c := make([]int32, n)
```
is replaced with:
```
n32 := make([]int32, 3*n)
a := n32[:n:n]
b := n32[n : 2*n : 2*n]
b := n32[2*n:]
```
