### PR TITLE
sliceop: use errors.New for constant errors

### DIFF
--- a/sliceop/f64s/f64s_test.go
+++ b/sliceop/f64s/f64s_test.go
@@ -5,6 +5,7 @@
 package f64s
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -35,9 +36,9 @@ func TestMap(t *testing.T) {
 
 func TestTake(t *testing.T) {
 	var (
-		errLength           = fmt.Errorf("sliceop: length mismatch")
-		errSortedIndices    = fmt.Errorf("sliceop: indices not sorted")
-		errDuplicateIndices = fmt.Errorf("sliceop: duplicate indices")
+		errLength           = errors.New("sliceop: length mismatch")
+		errSortedIndices    = errors.New("sliceop: indices not sorted")
+		errDuplicateIndices = errors.New("sliceop: duplicate indices")
 	)
 
 	for _, tc := range []struct {

--- a/sliceop/sliceop.go
+++ b/sliceop/sliceop.go
@@ -8,14 +8,12 @@
 // slices package.
 package sliceop // import "go-hep.org/x/hep/sliceop"
 
-import (
-	"fmt"
-)
+import "errors"
 
 var (
-	errLength           = fmt.Errorf("sliceop: length mismatch")
-	errSortedIndices    = fmt.Errorf("sliceop: indices not sorted")
-	errDuplicateIndices = fmt.Errorf("sliceop: duplicate indices")
+	errLength           = errors.New("sliceop: length mismatch")
+	errSortedIndices    = errors.New("sliceop: indices not sorted")
+	errDuplicateIndices = errors.New("sliceop: duplicate indices")
 )
 
 // Filter creates a slice with all the elements x_i of src for which f(x_i) is true.


### PR DESCRIPTION
Use `errors.New` instead of `fmt.Errorf` when the message is a constant string.