### PR TITLE
groot/riofs: align default compression settings w/ ROOT

### DIFF
--- a/groot/riofs/file.go
+++ b/groot/riofs/file.go
@@ -5,7 +5,6 @@
 package riofs
 
 import (
-	"compress/flate"
 	"errors"
 	"fmt"
 	"io"
@@ -171,22 +170,24 @@ func Create(name string, opts ...FileOption) (*File, error) {
 	}
 
 	f := &File{
-		w:           fd,
-		closer:      fd,
-		id:          name,
-		version:     root.Version,
-		begin:       kBEGIN,
-		end:         kBEGIN,
-		units:       4,
-		compression: 1,
-		sinfos:      nil,
-		simap:       make(map[rbytes.StreamerInfo]struct{}),
+		w:       fd,
+		closer:  fd,
+		id:      name,
+		version: root.Version,
+		begin:   kBEGIN,
+		end:     kBEGIN,
+		units:   4,
+		sinfos:  nil,
+		simap:   make(map[rbytes.StreamerInfo]struct{}),
 	}
 	f.dir = *newDirectoryFile(name, "", f, nil)
 	f.dir.dir.named.SetTitle("")
 	f.spans.add(f.begin, kStartBigFile)
 
-	f.setCompression(rcompress.ZLIB, flate.BestCompression)
+	{
+		cfg := rcompress.SettingsFrom(rcompress.DefaultSettings.Compression())
+		f.setCompression(cfg.Alg, cfg.Lvl)
+	}
 
 	for _, opt := range opts {
 		if opt == nil {


### PR DESCRIPTION
groot was using flate.BestCompression (zlib and level=9) whereas ROOT/C++ is using flate.BestSpeed (zlib and level=1).

This CL configures groot to use flate.DefaultCompression (and zlib).

On "typical" payloads this amounts to:

```
$> time ./new-dbg -zip=zlib-1 -o groot-zlib-1.root
real 0m9.469s
user 0m8.644s
sys  0m0.872s

$> time ./new-dbg -zip=zlib-6 -o groot-zlib-6.root (proposed new default)
real 0m10.832s
user 0m10.422s
sys  0m0.972s

$> time ./new-dbg -zip=zlib-9 -o groot-zlib-9.root (go-hep@v0.35 default)
real 0m32.415s
user 0m32.550s
sys  0m1.086s
```

and for the disk sizes:
```
$> ll
87M Nov 12 15:19 groot-zlib-1.root
77M Nov 12 15:18 groot-zlib-6.root (proposed new default)
67M Nov 12 15:19 groot-zlib-9.root (go-hep@v0.35 default)
```