### PR TITLE
groot: fix go:generate portability for root-gen-type

### DIFF
--- a/groot/cmd/root-gen-type/.gitignore
+++ b/groot/cmd/root-gen-type/.gitignore
@@ -1,0 +1,2 @@
+/root-gen-type
+/root-gen-type.exe

--- a/groot/cmd/root-gen-type/main.go
+++ b/groot/cmd/root-gen-type/main.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 //go:generate go run ./gen-data.go -f ../../testdata/streamers.root
-//go:generate root-gen-type -p main -t Event,P3 -o ./testdata/streamers.txt ../../testdata/streamers.root
+//go:generate go run . -p main -t Event,P3 -o ./testdata/streamers.txt ../../testdata/streamers.root
 
 // Command root-gen-type generates a Go type from the StreamerInfo contained
 // in a ROOT file.


### PR DESCRIPTION
Use `go run` instead of requiring the binary to be already built.