### PR TITLE
all: modernize Go usage

### DIFF
--- a/brio/cmd/brio-gen/internal/gen/gen.go
+++ b/brio/cmd/brio-gen/internal/gen/gen.go
@@ -47,7 +47,7 @@ func NewGenerator(p string) (*Generator, error) {
 	}, nil
 }
 
-func (g *Generator) printf(format string, args ...interface{}) {
+func (g *Generator) printf(format string, args ...any) {
 	fmt.Fprintf(g.buf, format, args...)
 }
 
@@ -84,7 +84,7 @@ func (o *%[1]s) MarshalBinary() (data []byte, err error) {
 	)
 
 	typ := t.Underlying().(*types.Struct)
-	for i := 0; i < typ.NumFields(); i++ {
+	for i := range typ.NumFields() {
 		ft := typ.Field(i)
 		g.genMarshalType(ft.Type(), "o."+ft.Name())
 	}
@@ -236,7 +236,7 @@ func (g *Generator) genMarshalType(t types.Type, n string) {
 			g.printf("}\n")
 		default:
 			// un-named
-			for i := 0; i < ut.NumFields(); i++ {
+			for i := range ut.NumFields() {
 				elem := ut.Field(i)
 				g.genMarshalType(elem.Type(), n+"."+elem.Name())
 			}
@@ -297,7 +297,7 @@ func (o *%[1]s) UnmarshalBinary(data []byte) (err error) {
 	)
 
 	typ := t.Underlying().(*types.Struct)
-	for i := 0; i < typ.NumFields(); i++ {
+	for i := range typ.NumFields() {
 		ft := typ.Field(i)
 		g.genUnmarshalType(ft.Type(), "o."+ft.Name())
 	}
@@ -413,7 +413,7 @@ func (g *Generator) genUnmarshalType(t types.Type, n string) {
 			g.printf("}\n")
 		default:
 			// un-named.
-			for i := 0; i < ut.NumFields(); i++ {
+			for i := range ut.NumFields() {
 				elem := ut.Field(i)
 				g.genUnmarshalType(elem.Type(), n+"."+elem.Name())
 			}

--- a/cmd/fits2root/main.go
+++ b/cmd/fits2root/main.go
@@ -99,7 +99,7 @@ func process(oname, tname, fname string) error {
 
 	var (
 		wvars = make([]rtree.WriteVar, tbl.NumCols())
-		wargs = make([]interface{}, tbl.NumCols())
+		wargs = make([]any, tbl.NumCols())
 	)
 	for i, col := range tbl.Cols() {
 		wvars[i] = wvarFrom(col)

--- a/cmd/fits2root/main_test.go
+++ b/cmd/fits2root/main_test.go
@@ -25,7 +25,7 @@ func TestConvert(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		cols []fitsio.Column
-		data interface{}
+		data any
 		want string
 	}{
 		{
@@ -287,7 +287,7 @@ func TestConvert(t *testing.T) {
 				defer tbl.Close()
 
 				rslice := reflect.ValueOf(tc.data)
-				for i := 0; i < rslice.Len(); i++ {
+				for i := range rslice.Len() {
 					data := rslice.Index(i).Addr()
 					err = tbl.Write(data.Interface())
 					if err != nil {

--- a/cmd/lhef2hepmc/main.go
+++ b/cmd/lhef2hepmc/main.go
@@ -177,7 +177,7 @@ func main() {
 
 		nmax := 2
 		imax := int(lhevt.NUP)
-		for i := 0; i < imax; i++ {
+		for i := range imax {
 			if !*keep && lhevt.ISTUP[i] != 1 {
 				continue
 			}

--- a/cmd/npy2root/main_test.go
+++ b/cmd/npy2root/main_test.go
@@ -20,7 +20,7 @@ import (
 func TestConvert(t *testing.T) {
 	for _, tc := range []struct {
 		name string
-		want interface{}
+		want any
 	}{
 		// 4 scalars
 		{

--- a/cmd/podio-gen/generator.go
+++ b/cmd/podio-gen/generator.go
@@ -175,7 +175,7 @@ func (g *generator) generate() error {
 	return nil
 }
 
-func (g *generator) printf(format string, args ...interface{}) {
+func (g *generator) printf(format string, args ...any) {
 	fmt.Fprintf(g.buf, format, args...)
 }
 

--- a/cmd/root2csv/main.go
+++ b/cmd/root2csv/main.go
@@ -163,8 +163,8 @@ func processTree(oname, fname string, tree rtree.Tree) error {
 		return fmt.Errorf("could not write CSV header: %w", err)
 	}
 
-	row := make([]interface{}, len(nt.cols))
-	for irow := 0; irow < nrows; irow++ {
+	row := make([]any, len(nt.cols))
+	for irow := range nrows {
 		for i, col := range nt.cols {
 			row[i] = col.slice.Index(irow).Interface()
 		}
@@ -186,7 +186,7 @@ type ntuple struct {
 	n    int64
 	cols []column
 	args []rtree.ReadVar
-	vars []interface{}
+	vars []any
 }
 
 func (nt *ntuple) add(name string, leaf rtree.Leaf) {
@@ -262,7 +262,7 @@ func processGraph(oname, fname string, g rhist.Graph) error {
 	}
 
 	n := g.Len()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		var (
 			x, y = g.XY(i)
 		)
@@ -300,7 +300,7 @@ func processGraphErrors(oname, fname string, g rhist.GraphErrors) error {
 	}
 
 	n := g.Len()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		var (
 			x, y     = g.XY(i)
 			xlo, xhi = g.XError(i)

--- a/cmd/root2fits/main.go
+++ b/cmd/root2fits/main.go
@@ -118,7 +118,7 @@ func process(oname, tname, fname string) error {
 	defer tbl.Close()
 
 	rvars := rtree.NewReadVars(tree)
-	wvars := make([]interface{}, len(rvars))
+	wvars := make([]any, len(rvars))
 	for i, rvar := range rvars {
 		wvars[i] = rvar.Value
 	}

--- a/cmd/root2fits/main_test.go
+++ b/cmd/root2fits/main_test.go
@@ -28,13 +28,13 @@ func TestConvert(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
 		nevts int
-		data  func(i int) interface{}
+		data  func(i int) any
 		want  string
 	}{
 		{
 			name:  "builtins",
 			nevts: 5,
-			data: func(i int) interface{} {
+			data: func(i int) any {
 				type D struct {
 					B   bool
 					I8  int8
@@ -134,7 +134,7 @@ Str        | 00004
 		{
 			name:  "arrays",
 			nevts: 5,
-			data: func(i int) interface{} {
+			data: func(i int) any {
 				type D struct {
 					B   [3]bool
 					I8  [3]int8
@@ -246,7 +246,7 @@ F64        | [14 24 34]
 					t.Fatalf("could not create tree writer: %v", err)
 				}
 
-				for i := 0; i < int(tc.nevts); i++ {
+				for i := range int(tc.nevts) {
 					want := reflect.ValueOf(tc.data(i)).Elem().Interface()
 					for j, wvar := range wvars {
 						v := reflect.ValueOf(wvar.Value).Elem()
@@ -321,7 +321,7 @@ func display(o io.Writer, hname, fname string) error {
 		}
 	}
 
-	data := make([]interface{}, ncols)
+	data := make([]any, ncols)
 	names := make([]string, ncols)
 	for i, col := range table.Cols() {
 		names[i] = col.Name
@@ -335,7 +335,7 @@ func display(o io.Writer, hname, fname string) error {
 			return fmt.Errorf("could not read row %d: %w", irow, err)
 		}
 		fmt.Fprintf(o, "== %05d/%05d %s\n", irow+1, nrows, hdrline)
-		for i := 0; i < ncols; i++ {
+		for i := range ncols {
 			rv := reflect.Indirect(reflect.ValueOf(data[i]))
 			fmt.Fprintf(o, rowfmt, names[i], rv.Interface())
 		}

--- a/csvutil/csv.go
+++ b/csvutil/csv.go
@@ -28,7 +28,7 @@ func min(a, b int) int {
 	return b
 }
 
-func formatValue(val interface{}, quotes bool, recBuilder *strings.Builder) error {
+func formatValue(val any, quotes bool, recBuilder *strings.Builder) error {
 	rv := reflect.Indirect(reflect.ValueOf(val))
 	rt := rv.Type()
 	switch rt.Kind() {
@@ -48,7 +48,7 @@ func formatValue(val interface{}, quotes bool, recBuilder *strings.Builder) erro
 		}
 	case reflect.Slice:
 		recBuilder.WriteString("[")
-		for i := 0; i < rv.Len(); i++ {
+		for i := range rv.Len() {
 			if i > 0 {
 				recBuilder.WriteString(", ")
 			}
@@ -177,7 +177,7 @@ func (tbl *Table) WriteHeader(hdr string) error {
 }
 
 // WriteRow writes the data into the columns at the current row.
-func (tbl *Table) WriteRow(args ...interface{}) error {
+func (tbl *Table) WriteRow(args ...any) error {
 	var err error
 	if tbl.Writer == nil {
 		return fmt.Errorf("csvutil: Table is not in write mode")
@@ -206,7 +206,7 @@ func (tbl *Table) WriteRow(args ...interface{}) error {
 	return err
 }
 
-func (tbl *Table) write(args ...interface{}) error {
+func (tbl *Table) write(args ...any) error {
 	rec := make([]string, len(args))
 	var recBuilder strings.Builder
 	for i, arg := range args {
@@ -222,7 +222,7 @@ func (tbl *Table) write(args ...interface{}) error {
 
 func (tbl *Table) writeStruct(rv reflect.Value) error {
 	rt := rv.Type()
-	args := make([]interface{}, rt.NumField())
+	args := make([]any, rt.NumField())
 	for i := range args {
 		args[i] = rv.Field(i).Interface()
 	}
@@ -278,7 +278,7 @@ func (rows *Rows) Fields() []string {
 // dest can be either:
 // - a pointer to a struct value (whose fields will be filled with column values)
 // - a slice of values
-func (rows *Rows) Scan(dest ...interface{}) error {
+func (rows *Rows) Scan(dest ...any) error {
 	var err error
 	defer func() {
 		rows.err = err
@@ -304,10 +304,10 @@ func (rows *Rows) Scan(dest ...interface{}) error {
 	return err
 }
 
-func (rows *Rows) scan(args ...interface{}) error {
+func (rows *Rows) scan(args ...any) error {
 	var err error
 	n := min(len(rows.record), len(args))
-	for i := 0; i < n; i++ {
+	for i := range n {
 		rec := rows.record[i]
 		rv := reflect.ValueOf(args[i]).Elem()
 		rt := reflect.TypeOf(args[i]).Elem()
@@ -353,8 +353,8 @@ func (rows *Rows) scan(args ...interface{}) error {
 
 func (rows *Rows) scanStruct(rv reflect.Value) error {
 	rt := rv.Type()
-	args := make([]interface{}, rt.NumField())
-	for i := 0; i < rt.NumField(); i++ {
+	args := make([]any, rt.NumField())
+	for i := range rt.NumField() {
 		args[i] = rv.Field(i).Addr().Interface()
 	}
 	return rows.scan(args...)

--- a/csvutil/csv_example_test.go
+++ b/csvutil/csv_example_test.go
@@ -91,7 +91,7 @@ func Example_writeStruct() {
 		log.Fatalf("error writing header: %v\n", err)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		data := struct {
 			I int
 			F float64
@@ -127,7 +127,7 @@ func Example_writeSlice() {
 		log.Fatalf("error writing header: %v\n", err)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		var (
 			f = float64(i)
 			s = fmt.Sprintf("str-%d", i)

--- a/csvutil/csv_test.go
+++ b/csvutil/csv_test.go
@@ -330,7 +330,7 @@ func TestCSVWriterArgs(t *testing.T) {
 		t.Errorf("error writing header: %+v\n", err)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		var (
 			f = float64(i)
 			s = fmt.Sprintf("str-%d", i)
@@ -369,7 +369,7 @@ func TestCSVWriterStruct(t *testing.T) {
 		t.Errorf("error writing header: %+v\n", err)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		data := struct {
 			I int
 			F float64
@@ -413,7 +413,7 @@ func TestCSVWriterArgsSlice(t *testing.T) {
 		t.Fatalf("error writing header: %+v", err)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		var (
 			lii = [][]int{{1, 2, 3}, {2, 3, 4}, {7, 8, 15}}
 			lss = [][]string{{"foo", "bar", "baz"}, {"abc", "def", "ghi"}, {"qwerty"}}
@@ -453,7 +453,7 @@ func TestCSVAppend(t *testing.T) {
 		t.Errorf("error writing header: %+v\n", err)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		data := struct {
 			I int
 			F float64

--- a/csvutil/csvdriver/driver_test.go
+++ b/csvutil/csvdriver/driver_test.go
@@ -184,7 +184,7 @@ func TestQL(t *testing.T) {
 		t.Fatalf("error creating table: %+v\n", err)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		f := float64(i)
 		s := fmt.Sprintf("str-%d", i)
 		_, err = tx.Exec("insert into csv values($1,$2,$3);", i, f, s)
@@ -226,7 +226,7 @@ func TestCreate(t *testing.T) {
 		t.Fatalf("error creating table: %+v\n", err)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		f := float64(i)
 		s := fmt.Sprintf("str-%d", i)
 		_, err = tx.Exec("insert into csv values($1,$2,$3);", i, f, s)
@@ -268,7 +268,7 @@ func TestCreateRollback(t *testing.T) {
 		t.Fatalf("error creating table: %+v\n", err)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		f := float64(i)
 		s := fmt.Sprintf("str-%d", i)
 		_, err = tx.Exec("insert into csv values($1,$2,$3);", i, f, s)

--- a/csvutil/csvdriver/import.go
+++ b/csvutil/csvdriver/import.go
@@ -182,9 +182,9 @@ func (st *schemaType) Decl() string {
 	return strings.Join(o, ", ")
 }
 
-func (st *schemaType) Args() ([]driver.NamedValue, []interface{}) {
+func (st *schemaType) Args() ([]driver.NamedValue, []any) {
 	vargs := make([]driver.NamedValue, len(*st))
-	pargs := make([]interface{}, len(*st))
+	pargs := make([]any, len(*st))
 	for i, v := range *st {
 		ptr := reflect.New(v.v.Type())
 		vargs[i] = driver.NamedValue{

--- a/fads/fastjet_finder.go
+++ b/fads/fastjet_finder.go
@@ -37,7 +37,7 @@ type FastJetFinder struct {
 	overlapThreshold float64
 
 	// fastjet area method ---
-	areaDef    interface{}
+	areaDef    any
 	areaAlg    int
 	computeRho bool
 

--- a/fads/propagator.go
+++ b/fads/propagator.go
@@ -189,10 +189,7 @@ func (tsk *Propagator) Process(ctx fwk.Context) error {
 
 			output = append(output, *c)
 			if math.Abs(q) > 1e-9 {
-				pid := c.Pid
-				if pid < 0 {
-					pid = 0
-				}
+				pid := max(c.Pid, 0)
 				switch pid {
 				case 11:
 					eles = append(eles, *c)
@@ -306,10 +303,7 @@ func (tsk *Propagator) Process(ctx fwk.Context) error {
 
 				output = append(output, *c)
 				if math.Abs(q) > 1e-9 {
-					pid := c.Pid
-					if pid < 0 {
-						pid = 0
-					}
+					pid := max(c.Pid, 0)
 					switch pid {
 					case 11:
 						eles = append(eles, *c)

--- a/fads/unique_obj_finder.go
+++ b/fads/unique_obj_finder.go
@@ -90,7 +90,7 @@ func (tsk *UniqueObjectFinder) Process(ctx fwk.Context) error {
 			cand := &input[i]
 			unique := false
 		uniqueloop:
-			for jcol := 0; jcol < icol; jcol++ {
+			for jcol := range icol {
 				jcands := colls[jcol].In
 				for j := range jcands {
 					jcand := &jcands[j]

--- a/fastjet/algorithm_test.go
+++ b/fastjet/algorithm_test.go
@@ -276,11 +276,8 @@ func TestInclusiveJetAlgorithms(t *testing.T) {
 				t.Fatalf("got %d jets, want %d", len(jets), len(want))
 			}
 
-			n := len(jets)
-			if len(want) < n {
-				n = len(want)
-			}
-			for i := 0; i < n; i++ {
+			n := min(len(want), len(jets))
+			for i := range n {
 				ref := want[i][:]
 				jet := jets[i]
 				rap := jet.Rapidity()
@@ -344,11 +341,8 @@ func TestExclusiveJetAlgorithms(t *testing.T) {
 				t.Fatalf("got %d jets, want %d", len(jets), len(want))
 			}
 
-			n := len(jets)
-			if len(want) < n {
-				n = len(want)
-			}
-			for i := 0; i < n; i++ {
+			n := min(len(want), len(jets))
+			for i := range n {
 				ref := want[i][:]
 				jet := jets[i]
 				rap := jet.Rapidity()

--- a/fastjet/clustersequence.go
+++ b/fastjet/clustersequence.go
@@ -100,11 +100,9 @@ func (cs *ClusterSequence) ExclusiveJetsUpTo(njets int) ([]Jet, error) {
 	// calculate the point where we have to stop the clustering
 	// relation between stoppt, njets assumes one extra jet disappears
 	// at each clustering
-	stoppt := 2*cs.initn - njets
+	//
 	// make sure it's safe when more jets are requested than there are particles
-	if stoppt < cs.initn {
-		stoppt = cs.initn
-	}
+	stoppt := max(2*cs.initn-njets, cs.initn)
 	// additional checking
 	if 2*cs.initn != len(cs.history) {
 		err = errors.New("fastjet: too few initial jets")
@@ -329,10 +327,7 @@ func (cs *ClusterSequence) jetScaleForAlgorithm(jet *Jet) float64 {
 		return math.Pow(kt2, 2*p)
 
 	case EeKtAlgorithm:
-		e := jet.E()
-		if e < 1e-300 {
-			e = 1e-300
-		}
+		e := max(jet.E(), 1e-300)
 		return e * e
 
 	default:
@@ -431,7 +426,7 @@ func (cs *ClusterSequence) runN3Dumb() error {
 		jj := -2
 		// find smallest beam distance
 		ymin := cs.jetScaleForAlgorithm(jets[0].jet)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			y := cs.jetScaleForAlgorithm(jets[i].jet)
 			if y < ymin {
 				ymin = y
@@ -441,7 +436,7 @@ func (cs *ClusterSequence) runN3Dumb() error {
 		}
 
 		// find smallest distance between pair of jets
-		for i := 0; i < n-1; i++ {
+		for i := range n - 1 {
 			ijet := jets[i].jet
 			for j := i + 1; j < n; j++ {
 				jjet := jets[j].jet

--- a/fastjet/internal/delaunay/delaunay_test.go
+++ b/fastjet/internal/delaunay/delaunay_test.go
@@ -7,6 +7,7 @@ package delaunay
 import (
 	"math"
 	"math/rand"
+	"slices"
 	"testing"
 )
 
@@ -46,7 +47,7 @@ func TestHierarchicalDelaunayDuplicates(t *testing.T) {
 				ok = true
 				// remove triangles that have been matched from slice,
 				// in case there are duplicate triangles.
-				exp = append(exp[:j], exp[j+1:]...)
+				exp = slices.Delete(exp, j, j+1)
 				break
 			}
 		}
@@ -111,7 +112,7 @@ func TestHierarchicalDelaunayInsertSmall(t *testing.T) {
 				ok = true
 				// remove triangles that have been matched from slice,
 				// in case there are duplicate triangles.
-				exp = append(exp[:j], exp[j+1:]...)
+				exp = slices.Delete(exp, j, j+1)
 				break
 			}
 		}
@@ -199,7 +200,7 @@ func TestHierarchicalDelaunayInsertMedium(t *testing.T) {
 				ok = true
 				// remove triangles that have been matched from slice,
 				// in case there are duplicate triangles.
-				exp = append(exp[:j], exp[j+1:]...)
+				exp = slices.Delete(exp, j, j+1)
 				break
 			}
 		}
@@ -236,9 +237,9 @@ func grid(nx, ny int, angle float64) []*Point {
 	s := math.Sin(angle)
 	c := math.Cos(angle)
 	var points []*Point
-	for xi := 0; xi < nx; xi++ {
+	for xi := range nx {
 		tx := float64(xi)
-		for yi := 0; yi < ny; yi++ {
+		for yi := range ny {
 			ty := float64(yi)
 			x := tx*c - ty*s
 			y := tx*s + ty*c
@@ -270,7 +271,7 @@ func TestHierarchicalDelaunayGridRotated(t *testing.T) {
 
 func benchmarkHierarchicalDelaunayInsertion(i int, b *testing.B) {
 	ps := make([]*Point, i)
-	for j := 0; j < i; j++ {
+	for j := range i {
 		x := rand.Float64() * 1000
 		y := rand.Float64() * 1000
 		ps[j] = NewPoint(x, y)
@@ -401,7 +402,7 @@ func TestHierarchicalDelaunayRemovalSmall(t *testing.T) {
 				ok = true
 				// remove triangles that have been matched from slice,
 				// in case there are duplicate triangles.
-				exp = append(exp[:j], exp[j+1:]...)
+				exp = slices.Delete(exp, j, j+1)
 				break
 			}
 		}
@@ -506,7 +507,7 @@ func TestHierarchicalDelaunayRemovalMedium(t *testing.T) {
 				ok = true
 				// remove triangles that have been matched from slice,
 				// in case there are duplicate triangles.
-				exp = append(exp[:j], exp[j+1:]...)
+				exp = slices.Delete(exp, j, j+1)
 				break
 			}
 		}
@@ -542,7 +543,7 @@ func TestHierarchicalDelaunayRemovalMedium(t *testing.T) {
 
 func benchmarkHierarchicalDelaunayRemoval(i int, b *testing.B) {
 	ps := make([]*Point, i)
-	for j := 0; j < i; j++ {
+	for j := range i {
 		x := rand.Float64() * 1000
 		y := rand.Float64() * 1000
 		ps[j] = NewPoint(x, y)

--- a/fastjet/internal/delaunay/point.go
+++ b/fastjet/internal/delaunay/point.go
@@ -7,6 +7,7 @@ package delaunay
 import (
 	"fmt"
 	"math"
+	"slices"
 
 	"go-hep.org/x/hep/fastjet/internal/predicates"
 )
@@ -311,11 +312,8 @@ func (ps points) remove(pts ...*Point) points {
 	out := make(points, 0, len(ps))
 	for _, p := range ps {
 		keep := true
-		for _, pt := range pts {
-			if p.Equals(pt) {
-				keep = false
-				break
-			}
+		if slices.ContainsFunc(pts, p.Equals) {
+			keep = false
 		}
 		if keep {
 			out = append(out, p)
@@ -330,7 +328,7 @@ func (ps points) remove(pts ...*Point) points {
 func (points points) polyArea() float64 {
 	var area float64
 	j := len(points) - 1
-	for i := 0; i < len(points); i++ {
+	for i := range points {
 		area += (points[j].x + points[i].x) * (points[j].y - points[i].y)
 		j = i
 	}

--- a/fastjet/internal/heap/heap_test.go
+++ b/fastjet/internal/heap/heap_test.go
@@ -13,7 +13,7 @@ import (
 // FIXME B/op is higher here, than for PQ
 func BenchmarkHeap(b *testing.B) {
 	var items []*pair
-	for i := 0; i < 5000; i++ {
+	for range 5000 {
 		jeti := rand.Int()
 		jetj := rand.Int()
 		dij := rand.Float64()
@@ -34,7 +34,7 @@ func BenchmarkHeap(b *testing.B) {
 
 func BenchmarkPQ(b *testing.B) {
 	var items []*pair
-	for i := 0; i < 5000; i++ {
+	for range 5000 {
 		jeti := rand.Int()
 		jetj := rand.Int()
 		dij := rand.Float64()
@@ -148,12 +148,12 @@ func (pq PQ) Swap(i, j int) {
 	pq[i], pq[j] = pq[j], pq[i]
 }
 
-func (pq *PQ) Push(x interface{}) {
+func (pq *PQ) Push(x any) {
 	item := x.(*pair)
 	*pq = append(*pq, item)
 }
 
-func (pq *PQ) Pop() interface{} {
+func (pq *PQ) Pop() any {
 	old := *pq
 	n := len(old)
 	item := old[n-1]

--- a/fastjet/jet.go
+++ b/fastjet/jet.go
@@ -17,7 +17,7 @@ const (
 )
 
 // UserInfo holds extra user information in a Jet
-type UserInfo interface{}
+type UserInfo any
 
 // Jet holds minimal information of use for jet-clustering routines
 type Jet struct {

--- a/fit/curve1d_test.go
+++ b/fit/curve1d_test.go
@@ -101,7 +101,7 @@ func genXY(n int, f func(x float64, ps []float64) float64, ps []float64, xmin, x
 	rnd := rand.New(rand.NewSource(1234))
 	xstep := (xmax - xmin) / float64(n)
 	p := make([]float64, len(ps))
-	for i := 0; i < n; i++ {
+	for i := range n {
 		x := xmin + xstep*float64(i)
 		for j := range p {
 			v := rnd.NormFloat64()

--- a/fit/curve_nd_test.go
+++ b/fit/curve_nd_test.go
@@ -23,8 +23,8 @@ func genData2D(n0, n1 int, f func(x, ps []float64) float64, ps []float64, x0min,
 		x1step = (x1max - x1min) / float64(n1)
 		p      = make([]float64, len(ps))
 	)
-	for i := 0; i < n0; i++ {
-		for j := 0; j < n1; j++ {
+	for i := range n0 {
+		for j := range n1 {
 			x := []float64{x0min + x0step*float64(i), x1min + x1step*float64(j)}
 			for k := range p {
 				v := rnd.NormFloat64()

--- a/fit/hist_example_test.go
+++ b/fit/hist_example_test.go
@@ -42,7 +42,7 @@ func ExampleH1D_gaussian() {
 	// Draw some random values from the standard
 	// normal distribution.
 	hist := hbook.NewH1D(100, -20, +25)
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		v := dist.Rand()
 		hist.Fill(v, 1)
 	}

--- a/fmom/eetaphim.go
+++ b/fmom/eetaphim.go
@@ -104,10 +104,7 @@ func (p4 *EEtaPhiM) CosTh() float64 {
 
 func (p4 *EEtaPhiM) SinTh() float64 {
 	eta := p4.Eta()
-	abseta := math.Abs(eta)
-	if abseta > 710 {
-		abseta = 710
-	}
+	abseta := min(math.Abs(eta), 710)
 	return 1 / math.Cosh(abseta)
 }
 

--- a/fmom/etetaphim.go
+++ b/fmom/etetaphim.go
@@ -104,10 +104,7 @@ func (p4 *EtEtaPhiM) CosTh() float64 {
 
 func (p4 *EtEtaPhiM) SinTh() float64 {
 	eta := p4.Eta()
-	abseta := math.Abs(eta)
-	if abseta > 710 {
-		abseta = 710
-	}
+	abseta := min(math.Abs(eta), 710)
 	return 1 / math.Cosh(abseta)
 }
 

--- a/fmom/ptetaphim.go
+++ b/fmom/ptetaphim.go
@@ -102,11 +102,8 @@ func (p4 *PtEtaPhiM) CosTh() float64 {
 
 func (p4 *PtEtaPhiM) SinTh() float64 {
 	eta := p4.Eta()
-	abseta := math.Abs(eta)
 	// avoid numeric overflow if very large eta
-	if abseta > 710 {
-		abseta = 710
-	}
+	abseta := min(math.Abs(eta), 710)
 	return 1 / math.Cosh(abseta)
 }
 

--- a/fwk/cmd/fwk-new-comp/gen.go
+++ b/fwk/cmd/fwk-new-comp/gen.go
@@ -18,7 +18,7 @@ func gen_svc(c Component) error {
 	return gen(os.Stdout, g_svc_template, c)
 }
 
-func gen(w io.Writer, text string, data interface{}) error {
+func gen(w io.Writer, text string, data any) error {
 	t := template.Must(template.New("fwk").Parse(text))
 	return t.Execute(w, data)
 }

--- a/fwk/core.go
+++ b/fwk/core.go
@@ -124,9 +124,9 @@ type Scripter interface {
 
 // PropMgr manages properties attached to components.
 type PropMgr interface {
-	DeclProp(c Component, name string, ptr interface{}) error
-	SetProp(c Component, name string, value interface{}) error
-	GetProp(c Component, name string) (interface{}, error)
+	DeclProp(c Component, name string, ptr any) error
+	SetProp(c Component, name string, value any) error
+	GetProp(c Component, name string) (any, error)
 	HasProp(c Component, name string) bool
 }
 
@@ -134,15 +134,15 @@ type PropMgr interface {
 // Properties of a given component can be modified
 // by a job-option or by other components.
 type Property interface {
-	DeclProp(name string, ptr interface{}) error
-	SetProp(name string, value interface{}) error
-	GetProp(name string) (interface{}, error)
+	DeclProp(name string, ptr any) error
+	SetProp(name string, value any) error
+	GetProp(name string) (any, error)
 }
 
-// Store provides access to a concurrent-safe map[string]interface{} store.
+// Store provides access to a concurrent-safe map[string]any store.
 type Store interface {
-	Get(key string) (interface{}, error)
-	Put(key string, value interface{}) error
+	Get(key string) (any, error)
+	Put(key string, value any) error
 	Has(key string) bool
 }
 
@@ -211,12 +211,12 @@ func (lvl Level) String() string {
 
 // MsgStream provides access to verbosity-defined formated messages, a la fmt.Printf.
 type MsgStream interface {
-	Debugf(format string, a ...interface{})
-	Infof(format string, a ...interface{})
-	Warnf(format string, a ...interface{})
-	Errorf(format string, a ...interface{})
+	Debugf(format string, a ...any)
+	Infof(format string, a ...any)
+	Warnf(format string, a ...any)
+	Errorf(format string, a ...any)
 
-	Msg(lvl Level, format string, a ...interface{})
+	Msg(lvl Level, format string, a ...any)
 }
 
 // Deleter prepares values to be GC-reclaimed

--- a/fwk/dflow.go
+++ b/fwk/dflow.go
@@ -84,10 +84,10 @@ func (svc *dflowsvc) StartSvc(ctx Context) error {
 	}
 
 	// detect cycles.
-	graph := make(map[interface{}][]interface{})
+	graph := make(map[any][]any)
 	for _, n := range nodenames {
 		node := svc.nodes[n]
-		graph[n] = []interface{}{}
+		graph[n] = []any{}
 		for in := range node.in {
 			for _, o := range nodenames {
 				if o == n {

--- a/fwk/fwk_test.go
+++ b/fwk/fwk_test.go
@@ -252,7 +252,7 @@ func getsumsq(n int64) int64 {
 
 func newTestReader(max int) io.Reader {
 	buf := new(bytes.Buffer)
-	for i := 0; i < max; i++ {
+	for i := range max {
 		fmt.Fprintf(buf, "%d\n", int64(i))
 	}
 	return buf
@@ -444,7 +444,7 @@ func Benchmark___SeqApp(b *testing.B) {
 	})
 
 	input := "t0"
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		name := fmt.Sprintf("tx-%d", i)
 		out := fmt.Sprintf("tx-%d", i)
 		app.Create(job.C{
@@ -499,7 +499,7 @@ func Benchmark__ConcApp(b *testing.B) {
 	})
 
 	input := "t0"
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		name := fmt.Sprintf("tx-%d", i)
 		out := fmt.Sprintf("tx-%d", i)
 		app.Create(job.C{

--- a/fwk/hbooksvc/hsvc_test.go
+++ b/fwk/hbooksvc/hsvc_test.go
@@ -33,7 +33,7 @@ func TestHbookSvcSeq(t *testing.T) {
 
 	app := newapp(nentries, 0)
 
-	for i := 0; i < nhists; i++ {
+	for i := range nhists {
 		app.Create(job.C{
 			Type:  "go-hep.org/x/hep/fwk/hbooksvc.testhsvc",
 			Name:  fmt.Sprintf("t%03d", i),
@@ -64,7 +64,7 @@ func TestHbookSvcConc(t *testing.T) {
 		app := newapp(nentries, nprocs)
 		app.Infof("=== nprocs: %d ===\n", nprocs)
 
-		for i := 0; i < nhists; i++ {
+		for i := range nhists {
 			app.Create(job.C{
 				Type:  "go-hep.org/x/hep/fwk/hbooksvc.testhsvc",
 				Name:  fmt.Sprintf("t%03d", i),

--- a/fwk/hbooksvc/stream.go
+++ b/fwk/hbooksvc/stream.go
@@ -50,7 +50,7 @@ func (stream *istream) close() error {
 	return err
 }
 
-func (stream *istream) read(name string, ptr interface{}) error {
+func (stream *istream) read(name string, ptr any) error {
 	var err error
 
 	seekr, ok := stream.f.(io.Seeker)

--- a/fwk/hsvc.go
+++ b/fwk/hsvc.go
@@ -12,7 +12,7 @@ import (
 // be saved or loaded by the HistSvc.
 type Hist interface {
 	Name() string
-	Value() interface{}
+	Value() any
 }
 
 // HID is a histogram, scatter or profile identifier
@@ -28,7 +28,7 @@ func (h H1D) Name() string {
 	return string(h.ID)
 }
 
-func (h H1D) Value() interface{} {
+func (h H1D) Value() any {
 	return h.Hist
 }
 
@@ -42,7 +42,7 @@ func (h H2D) Name() string {
 	return string(h.ID)
 }
 
-func (h H2D) Value() interface{} {
+func (h H2D) Value() any {
 	return h.Hist
 }
 
@@ -56,7 +56,7 @@ func (p P1D) Name() string {
 	return string(p.ID)
 }
 
-func (p P1D) Value() interface{} {
+func (p P1D) Value() any {
 	return p.Profile
 }
 
@@ -70,7 +70,7 @@ func (s S2D) Name() string {
 	return string(s.ID)
 }
 
-func (s S2D) Value() interface{} {
+func (s S2D) Value() any {
 	return s.Scatter
 }
 

--- a/fwk/internal/fwktest/outputstream.go
+++ b/fwk/internal/fwktest/outputstream.go
@@ -5,8 +5,8 @@
 package fwktest
 
 import (
-	"fmt"
 	"io"
+	"strconv"
 
 	"go-hep.org/x/hep/fwk"
 )
@@ -32,7 +32,7 @@ func (out *OutputStream) Write(ctx fwk.Context) error {
 	}
 
 	data := v.(int64)
-	_, err = out.W.Write([]byte(fmt.Sprintf("%d\n", data)))
+	_, err = out.W.Write([]byte(strconv.FormatInt(data, 10) + "\n"))
 	if err != nil {
 		return err
 	}

--- a/fwk/job/gocodec.go
+++ b/fwk/job/gocodec.go
@@ -33,7 +33,7 @@ type GoEncoder struct {
 }
 
 // Encode encodes data into the underlying io.Writer
-func (enc *GoEncoder) Encode(data interface{}) error {
+func (enc *GoEncoder) Encode(data any) error {
 	var err error
 	stmts, ok := data.([]Stmt)
 	if !ok {
@@ -164,7 +164,7 @@ func newApp() *job.Job {
 
 		case StmtSetProp:
 			var key string
-			var val interface{}
+			var val any
 			for k, v := range stmt.Data.Props {
 				key = k
 				val = v
@@ -204,7 +204,7 @@ func (enc *GoEncoder) repr(props P) []byte {
 	return buf.Bytes()
 }
 
-func (enc *GoEncoder) value(v interface{}) string {
+func (enc *GoEncoder) value(v any) string {
 	typ := reflect.TypeOf(v)
 	prop := ""
 	switch typ.Kind() {

--- a/fwk/job/io.go
+++ b/fwk/job/io.go
@@ -6,7 +6,7 @@ package job
 
 // Encoder encodes data into the underlying io.Writer
 type Encoder interface {
-	Encode(data interface{}) error
+	Encode(data any) error
 }
 
 // Save saves a job's configuration description using the Encoder enc.
@@ -16,7 +16,7 @@ func Save(stmts []Stmt, enc Encoder) error {
 
 // Decoder decodes data from the unerlying io.Reader
 type Decoder interface {
-	Decode(ptr interface{}) error
+	Decode(ptr any) error
 }
 
 // Load loads a job's configuration description using the Decoder dec.

--- a/fwk/job/job.go
+++ b/fwk/job/job.go
@@ -19,7 +19,7 @@ type C struct {
 
 // P holds the configuration data (the properties) of a fwk.Component
 // a map of key-value pairs.
-type P map[string]interface{}
+type P map[string]any
 
 // Job is the go-based scripting interface to create, configure and run a fwk.App.
 type Job struct {
@@ -100,7 +100,7 @@ func (job *Job) Create(cfg C) fwk.Component {
 // SetProp sets the property name of the component c with the value v.
 // SetProp panics if the component does not have such property or
 // if the types do not match.
-func (job *Job) SetProp(c fwk.Component, name string, value interface{}) {
+func (job *Job) SetProp(c fwk.Component, name string, value any) {
 	job.setProp(c, name, value)
 	job.stmts = append(job.stmts, Stmt{
 		Type: StmtSetProp,
@@ -114,7 +114,7 @@ func (job *Job) SetProp(c fwk.Component, name string, value interface{}) {
 	})
 }
 
-func (job *Job) setProp(c fwk.Component, name string, value interface{}) {
+func (job *Job) setProp(c fwk.Component, name string, value any) {
 	if !job.app.HasProp(c, name) {
 		err := fmt.Errorf("component [%s:%s] has no property named %q",
 			c.Type(),
@@ -159,22 +159,22 @@ func (job *Job) Stmts() []Stmt {
 }
 
 // Debugf displays a (formated) DBG message
-func (job *Job) Debugf(format string, a ...interface{}) {
+func (job *Job) Debugf(format string, a ...any) {
 	job.app.Msg().Debugf(format, a...)
 }
 
 // Infof displays a (formated) INFO message
-func (job *Job) Infof(format string, a ...interface{}) {
+func (job *Job) Infof(format string, a ...any) {
 	job.app.Msg().Infof(format, a...)
 }
 
 // Warnf displays a (formated) WARN message
-func (job *Job) Warnf(format string, a ...interface{}) {
+func (job *Job) Warnf(format string, a ...any) {
 	job.app.Msg().Warnf(format, a...)
 }
 
 // Errorf displays a (formated) ERR message
-func (job *Job) Errorf(format string, a ...interface{}) {
+func (job *Job) Errorf(format string, a ...any) {
 	job.app.Msg().Errorf(format, a...)
 }
 

--- a/fwk/msgstream.go
+++ b/fwk/msgstream.go
@@ -42,29 +42,29 @@ func newMsgStream(name string, lvl Level, w WriteSyncer) msgstream {
 }
 
 // Debugf displays a (formated) DBG message
-func (msg msgstream) Debugf(format string, a ...interface{}) {
+func (msg msgstream) Debugf(format string, a ...any) {
 	msg.Msg(LvlDebug, format, a...)
 }
 
 // Infof displays a (formated) INFO message
-func (msg msgstream) Infof(format string, a ...interface{}) {
+func (msg msgstream) Infof(format string, a ...any) {
 	msg.Msg(LvlInfo, format, a...)
 }
 
 // Warnf displays a (formated) WARN message
-func (msg msgstream) Warnf(format string, a ...interface{}) {
+func (msg msgstream) Warnf(format string, a ...any) {
 	defer msg.flush()
 	msg.Msg(LvlWarning, format, a...)
 }
 
 // Errorf displays a (formated) ERR message
-func (msg msgstream) Errorf(format string, a ...interface{}) {
+func (msg msgstream) Errorf(format string, a ...any) {
 	defer msg.flush()
 	msg.Msg(LvlError, format, a...)
 }
 
 // Msg displays a (formated) message with level lvl.
-func (msg msgstream) Msg(lvl Level, format string, a ...interface{}) {
+func (msg msgstream) Msg(lvl Level, format string, a ...any) {
 	if lvl < msg.lvl {
 		return
 	}

--- a/fwk/registry.go
+++ b/fwk/registry.go
@@ -52,7 +52,7 @@ func (app *appmgr) New(t, n string) (Component, error) {
 	if _, dup := app.props[n]; dup {
 		return nil, fmt.Errorf("component with name [%s] already created", n)
 	}
-	app.props[n] = make(map[string]interface{})
+	app.props[n] = make(map[string]any)
 
 	c, err := fct(t, n, app)
 	if err != nil {

--- a/fwk/rio/input.go
+++ b/fwk/rio/input.go
@@ -59,7 +59,7 @@ func (input *InputStreamer) Connect(ports []fwk.Port) error {
 func (input *InputStreamer) Read(ctx fwk.Context) error {
 	store := ctx.Store()
 	recs := make(map[string]struct{}, len(input.ports))
-	for i := 0; i < len(input.ports); i++ {
+	for range len(input.ports) {
 		if !input.scan.Scan() {
 			err := input.scan.Err()
 			if err == nil {

--- a/fwk/store.go
+++ b/fwk/store.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 )
 
-type achan chan interface{}
+type achan chan any
 
 // datastore stores (event) data and provides concurrent-safe access to it.
 type datastore struct {
@@ -22,7 +22,7 @@ func (ds *datastore) Configure(ctx Context) error {
 	return nil
 }
 
-func (ds *datastore) Get(k string) (interface{}, error) {
+func (ds *datastore) Get(k string) (any, error) {
 	ch, ok := ds.store[k]
 	if !ok {
 		return nil, fmt.Errorf("Store.Get: no such key [%v]", k)
@@ -39,7 +39,7 @@ func (ds *datastore) Get(k string) (interface{}, error) {
 	}
 }
 
-func (ds *datastore) Put(k string, v interface{}) error {
+func (ds *datastore) Put(k string, v any) error {
 	select {
 	case ds.store[k] <- v:
 		return nil

--- a/fwk/svcbase.go
+++ b/fwk/svcbase.go
@@ -39,17 +39,17 @@ func (svc *SvcBase) Name() string {
 
 // DeclProp declares this service has a property named n,
 // and takes a pointer to the associated value.
-func (svc *SvcBase) DeclProp(n string, ptr interface{}) error {
+func (svc *SvcBase) DeclProp(n string, ptr any) error {
 	return svc.mgr.DeclProp(svc, n, ptr)
 }
 
 // SetProp sets the property name n with the value v.
-func (svc *SvcBase) SetProp(name string, value interface{}) error {
+func (svc *SvcBase) SetProp(name string, value any) error {
 	return svc.mgr.SetProp(svc, name, value)
 }
 
 // GetProp returns the value of the property named n.
-func (svc *SvcBase) GetProp(name string) (interface{}, error) {
+func (svc *SvcBase) GetProp(name string) (any, error) {
 	return svc.mgr.GetProp(svc, name)
 }
 

--- a/fwk/taskbase.go
+++ b/fwk/taskbase.go
@@ -51,17 +51,17 @@ func (tsk *TaskBase) DeclOutPort(n string, t reflect.Type) error {
 
 // DeclProp declares this task has a property named n,
 // and takes a pointer to the associated value.
-func (tsk *TaskBase) DeclProp(n string, ptr interface{}) error {
+func (tsk *TaskBase) DeclProp(n string, ptr any) error {
 	return tsk.mgr.DeclProp(tsk, n, ptr)
 }
 
 // SetProp sets the property name n with the value v.
-func (tsk *TaskBase) SetProp(n string, v interface{}) error {
+func (tsk *TaskBase) SetProp(n string, v any) error {
 	return tsk.mgr.SetProp(tsk, n, v)
 }
 
 // GetProp returns the value of the property named n.
-func (tsk *TaskBase) GetProp(n string) (interface{}, error) {
+func (tsk *TaskBase) GetProp(n string) (any, error) {
 	return tsk.mgr.GetProp(tsk, n)
 }
 

--- a/fwk/utils/builder/templates.go
+++ b/fwk/utils/builder/templates.go
@@ -65,7 +65,7 @@ func main() {
 `
 )
 
-func render(w io.Writer, text string, data interface{}) error {
+func render(w io.Writer, text string, data any) error {
 	t := template.New("fwk-main")
 	t.Funcs(template.FuncMap{
 		"trim":       strings.TrimSpace,

--- a/fwk/utils/parallel/parallel_test.go
+++ b/fwk/utils/parallel/parallel_test.go
@@ -23,7 +23,7 @@ func TestParallelMaxPar(t *testing.T) {
 	n := 0
 	tot := 0
 	r := parallel.NewRun(maxPar)
-	for i := 0; i < totalDo; i++ {
+	for range totalDo {
 		r.Do(func() error {
 			mu.Lock()
 			tot++
@@ -66,7 +66,7 @@ func TestParallelError(t *testing.T) {
 		errDo   = 5
 	)
 	r := parallel.NewRun(6)
-	for i := 0; i < totalDo; i++ {
+	for i := range totalDo {
 		i := i
 		if i >= errDo {
 			r.Do(func() error {

--- a/fwk/utils/tarjan/tarjan.go
+++ b/fwk/utils/tarjan/tarjan.go
@@ -37,11 +37,11 @@ package tarjan // import "go-hep.org/x/hep/fwk/utils/tarjan"
 // vertex itself is also a connected group.
 //
 // The example shows the same graph as in the Wikipedia article.
-func Connections(graph map[interface{}][]interface{}) [][]interface{} {
+func Connections(graph map[any][]any) [][]any {
 	g := &data{
 		graph: graph,
 		nodes: make([]node, 0, len(graph)),
-		index: make(map[interface{}]int, len(graph)),
+		index: make(map[any]int, len(graph)),
 	}
 	for v := range g.graph {
 		if _, ok := g.index[v]; !ok {
@@ -53,11 +53,11 @@ func Connections(graph map[interface{}][]interface{}) [][]interface{} {
 
 // data contains all common data for a single operation.
 type data struct {
-	graph  map[interface{}][]interface{}
+	graph  map[any][]any
 	nodes  []node
-	stack  []interface{}
-	index  map[interface{}]int
-	output [][]interface{}
+	stack  []any
+	index  map[any]int
+	output [][]any
 }
 
 // node stores data for a single vertex in the connection process.
@@ -68,7 +68,7 @@ type node struct {
 
 // strongConnect runs Tarjan's algorithm recursivley and outputs a grouping of
 // strongly connected vertices.
-func (data *data) strongConnect(v interface{}) *node {
+func (data *data) strongConnect(v any) *node {
 	index := len(data.nodes)
 	data.index[v] = index
 	data.stack = append(data.stack, v)
@@ -90,7 +90,7 @@ func (data *data) strongConnect(v interface{}) *node {
 	}
 
 	if node.lowlink == index {
-		var vertices []interface{}
+		var vertices []any
 		i := len(data.stack) - 1
 		for {
 			w := data.stack[i]

--- a/fwk/utils/tarjan/tarjan_test.go
+++ b/fwk/utils/tarjan/tarjan_test.go
@@ -23,15 +23,15 @@ import (
 )
 
 func TestTypeString(t *testing.T) {
-	graph := make(map[interface{}][]interface{})
-	graph["1"] = []interface{}{"2"}
-	graph["2"] = []interface{}{"3"}
-	graph["3"] = []interface{}{"1"}
-	graph["4"] = []interface{}{"2", "3", "5"}
-	graph["5"] = []interface{}{"4", "6"}
-	graph["6"] = []interface{}{"3", "7"}
-	graph["7"] = []interface{}{"6"}
-	graph["8"] = []interface{}{"5", "7", "8"}
+	graph := make(map[any][]any)
+	graph["1"] = []any{"2"}
+	graph["2"] = []any{"3"}
+	graph["3"] = []any{"1"}
+	graph["4"] = []any{"2", "3", "5"}
+	graph["5"] = []any{"4", "6"}
+	graph["6"] = []any{"3", "7"}
+	graph["7"] = []any{"6"}
+	graph["8"] = []any{"5", "7", "8"}
 
 	o := Connections(graph)
 	output := sortConnections(o)
@@ -47,15 +47,15 @@ func TestTypeString(t *testing.T) {
 }
 
 func TestTypeInt(t *testing.T) {
-	graph := make(map[interface{}][]interface{})
-	graph[1] = []interface{}{2}
-	graph[2] = []interface{}{3}
-	graph[3] = []interface{}{1}
-	graph[4] = []interface{}{2, 3, 5}
-	graph[5] = []interface{}{4, 6}
-	graph[6] = []interface{}{3, 7}
-	graph[7] = []interface{}{6}
-	graph[8] = []interface{}{5, 7, 8}
+	graph := make(map[any][]any)
+	graph[1] = []any{2}
+	graph[2] = []any{3}
+	graph[3] = []any{1}
+	graph[4] = []any{2, 3, 5}
+	graph[5] = []any{4, 6}
+	graph[6] = []any{3, 7}
+	graph[7] = []any{6}
+	graph[8] = []any{5, 7, 8}
 
 	o := Connections(graph)
 	output := sortConnections(o)
@@ -71,15 +71,15 @@ func TestTypeInt(t *testing.T) {
 }
 
 func TestTypeMixed(t *testing.T) {
-	graph := make(map[interface{}][]interface{})
-	graph[1] = []interface{}{2}
-	graph[2] = []interface{}{"3"}
-	graph["3"] = []interface{}{1}
-	graph[4] = []interface{}{2, "3", 5}
-	graph[5] = []interface{}{4, "6"}
-	graph["6"] = []interface{}{"3", 7}
-	graph[7] = []interface{}{"6"}
-	graph[8] = []interface{}{5, 7, 8}
+	graph := make(map[any][]any)
+	graph[1] = []any{2}
+	graph[2] = []any{"3"}
+	graph["3"] = []any{1}
+	graph[4] = []any{2, "3", 5}
+	graph[5] = []any{4, "6"}
+	graph["6"] = []any{"3", 7}
+	graph[7] = []any{"6"}
+	graph[8] = []any{5, 7, 8}
 
 	o := Connections(graph)
 	output := sortConnections(o)
@@ -95,7 +95,7 @@ func TestTypeMixed(t *testing.T) {
 }
 
 func TestEmptyGraph(t *testing.T) {
-	graph := make(map[interface{}][]interface{})
+	graph := make(map[any][]any)
 
 	output := Connections(graph)
 	if len(output) != 0 {
@@ -104,8 +104,8 @@ func TestEmptyGraph(t *testing.T) {
 }
 
 func TestSingleVertex(t *testing.T) {
-	graph := make(map[interface{}][]interface{})
-	graph["1"] = []interface{}{}
+	graph := make(map[any][]any)
+	graph["1"] = []any{}
 
 	o := Connections(graph)
 	output := sortConnections(o)
@@ -115,8 +115,8 @@ func TestSingleVertex(t *testing.T) {
 }
 
 func TestSingleVertexLoop(t *testing.T) {
-	graph := make(map[interface{}][]interface{})
-	graph["1"] = []interface{}{"1"}
+	graph := make(map[any][]any)
+	graph["1"] = []any{"1"}
 
 	o := Connections(graph)
 	output := sortConnections(o)
@@ -126,10 +126,10 @@ func TestSingleVertexLoop(t *testing.T) {
 }
 
 func TestMultipleVertexLoop(t *testing.T) {
-	graph := make(map[interface{}][]interface{})
-	graph["1"] = []interface{}{"2"}
-	graph["2"] = []interface{}{"3"}
-	graph["3"] = []interface{}{"1"}
+	graph := make(map[any][]any)
+	graph["1"] = []any{"2"}
+	graph["2"] = []any{"3"}
+	graph["3"] = []any{"1"}
 
 	o := Connections(graph)
 	output := sortConnections(o)
@@ -145,15 +145,15 @@ func TestMultipleVertexLoop(t *testing.T) {
 }
 
 func ExampleConnections() {
-	graph := make(map[interface{}][]interface{})
-	graph["1"] = []interface{}{"2"}
-	graph["2"] = []interface{}{"3"}
-	graph["3"] = []interface{}{"1"}
-	graph["4"] = []interface{}{"2", "3", "5"}
-	graph["5"] = []interface{}{"4", "6"}
-	graph["6"] = []interface{}{"3", "7"}
-	graph["7"] = []interface{}{"6"}
-	graph["8"] = []interface{}{"5", "7", "8"}
+	graph := make(map[any][]any)
+	graph["1"] = []any{"2"}
+	graph["2"] = []any{"3"}
+	graph["3"] = []any{"1"}
+	graph["4"] = []any{"2", "3", "5"}
+	graph["5"] = []any{"4", "6"}
+	graph["6"] = []any{"3", "7"}
+	graph["7"] = []any{"6"}
+	graph["8"] = []any{"5", "7", "8"}
 
 	o := Connections(graph)
 	output := sortConnections(o)
@@ -163,7 +163,7 @@ func ExampleConnections() {
 	// [[1 2 3] [6 7] [4 5] [8]]
 }
 
-func sortConnections(connections [][]interface{}) [][]string {
+func sortConnections(connections [][]any) [][]string {
 	out := make([][]string, 0, len(connections))
 	for _, cons := range connections {
 		slice := make([]string, 0, len(cons))

--- a/geo/gdml/solids_test.go
+++ b/geo/gdml/solids_test.go
@@ -15,7 +15,7 @@ func TestReadSolids(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		raw  string
-		want interface{}
+		want any
 	}{
 		{
 			name: "box",

--- a/groot/cmd/root-gen-datareader/main.go
+++ b/groot/cmd/root-gen-datareader/main.go
@@ -226,7 +226,7 @@ func newContext(pkg, file, tree string, dataReader, verbose bool) *Context {
 	return ctx
 }
 
-func (ctx *Context) printf(format string, args ...interface{}) {
+func (ctx *Context) printf(format string, args ...any) {
 	if ctx.Verbose {
 		log.Printf(format, args...)
 	}

--- a/groot/cmd/root-gen-rfunc/testdata/func1_golden.txt
+++ b/groot/cmd/root-gen-rfunc/testdata/func1_golden.txt
@@ -20,7 +20,7 @@ func (f *FuncF64F64ToBool) RVars() []string { return f.rvars }
 
 
 // Bind implements rfunc.Formula
-func (f *FuncF64F64ToBool) Bind(args []interface{}) error {
+func (f *FuncF64F64ToBool) Bind(args []any) error {
 	if got, want := len(args), 2; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -51,7 +51,7 @@ func (f *FuncF64F64ToBool) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncF64F64ToBool) Func() interface{} {
+func (f *FuncF64F64ToBool) Func() any {
 	return func()  bool {
 		return f.fct(
 			*f.arg0,

--- a/groot/cmd/root-gen-rfunc/testdata/func2_golden.txt
+++ b/groot/cmd/root-gen-rfunc/testdata/func2_golden.txt
@@ -20,7 +20,7 @@ func (f *MyFunc) RVars() []string { return f.rvars }
 
 
 // Bind implements rfunc.Formula
-func (f *MyFunc) Bind(args []interface{}) error {
+func (f *MyFunc) Bind(args []any) error {
 	if got, want := len(args), 2; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -51,7 +51,7 @@ func (f *MyFunc) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *MyFunc) Func() interface{} {
+func (f *MyFunc) Func() any {
 	return func()  bool {
 		return f.fct(
 			*f.arg0,

--- a/groot/cmd/root-gen-rfunc/testdata/math_abs_golden.txt
+++ b/groot/cmd/root-gen-rfunc/testdata/math_abs_golden.txt
@@ -19,7 +19,7 @@ func (f *MyAbs) RVars() []string { return f.rvars }
 
 
 // Bind implements rfunc.Formula
-func (f *MyAbs) Bind(args []interface{}) error {
+func (f *MyAbs) Bind(args []any) error {
 	if got, want := len(args), 1; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -40,7 +40,7 @@ func (f *MyAbs) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *MyAbs) Func() interface{} {
+func (f *MyAbs) Func() any {
 	return func()  float64 {
 		return f.fct(
 			*f.arg0,

--- a/groot/cmd/root-gen-rfunc/testdata/math_hypot_golden.txt
+++ b/groot/cmd/root-gen-rfunc/testdata/math_hypot_golden.txt
@@ -20,7 +20,7 @@ func (f *HypotFormula) RVars() []string { return f.rvars }
 
 
 // Bind implements rfunc.Formula
-func (f *HypotFormula) Bind(args []interface{}) error {
+func (f *HypotFormula) Bind(args []any) error {
 	if got, want := len(args), 2; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -51,7 +51,7 @@ func (f *HypotFormula) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *HypotFormula) Func() interface{} {
+func (f *HypotFormula) Func() any {
 	return func()  float64 {
 		return f.fct(
 			*f.arg0,

--- a/groot/cmd/root-gen-streamer/main_test.go
+++ b/groot/cmd/root-gen-streamer/main_test.go
@@ -145,7 +145,7 @@ key[000]: data;1 "" (go_hep_org::x::hep::groot::internal::rdatatest::T1) => &{he
 				t.Fatalf("could not recompile package with streamer data:\n%v\nerr: %v", out.String(), err)
 			}
 
-			err = os.WriteFile("testdata/run.go", []byte(fmt.Sprintf(`//go:build ignore
+			err = os.WriteFile("testdata/run.go", fmt.Appendf(nil, `//go:build ignore
 
 package main
 
@@ -175,7 +175,7 @@ func main() {
 	}
 }
 `, tc.tmpl,
-			)), 0644)
+			), 0644)
 
 			if err != nil {
 				t.Fatalf("could not generate test-write program: %v", err)

--- a/groot/cmd/root-srv/data.go
+++ b/groot/cmd/root-srv/data.go
@@ -67,7 +67,7 @@ type jsNode struct {
 	Attr     jsAttr   `json:"a_attr,omitempty"`
 }
 
-type jsAttr map[string]interface{}
+type jsAttr map[string]any
 
 type brancher interface {
 	Branches() []rtree.Branch

--- a/groot/cmd/root-srv/server.go
+++ b/groot/cmd/root-srv/server.go
@@ -304,7 +304,7 @@ func (srv *server) process(preq plotRequest) {
 	var (
 		h    http.HandlerFunc
 		hreq *http.Request
-		req  interface{}
+		req  any
 		ep   string
 		err  error
 		body = new(bytes.Buffer)

--- a/groot/example_test.go
+++ b/groot/example_test.go
@@ -212,7 +212,7 @@ func ExampleOpen_graph() {
 	fmt.Printf("name:  %q\n", g.Name())
 	fmt.Printf("title: %q\n", g.Title())
 	fmt.Printf("#pts:  %d\n", g.Len())
-	for i := 0; i < g.Len(); i++ {
+	for i := range g.Len() {
 		x, y := g.XY(i)
 		fmt.Printf("(x,y)[%d] = (%+e, %+e)\n", i, x, y)
 	}

--- a/groot/gen.rcont.go
+++ b/groot/gen.rcont.go
@@ -135,11 +135,11 @@ func (arr *{{.Name}}) At(i int) {{.Type}} {
 	return arr.Data[i]
 }
 
-func (arr *{{.Name}}) Get(i int) interface{} {
+func (arr *{{.Name}}) Get(i int) any {
 	return arr.Data[i]
 }
 
-func (arr *{{.Name}}) Set(i int, v interface{}) {
+func (arr *{{.Name}}) Set(i int, v any) {
 	arr.Data[i] = v.({{.Type}})
 }
 

--- a/groot/gen.rtree.go
+++ b/groot/gen.rtree.go
@@ -429,14 +429,14 @@ func (leaf *{{.Name}}) readFromBuffer(r *rbytes.RBuffer) error {
     return r.Err()
 }
 
-func (leaf *{{.Name}}) unsafeDecayArray(ptr interface{}) interface{} {
+func (leaf *{{.Name}}) unsafeDecayArray(ptr any) any {
 	rv := reflect.ValueOf(ptr).Elem()
 	sz := rv.Type().Size() / {{.GoLenType}}
 	sli := unsafe.Slice((*{{.Type}})(unsafe.Pointer(rv.UnsafeAddr())), sz)
 	return &sli
 }
 
-func (leaf *{{.Name}}) setAddress(ptr interface{}) error {
+func (leaf *{{.Name}}) setAddress(ptr any) error {
 	if ptr == nil {
 		return leaf.setAddress(newValue(leaf))
 	}

--- a/groot/groot.go
+++ b/groot/groot.go
@@ -96,8 +96,8 @@ type ObjArray interface {
 // Array describes ROOT abstract array type.
 type Array interface {
 	Len() int // number of array elements
-	Get(i int) interface{}
-	Set(i int, v interface{})
+	Get(i int) any
+	Set(i int, v any)
 }
 
 // ObjString is a ROOT string that implements ROOT TObject.

--- a/groot/internal/genroot/genrfunc.go
+++ b/groot/internal/genroot/genrfunc.go
@@ -163,13 +163,13 @@ func genRFuncName(sig *types.Signature) string {
 	}
 
 	params := sig.Params()
-	for i := 0; i < params.Len(); i++ {
+	for i := range params.Len() {
 		o.WriteString(code(params.At(i).Type()))
 	}
 	res := sig.Results()
 	if res.Len() > 0 {
 		o.WriteString("To")
-		for i := 0; i < res.Len(); i++ {
+		for i := range res.Len() {
 			o.WriteString(code(res.At(i).Type()))
 		}
 	}
@@ -417,7 +417,7 @@ func (f *{{.Type}}) RVars() []string { return nil }
 {{end}}
 
 // Bind implements rfunc.Formula
-func (f *{{.Type}}) Bind(args []interface{}) error {
+func (f *{{.Type}}) Bind(args []any) error {
 	if got, want := len(args), {{.NumIn}}; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -440,7 +440,7 @@ func (f *{{.Type}}) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *{{.Type}}) Func() interface{} {
+func (f *{{.Type}}) Func() any {
 	return func() {{.Return}} {
 		return f.fct(
 {{- range $i, $typ := .In}}
@@ -476,26 +476,26 @@ const rfuncTestTmpl = `func Test{{.Type}}(t *testing.T) {
 	}
 
 {{if gt .NumIn 0}}
-	ptrs := make([]interface{}, {{.NumIn}})
+	ptrs := make([]any, {{.NumIn}})
 {{- range $i, $typ := .In}}
 	ptrs[{{$i}}] = new({{$typ}})
 {{- end}}
 {{else}}
-	var ptrs []interface{}
+	var ptrs []any
 {{- end}}
 
 {{if gt .NumIn 0}}
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs)-1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -503,7 +503,7 @@ const rfuncTestTmpl = `func Test{{.Type}}(t *testing.T) {
 	}
 {{- else}}
 	{
-		bad := make([]interface{}, 1)
+		bad := make([]any, 1)
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")

--- a/groot/internal/httpio/reader.go
+++ b/groot/internal/httpio/reader.go
@@ -74,7 +74,7 @@ func Open(uri string, opts ...Option) (r *Reader, err error) {
 
 	r.req.Header.Set("Range", "")
 	r.pool = sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			return r.req.Clone(r.ctx)
 		},
 	}

--- a/groot/internal/rcompress/rcompress.go
+++ b/groot/internal/rcompress/rcompress.go
@@ -168,10 +168,7 @@ func Compress(dst, src []byte, compr int32) ([]byte, error) {
 	}
 
 	for beg = 0; beg < len(src); beg += blksz {
-		end = beg + blksz
-		if end > len(src) {
-			end = len(src)
-		}
+		end = min(beg+blksz, len(src))
 		// FIXME(sbinet): split out into compressBlock{Zlib,LZ4,...}
 		n, err := compressBlock(alg, lvl, dst[cur:], src[beg:end])
 		switch err {

--- a/groot/internal/rtests/rtests.go
+++ b/groot/internal/rtests/rtests.go
@@ -39,7 +39,7 @@ var (
 // executes it via ROOT C++.
 // RunCxxROOT returns the combined stdout/stderr output and an error, if any.
 // If 'fct' ends with a '+', RunCxxROOT will run the macro through ACliC.
-func RunCxxROOT(fct string, code []byte, args ...interface{}) ([]byte, error) {
+func RunCxxROOT(fct string, code []byte, args ...any) ([]byte, error) {
 	aclic := ""
 	if strings.HasSuffix(fct, "+") {
 		aclic = "+"

--- a/groot/rarrow/rarrow.go
+++ b/groot/rarrow/rarrow.go
@@ -285,7 +285,7 @@ func appendData(bldr array.Builder, v rtree.ReadVar, dt arrow.DataType) {
 		v := reflect.ValueOf(v.Value).Elem()
 		sub.Reserve(v.Len())
 		bldr.Append(true)
-		for i := 0; i < v.Len(); i++ {
+		for i := range v.Len() {
 			appendValue(sub, v.Index(i).Interface())
 		}
 
@@ -294,14 +294,14 @@ func appendData(bldr array.Builder, v rtree.ReadVar, dt arrow.DataType) {
 		v := reflect.ValueOf(v.Value).Elem()
 		sub.Reserve(v.Len())
 		bldr.Append(true)
-		for i := 0; i < v.Len(); i++ {
+		for i := range v.Len() {
 			appendValue(sub, v.Index(i).Interface())
 		}
 
 	case *array.StructBuilder:
 		bldr.Append(true)
 		v := reflect.ValueOf(v.Value).Elem()
-		for i := 0; i < bldr.NumField(); i++ {
+		for i := range bldr.NumField() {
 			f := bldr.FieldBuilder(i)
 			appendValue(f, v.Field(i).Interface())
 		}
@@ -311,7 +311,7 @@ func appendData(bldr array.Builder, v rtree.ReadVar, dt arrow.DataType) {
 	}
 }
 
-func appendValue(bldr array.Builder, v interface{}) {
+func appendValue(bldr array.Builder, v any) {
 	switch b := bldr.(type) {
 	case *array.BooleanBuilder:
 		b.Append(v.(bool))
@@ -352,7 +352,7 @@ func appendValue(bldr array.Builder, v interface{}) {
 		b.Append(true)
 		sub := b.ValueBuilder()
 		v := reflect.ValueOf(v)
-		for i := 0; i < v.Len(); i++ {
+		for i := range v.Len() {
 			appendValue(sub, v.Index(i).Interface())
 		}
 
@@ -360,14 +360,14 @@ func appendValue(bldr array.Builder, v interface{}) {
 		b.Append(true)
 		sub := b.ValueBuilder()
 		v := reflect.ValueOf(v)
-		for i := 0; i < v.Len(); i++ {
+		for i := range v.Len() {
 			appendValue(sub, v.Index(i).Interface())
 		}
 
 	case *array.StructBuilder:
 		b.Append(true)
 		v := reflect.ValueOf(v)
-		for i := 0; i < b.NumField(); i++ {
+		for i := range b.NumField() {
 			f := b.FieldBuilder(i)
 			appendValue(f, v.Field(i).Interface())
 		}

--- a/groot/rarrow/tree_writer.go
+++ b/groot/rarrow/tree_writer.go
@@ -64,7 +64,7 @@ func (fw *flatTreeWriter) Write(rec array.Record) error {
 		}
 	}
 
-	for irow := 0; irow < nrows; irow++ {
+	for irow := range nrows {
 		for icol, col := range rec.Columns() {
 			wvar := &fw.ctx.wvars[icol]
 			err := fw.ctx.readFrom(wvar, irow, col)
@@ -271,7 +271,7 @@ func (ctx *contextWriter) readFrom(wvar *rtree.WriteVar, irow int, arr array.Int
 		ptr := &rtree.WriteVar{
 			Name: "_rarrow_elem_" + wvar.Name,
 		}
-		for i := 0; i < rv.Len(); i++ {
+		for i := range rv.Len() {
 			ptr.Value = rv.Index(i).Addr().Interface()
 			err := ctx.readFrom(ptr, i, ra)
 			if err != nil {
@@ -310,7 +310,7 @@ func (ctx *contextWriter) readFrom(wvar *rtree.WriteVar, irow int, arr array.Int
 		ptr := &rtree.WriteVar{
 			Name: "_rarrow_elem_" + wvar.Name,
 		}
-		for i := 0; i < sli.Len(); i++ {
+		for i := range sli.Len() {
 			ptr.Value = rv.Index(i).Addr().Interface()
 			err := ctx.readFrom(ptr, i, sli)
 			if err != nil {

--- a/groot/rbase/rw_test.go
+++ b/groot/rbase/rw_test.go
@@ -176,7 +176,7 @@ func TestWriteWBuffer(t *testing.T) {
 	}
 }
 
-func testWriteWBuffer(t *testing.T, name, file string, want interface{}) {
+func testWriteWBuffer(t *testing.T, name, file string, want any) {
 	rdata, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatal(err)
@@ -244,7 +244,7 @@ func TestReadRBuffer(t *testing.T) {
 	}
 }
 
-func testReadRBuffer(t *testing.T, name, file string, want interface{}) {
+func testReadRBuffer(t *testing.T, name, file string, want any) {
 	data, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatal(err)

--- a/groot/rbytes/rbuffer.go
+++ b/groot/rbytes/rbuffer.go
@@ -60,13 +60,13 @@ type RBuffer struct {
 	r      rbuff
 	err    error
 	offset uint32
-	refs   map[int64]interface{}
+	refs   map[int64]any
 	sictx  StreamerInfoContext
 }
 
-func NewRBuffer(data []byte, refs map[int64]interface{}, offset uint32, ctx StreamerInfoContext) *RBuffer {
+func NewRBuffer(data []byte, refs map[int64]any, offset uint32, ctx StreamerInfoContext) *RBuffer {
 	if refs == nil {
-		refs = make(map[int64]interface{})
+		refs = make(map[int64]any)
 	}
 
 	return &RBuffer{
@@ -77,7 +77,7 @@ func NewRBuffer(data []byte, refs map[int64]interface{}, offset uint32, ctx Stre
 	}
 }
 
-func (r *RBuffer) Reset(data []byte, refs map[int64]interface{}, offset uint32, ctx StreamerInfoContext) *RBuffer {
+func (r *RBuffer) Reset(data []byte, refs map[int64]any, offset uint32, ctx StreamerInfoContext) *RBuffer {
 	if r == nil {
 		return NewRBuffer(data, refs, offset, ctx)
 	}
@@ -266,7 +266,7 @@ func (r *RBuffer) ReadCString(n int) string {
 	}
 
 	buf := make([]byte, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		r.read(buf[i : i+1])
 		if buf[i] == 0 {
 			buf = buf[:i]
@@ -705,7 +705,7 @@ func (r *RBuffer) ReadObjectAny() (obj root.Object) {
 	}
 }
 
-func (r *RBuffer) RStream(si StreamerInfo, ptr interface{}) error {
+func (r *RBuffer) RStream(si StreamerInfo, ptr any) error {
 	const kind = ObjectWise
 	dec, err := si.NewDecoder(kind, r)
 	if err != nil {

--- a/groot/rbytes/rbytes.go
+++ b/groot/rbytes/rbytes.go
@@ -87,12 +87,12 @@ type StreamerElement interface {
 
 // Decoder is the interface that wraps the basic DecodeROOT method.
 type Decoder interface {
-	DecodeROOT(ptr interface{}) error
+	DecodeROOT(ptr any) error
 }
 
 // Encoder is the interface that wraps the basic EncodeROOT method.
 type Encoder interface {
-	EncodeROOT(ptr interface{}) error
+	EncodeROOT(ptr any) error
 }
 
 // StreamerInfoContext defines the protocol to retrieve a ROOT StreamerInfo
@@ -138,7 +138,7 @@ type Streamer interface {
 
 // Binder wraps the Bind method.
 type Binder interface {
-	Bind(ptr interface{}) error
+	Bind(ptr any) error
 }
 
 // Counter wraps the Count method.

--- a/groot/rbytes/wbuffer.go
+++ b/groot/rbytes/wbuffer.go
@@ -64,13 +64,13 @@ type WBuffer struct {
 	w      wbuff
 	err    error
 	offset uint32
-	refs   map[interface{}]int64
+	refs   map[any]int64
 	sictx  StreamerInfoContext
 }
 
-func NewWBuffer(data []byte, refs map[interface{}]int64, offset uint32, ctx StreamerInfoContext) *WBuffer {
+func NewWBuffer(data []byte, refs map[any]int64, offset uint32, ctx StreamerInfoContext) *WBuffer {
 	if refs == nil {
-		refs = make(map[interface{}]int64)
+		refs = make(map[any]int64)
 	}
 
 	return &WBuffer{

--- a/groot/rbytes/wbuffer_test.go
+++ b/groot/rbytes/wbuffer_test.go
@@ -110,296 +110,296 @@ func TestWBufferEmpty(t *testing.T) {
 func TestWBuffer_Write(t *testing.T) {
 	for _, tc := range []struct {
 		name string
-		want interface{}
-		wfct func(*WBuffer, interface{})
-		rfct func(*RBuffer) interface{}
-		cmp  func(a, b interface{}) bool
+		want any
+		wfct func(*WBuffer, any)
+		rfct func(*RBuffer) any
+		cmp  func(a, b any) bool
 	}{
 		{
 			name: "bool-true",
 			want: true,
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteBool(v.(bool))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadBool()
 			},
 		},
 		{
 			name: "bool-false",
 			want: false,
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteBool(v.(bool))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadBool()
 			},
 		},
 		{
 			name: "int8",
 			want: int8(42),
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteI8(v.(int8))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadI8()
 			},
 		},
 		{
 			name: "int16",
 			want: int16(42),
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteI16(v.(int16))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadI16()
 			},
 		},
 		{
 			name: "int32",
 			want: int32(42),
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteI32(v.(int32))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadI32()
 			},
 		},
 		{
 			name: "int64",
 			want: int64(42),
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteI64(v.(int64))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadI64()
 			},
 		},
 		{
 			name: "uint8",
 			want: uint8(42),
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteU8(v.(uint8))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadU8()
 			},
 		},
 		{
 			name: "uint16",
 			want: uint16(42),
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteU16(v.(uint16))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadU16()
 			},
 		},
 		{
 			name: "uint32",
 			want: uint32(42),
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteU32(v.(uint32))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadU32()
 			},
 		},
 		{
 			name: "uint64",
 			want: uint64(42),
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteU64(v.(uint64))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadU64()
 			},
 		},
 		{
 			name: "float32",
 			want: float32(42),
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteF32(v.(float32))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadF32()
 			},
 		},
 		{
 			name: "float32-nan",
 			want: float32(math.NaN()),
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteF32(v.(float32))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadF32()
 			},
-			cmp: func(a, b interface{}) bool {
+			cmp: func(a, b any) bool {
 				return math.IsNaN(float64(a.(float32))) && math.IsNaN(float64(b.(float32)))
 			},
 		},
 		{
 			name: "float32-inf",
 			want: float32(math.Inf(-1)),
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteF32(v.(float32))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadF32()
 			},
-			cmp: func(a, b interface{}) bool {
+			cmp: func(a, b any) bool {
 				return math.IsInf(float64(a.(float32)), -1) && math.IsInf(float64(b.(float32)), -1)
 			},
 		},
 		{
 			name: "float32+inf",
 			want: float32(math.Inf(+1)),
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteF32(v.(float32))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadF32()
 			},
-			cmp: func(a, b interface{}) bool {
+			cmp: func(a, b any) bool {
 				return math.IsInf(float64(a.(float32)), +1) && math.IsInf(float64(b.(float32)), +1)
 			},
 		},
 		{
 			name: "float64",
 			want: float64(42),
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteF64(v.(float64))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadF64()
 			},
 		},
 		{
 			name: "float64-nan",
 			want: math.NaN(),
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteF64(v.(float64))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadF64()
 			},
-			cmp: func(a, b interface{}) bool {
+			cmp: func(a, b any) bool {
 				return math.IsNaN(a.(float64)) && math.IsNaN(b.(float64))
 			},
 		},
 		{
 			name: "float64-inf",
 			want: math.Inf(-1),
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteF64(v.(float64))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadF64()
 			},
-			cmp: func(a, b interface{}) bool {
+			cmp: func(a, b any) bool {
 				return math.IsInf(a.(float64), -1) && math.IsInf(b.(float64), -1)
 			},
 		},
 		{
 			name: "float64+inf",
 			want: math.Inf(+1),
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteF64(v.(float64))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadF64()
 			},
-			cmp: func(a, b interface{}) bool {
+			cmp: func(a, b any) bool {
 				return math.IsInf(a.(float64), +1) && math.IsInf(b.(float64), +1)
 			},
 		},
 		{
 			name: "cstring-1",
 			want: "hello world",
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteCString(v.(string))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadCString(len("hello world"))
 			},
 		},
 		{
 			name: "cstring-2",
 			want: "hello world",
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteCString(v.(string))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadCString(len("hello world") + 1)
 			},
 		},
 		{
 			name: "cstring-3",
 			want: "hello world",
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteCString(v.(string))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadCString(len("hello world") + 10)
 			},
 		},
 		{
 			name: "cstring-4",
 			want: "hello",
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteCString(v.(string))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadCString(len("hello"))
 			},
 		},
 		{
 			name: "cstring-5",
 			want: string([]byte{1, 2, 3, 4}),
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteCString(v.(string))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadCString(len([]byte{1, 2, 3, 4, 0, 1}))
 			},
 		},
 		{
 			name: "std::string-1",
 			want: "hello",
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteStdString(v.(string))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadStdString()
 			},
 		},
 		{
 			name: "std::string-2",
 			want: strings.Repeat("hello", 256),
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteStdString(v.(string))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadStdString()
 			},
 		},
 		{
 			name: "static-arr-i32",
 			want: []int32{1, 2, 0, 2, 1},
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteStaticArrayI32(v.([]int32))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				return r.ReadStaticArrayI32()
 			},
 		},
 		{
 			name: "fast-arr-bool",
 			want: []bool{true, false, false, true, false},
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteArrayBool(v.([]bool))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				sli := make([]bool, 5)
 				r.ReadArrayBool(sli)
 				return sli
@@ -408,10 +408,10 @@ func TestWBuffer_Write(t *testing.T) {
 		{
 			name: "fast-arr-i8",
 			want: []int8{1, 2, 0, 2, 1},
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteArrayI8(v.([]int8))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				sli := make([]int8, 5)
 				r.ReadArrayI8(sli)
 				return sli
@@ -420,10 +420,10 @@ func TestWBuffer_Write(t *testing.T) {
 		{
 			name: "fast-arr-i16",
 			want: []int16{1, 2, 0, 2, 1},
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteArrayI16(v.([]int16))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				sli := make([]int16, 5)
 				r.ReadArrayI16(sli)
 				return sli
@@ -432,10 +432,10 @@ func TestWBuffer_Write(t *testing.T) {
 		{
 			name: "fast-arr-i32",
 			want: []int32{1, 2, 0, 2, 1},
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteArrayI32(v.([]int32))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				sli := make([]int32, 5)
 				r.ReadArrayI32(sli)
 				return sli
@@ -444,10 +444,10 @@ func TestWBuffer_Write(t *testing.T) {
 		{
 			name: "fast-arr-i64",
 			want: []int64{1, 2, 0, 2, 1},
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteArrayI64(v.([]int64))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				sli := make([]int64, 5)
 				r.ReadArrayI64(sli)
 				return sli
@@ -456,10 +456,10 @@ func TestWBuffer_Write(t *testing.T) {
 		{
 			name: "fast-arr-u8",
 			want: []uint8{1, 2, 0, 2, 1},
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteArrayU8(v.([]uint8))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				sli := make([]uint8, 5)
 				r.ReadArrayU8(sli)
 				return sli
@@ -468,10 +468,10 @@ func TestWBuffer_Write(t *testing.T) {
 		{
 			name: "fast-arr-u16",
 			want: []uint16{1, 2, 0, 2, 1},
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteArrayU16(v.([]uint16))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				sli := make([]uint16, 5)
 				r.ReadArrayU16(sli)
 				return sli
@@ -480,10 +480,10 @@ func TestWBuffer_Write(t *testing.T) {
 		{
 			name: "fast-arr-u32",
 			want: []uint32{1, 2, 0, 2, 1},
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteArrayU32(v.([]uint32))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				sli := make([]uint32, 5)
 				r.ReadArrayU32(sli)
 				return sli
@@ -492,10 +492,10 @@ func TestWBuffer_Write(t *testing.T) {
 		{
 			name: "fast-arr-u64",
 			want: []uint64{1, 2, 0, 2, 1},
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteArrayU64(v.([]uint64))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				sli := make([]uint64, 5)
 				r.ReadArrayU64(sli)
 				return sli
@@ -504,10 +504,10 @@ func TestWBuffer_Write(t *testing.T) {
 		{
 			name: "fast-arr-f32",
 			want: []float32{1, 2, 0, 2, 1},
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteArrayF32(v.([]float32))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				sli := make([]float32, 5)
 				r.ReadArrayF32(sli)
 				return sli
@@ -516,15 +516,15 @@ func TestWBuffer_Write(t *testing.T) {
 		{
 			name: "fast-arr-f32-nan+inf-inf",
 			want: []float32{1, float32(math.Inf(+1)), 0, float32(math.NaN()), float32(math.Inf(-1))},
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteArrayF32(v.([]float32))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				sli := make([]float32, 5)
 				r.ReadArrayF32(sli)
 				return sli
 			},
-			cmp: func(a, b interface{}) bool {
+			cmp: func(a, b any) bool {
 				aa := a.([]float32)
 				bb := b.([]float32)
 				if len(aa) != len(bb) {
@@ -568,10 +568,10 @@ func TestWBuffer_Write(t *testing.T) {
 		{
 			name: "fast-arr-f64",
 			want: []float64{1, 2, 0, 2, 1},
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteArrayF64(v.([]float64))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				sli := make([]float64, 5)
 				r.ReadArrayF64(sli)
 				return sli
@@ -580,15 +580,15 @@ func TestWBuffer_Write(t *testing.T) {
 		{
 			name: "fast-arr-f64-nan+inf-inf",
 			want: []float64{1, math.Inf(+1), 0, math.NaN(), math.Inf(-1)},
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteArrayF64(v.([]float64))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				sli := make([]float64, 5)
 				r.ReadArrayF64(sli)
 				return sli
 			},
-			cmp: func(a, b interface{}) bool {
+			cmp: func(a, b any) bool {
 				aa := a.([]float64)
 				bb := b.([]float64)
 				if len(aa) != len(bb) {
@@ -632,10 +632,10 @@ func TestWBuffer_Write(t *testing.T) {
 		{
 			name: "fast-arr-str",
 			want: []string{"hello", "world"},
-			wfct: func(w *WBuffer, v interface{}) {
+			wfct: func(w *WBuffer, v any) {
 				w.WriteArrayString(v.([]string))
 			},
-			rfct: func(r *RBuffer) interface{} {
+			rfct: func(r *RBuffer) any {
 				sli := make([]string, 2)
 				r.ReadArrayString(sli)
 				return sli

--- a/groot/rcmd/copy_test.go
+++ b/groot/rcmd/copy_test.go
@@ -255,7 +255,7 @@ func TestROOTCpTree(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		rdata.N = int32(i)
 		rdata.I32s = make([]int32, i)
 		for j := range rdata.I32s {

--- a/groot/rcmd/diff_test.go
+++ b/groot/rcmd/diff_test.go
@@ -463,7 +463,7 @@ func TestDiff(t *testing.T) {
 					t.Fatalf("%+v", err)
 				}
 
-				for i := 0; i < 5; i++ {
+				for i := range 5 {
 					data.I32 = int32(i)
 					data.F64 = float64(i)
 					data.Arr = [2]float64{float64(i + 1), float64(i + 2)}
@@ -510,7 +510,7 @@ func TestDiff(t *testing.T) {
 					t.Fatalf("%+v", err)
 				}
 
-				for i := 0; i < 6; i++ {
+				for i := range 6 {
 					data.I32 = int32(i)
 					data.F64 = float64(i)
 					data.Arr = [2]float64{float64(i + 1), float64(i + 2)}
@@ -561,7 +561,7 @@ func TestDiff(t *testing.T) {
 					t.Fatalf("%+v", err)
 				}
 
-				for i := 0; i < 5; i++ {
+				for i := range 5 {
 					data.I32 = int32(i)
 					data.F64 = float64(i + 1)
 					data.Arr = [2]float64{float64(i + 1), float64(i + 2)}
@@ -608,7 +608,7 @@ func TestDiff(t *testing.T) {
 					t.Fatalf("%+v", err)
 				}
 
-				for i := 0; i < 5; i++ {
+				for i := range 5 {
 					data.I32 = int32(i)
 					data.F64 = float64(i)
 					data.Arr = [2]float64{float64(i), float64(i + 2)}
@@ -715,7 +715,7 @@ key[dir-1/dir-11/tree][0004].Arr -- (-ref +chk)
 					t.Fatalf("%+v", err)
 				}
 
-				for i := 0; i < 5; i++ {
+				for i := range 5 {
 					data.I32 = int64(i)
 					data.F64 = float64(i + 1)
 					data.Arr = [2]float64{float64(i + 1), float64(i + 2)}
@@ -762,7 +762,7 @@ key[dir-1/dir-11/tree][0004].Arr -- (-ref +chk)
 					t.Fatalf("%+v", err)
 				}
 
-				for i := 0; i < 5; i++ {
+				for i := range 5 {
 					data.I32 = int32(i)
 					data.F64 = float64(i + 1)
 					data.Arr = [2]float64{float64(i + 1), float64(i + 2)}

--- a/groot/rcmd/dump.go
+++ b/groot/rcmd/dump.go
@@ -132,7 +132,7 @@ func (cmd *dumpCmd) dumpObj(obj root.Object) error {
 }
 
 func (cmd *dumpCmd) dumpList(lst root.List) error {
-	for i := 0; i < lst.Len(); i++ {
+	for i := range lst.Len() {
 		fmt.Fprintf(cmd.w, "lst[%s][%d]: ", lst.Name(), i)
 		err := cmd.dumpObj(lst.At(i))
 		if err != nil && !errors.Is(err, errIgnoreKey) {

--- a/groot/rcmd/merge_test.go
+++ b/groot/rcmd/merge_test.go
@@ -204,8 +204,8 @@ func makeFlatTree(n int) func(t *testing.T, fname string) error {
 			t.Fatalf("could not create tree writer: %+v", err)
 		}
 
-		for j := 0; j < n; j++ {
-			for i := 0; i < nevts; i++ {
+		for range n {
+			for i := range nevts {
 				evt.I32 = int32(i)
 				evt.F64 = float64(i)
 				evt.Str = fmt.Sprintf("evt-%0d", i)
@@ -253,7 +253,7 @@ func makeH1F(n int) func(t *testing.T, fname string) error {
 
 		h := hbook.NewH1D(10, 0, 10)
 		h.Annotation()["title"] = "h1f"
-		for i := 0; i < n; i++ {
+		for range n {
 			h.Fill(5, 1)
 			h.Fill(6, 2)
 		}
@@ -292,7 +292,7 @@ func makeH1D(n int) func(t *testing.T, fname string) error {
 
 		h := hbook.NewH1D(10, 0, 10)
 		h.Annotation()["title"] = "h1d"
-		for i := 0; i < n; i++ {
+		for range n {
 			h.Fill(5, 1)
 			h.Fill(6, 2)
 		}
@@ -331,7 +331,7 @@ func makeH1I(n int) func(t *testing.T, fname string) error {
 
 		h := hbook.NewH1D(10, 0, 10)
 		h.Annotation()["title"] = "h1i"
-		for i := 0; i < n; i++ {
+		for range n {
 			h.Fill(5, 1)
 			h.Fill(6, 2)
 		}
@@ -370,7 +370,7 @@ func makeH2D(n int) func(t *testing.T, fname string) error {
 
 		h := hbook.NewH2D(10, 0, 10, 10, 0, 10)
 		h.Annotation()["title"] = "h2d"
-		for i := 0; i < n; i++ {
+		for range n {
 			h.Fill(5, 5, 1)
 			h.Fill(6, 6, 2)
 		}
@@ -412,7 +412,7 @@ func makeGraph(beg, end int) func(t *testing.T, fname string) error {
 			ys []float64
 		)
 		for i := beg; i < end; i++ {
-			for j := 0; j < 10; j++ {
+			for j := range 10 {
 				xs = append(xs, float64(10*(1+i)+j))
 				ys = append(ys, float64(10*(1+i)+j))
 			}
@@ -456,7 +456,7 @@ func makeGraphErr(beg, end int) func(t *testing.T, fname string) error {
 			pts []hbook.Point2D
 		)
 		for i := beg; i < end; i++ {
-			for j := 0; j < 10; j++ {
+			for j := range 10 {
 				var (
 					x    = float64(10*(1+i) + j)
 					y    = float64(10*(1+i) + j)
@@ -510,7 +510,7 @@ func makeGraphAsymmErr(beg, end int) func(t *testing.T, fname string) error {
 			pts []hbook.Point2D
 		)
 		for i := beg; i < end; i++ {
-			for j := 0; j < 10; j++ {
+			for j := range 10 {
 				var (
 					x = float64(10*(1+i) + j)
 					y = float64(10*(1+i) + j)

--- a/groot/rcont/array_gen.go
+++ b/groot/rcont/array_gen.go
@@ -37,11 +37,11 @@ func (arr *ArrayC) At(i int) int8 {
 	return arr.Data[i]
 }
 
-func (arr *ArrayC) Get(i int) interface{} {
+func (arr *ArrayC) Get(i int) any {
 	return arr.Data[i]
 }
 
-func (arr *ArrayC) Set(i int, v interface{}) {
+func (arr *ArrayC) Set(i int, v any) {
 	arr.Data[i] = v.(int8)
 }
 
@@ -105,11 +105,11 @@ func (arr *ArrayS) At(i int) int16 {
 	return arr.Data[i]
 }
 
-func (arr *ArrayS) Get(i int) interface{} {
+func (arr *ArrayS) Get(i int) any {
 	return arr.Data[i]
 }
 
-func (arr *ArrayS) Set(i int, v interface{}) {
+func (arr *ArrayS) Set(i int, v any) {
 	arr.Data[i] = v.(int16)
 }
 
@@ -173,11 +173,11 @@ func (arr *ArrayI) At(i int) int32 {
 	return arr.Data[i]
 }
 
-func (arr *ArrayI) Get(i int) interface{} {
+func (arr *ArrayI) Get(i int) any {
 	return arr.Data[i]
 }
 
-func (arr *ArrayI) Set(i int, v interface{}) {
+func (arr *ArrayI) Set(i int, v any) {
 	arr.Data[i] = v.(int32)
 }
 
@@ -241,11 +241,11 @@ func (arr *ArrayL) At(i int) int64 {
 	return arr.Data[i]
 }
 
-func (arr *ArrayL) Get(i int) interface{} {
+func (arr *ArrayL) Get(i int) any {
 	return arr.Data[i]
 }
 
-func (arr *ArrayL) Set(i int, v interface{}) {
+func (arr *ArrayL) Set(i int, v any) {
 	arr.Data[i] = v.(int64)
 }
 
@@ -309,11 +309,11 @@ func (arr *ArrayL64) At(i int) int64 {
 	return arr.Data[i]
 }
 
-func (arr *ArrayL64) Get(i int) interface{} {
+func (arr *ArrayL64) Get(i int) any {
 	return arr.Data[i]
 }
 
-func (arr *ArrayL64) Set(i int, v interface{}) {
+func (arr *ArrayL64) Set(i int, v any) {
 	arr.Data[i] = v.(int64)
 }
 
@@ -377,11 +377,11 @@ func (arr *ArrayF) At(i int) float32 {
 	return arr.Data[i]
 }
 
-func (arr *ArrayF) Get(i int) interface{} {
+func (arr *ArrayF) Get(i int) any {
 	return arr.Data[i]
 }
 
-func (arr *ArrayF) Set(i int, v interface{}) {
+func (arr *ArrayF) Set(i int, v any) {
 	arr.Data[i] = v.(float32)
 }
 
@@ -445,11 +445,11 @@ func (arr *ArrayD) At(i int) float64 {
 	return arr.Data[i]
 }
 
-func (arr *ArrayD) Get(i int) interface{} {
+func (arr *ArrayD) Get(i int) any {
 	return arr.Data[i]
 }
 
-func (arr *ArrayD) Set(i int, v interface{}) {
+func (arr *ArrayD) Set(i int, v any) {
 	arr.Data[i] = v.(float64)
 }
 

--- a/groot/rcont/clonesarray_test.go
+++ b/groot/rcont/clonesarray_test.go
@@ -90,7 +90,7 @@ func TestTClonesArrayRW(t *testing.T) {
 				if g, w := got.Last(), want.Last(); g != w {
 					return false
 				}
-				for i := 0; i < got.Len(); i++ {
+				for i := range got.Len() {
 					if g, w := got.At(i), want.At(i); !reflect.DeepEqual(g, w) {
 						return false
 					}

--- a/groot/rcont/map.go
+++ b/groot/rcont/map.go
@@ -79,7 +79,7 @@ func (m *Map) UnmarshalROOT(r *rbytes.RBuffer) error {
 
 	nobjs := int(r.ReadI32())
 	m.tbl = make(map[root.Object]root.Object, nobjs)
-	for i := 0; i < nobjs; i++ {
+	for range nobjs {
 		k := r.ReadObjectAny()
 		if r.Err() != nil {
 			return r.Err()

--- a/groot/rcont/rw_test.go
+++ b/groot/rcont/rw_test.go
@@ -239,7 +239,7 @@ func TestWriteWBuffer(t *testing.T) {
 	}
 }
 
-func testWriteWBuffer(t *testing.T, name, file string, want interface{}) {
+func testWriteWBuffer(t *testing.T, name, file string, want any) {
 	rdata, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatal(err)
@@ -306,7 +306,7 @@ func TestReadRBuffer(t *testing.T) {
 	}
 }
 
-func testReadRBuffer(t *testing.T, name, file string, want interface{}) {
+func testReadRBuffer(t *testing.T, name, file string, want any) {
 	data, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatal(err)

--- a/groot/rdict/decoder.go
+++ b/groot/rdict/decoder.go
@@ -23,7 +23,7 @@ func newDecoder(r *rbytes.RBuffer, si *StreamerInfo, kind rbytes.StreamKind, ops
 	return &decoder{r, si, kind, ops}, nil
 }
 
-func (dec *decoder) DecodeROOT(ptr interface{}) error {
+func (dec *decoder) DecodeROOT(ptr any) error {
 	rv := reflect.ValueOf(ptr)
 	if rv.Kind() != reflect.Ptr {
 		return fmt.Errorf("rdict: invalid kind (got=%T, want=pointer)", ptr)
@@ -62,7 +62,7 @@ var (
 )
 
 type rstreamerInfo struct {
-	recv interface{}
+	recv any
 	rops []rstreamer
 	kind rbytes.StreamKind
 	si   *StreamerInfo
@@ -77,7 +77,7 @@ func newRStreamerInfo(si *StreamerInfo, kind rbytes.StreamKind, rops []rstreamer
 	}, nil
 }
 
-func (rr *rstreamerInfo) Bind(recv interface{}) error {
+func (rr *rstreamerInfo) Bind(recv any) error {
 	rv := reflect.ValueOf(recv)
 	if rv.Kind() != reflect.Ptr {
 		return fmt.Errorf("rdict: invalid kind (got=%T, want=pointer)", recv)
@@ -86,7 +86,7 @@ func (rr *rstreamerInfo) Bind(recv interface{}) error {
 	if recv, ok := recv.(rbytes.Unmarshaler); ok && rr.kind == rbytes.ObjectWise {
 		// FIXME(sbinet): handle mbr-/obj-wise
 		rr.rops = []rstreamer{{
-			op: func(r *rbytes.RBuffer, _ interface{}, _ *streamerConfig) error {
+			op: func(r *rbytes.RBuffer, _ any, _ *streamerConfig) error {
 				return recv.UnmarshalROOT(r)
 			},
 			cfg: nil,

--- a/groot/rdict/descr.go
+++ b/groot/rdict/descr.go
@@ -22,7 +22,7 @@ type elemDescr struct {
 	method []int
 	oclass string
 	nclass string
-	mbr    interface{} // member streamer
+	mbr    any // member streamer
 }
 
 type streamerConfig struct {
@@ -35,14 +35,14 @@ type streamerConfig struct {
 	count func() int // optional func to give the length of ROOT's C var-len arrays.
 }
 
-func (cfg *streamerConfig) counter(recv interface{}) int {
+func (cfg *streamerConfig) counter(recv any) int {
 	if cfg.count != nil {
 		return cfg.count()
 	}
 	return int(reflect.ValueOf(recv).Elem().FieldByIndex(cfg.descr.method).Int())
 }
 
-func (cfg *streamerConfig) adjust(recv interface{}) interface{} {
+func (cfg *streamerConfig) adjust(recv any) any {
 	if cfg == nil || cfg.offset < 0 {
 		return recv
 	}

--- a/groot/rdict/encoder.go
+++ b/groot/rdict/encoder.go
@@ -22,7 +22,7 @@ func newEncoder(w *rbytes.WBuffer, si *StreamerInfo, kind rbytes.StreamKind, ops
 	return &encoder{w, si, kind, ops}, nil
 }
 
-func (enc *encoder) EncodeROOT(ptr interface{}) error {
+func (enc *encoder) EncodeROOT(ptr any) error {
 	rv := reflect.ValueOf(ptr)
 	if rv.Kind() != reflect.Ptr {
 		return fmt.Errorf("rdict: invalid kind (got=%T, want=pointer)", ptr)
@@ -54,7 +54,7 @@ var (
 )
 
 type wstreamerInfo struct {
-	recv interface{}
+	recv any
 	wops []wstreamer
 	kind rbytes.StreamKind
 	si   *StreamerInfo
@@ -69,7 +69,7 @@ func newWStreamerInfo(si *StreamerInfo, kind rbytes.StreamKind, wops []wstreamer
 	}, nil
 }
 
-func (ww *wstreamerInfo) Bind(recv interface{}) error {
+func (ww *wstreamerInfo) Bind(recv any) error {
 	rv := reflect.ValueOf(recv)
 	if rv.Kind() != reflect.Ptr {
 		return fmt.Errorf("rdict: invalid kind (got=%T, want=pointer)", recv)
@@ -78,7 +78,7 @@ func (ww *wstreamerInfo) Bind(recv interface{}) error {
 	if recv, ok := recv.(rbytes.Marshaler); ok && ww.kind == rbytes.ObjectWise {
 		// FIXME(sbinet): handle mbr-/obj-wise
 		ww.wops = []wstreamer{{
-			op: func(w *rbytes.WBuffer, _ interface{}, _ *streamerConfig) (int, error) {
+			op: func(w *rbytes.WBuffer, _ any, _ *streamerConfig) (int, error) {
 				return recv.MarshalROOT(w)
 			},
 			cfg: nil,

--- a/groot/rdict/gen_streamer.go
+++ b/groot/rdict/gen_streamer.go
@@ -104,7 +104,7 @@ func (g *genStreamer) init() error {
 	return nil
 }
 
-func (g *genStreamer) printf(format string, args ...interface{}) {
+func (g *genStreamer) printf(format string, args ...any) {
 	fmt.Fprintf(g.buf, format, args...)
 }
 
@@ -154,7 +154,7 @@ func (o *%[1]s) MarshalROOT(w *rbytes.WBuffer) (int, error) {
 	)
 
 	typ := t.Underlying().(*types.Struct)
-	for i := 0; i < typ.NumFields(); i++ {
+	for i := range typ.NumFields() {
 		ft := typ.Field(i)
 		n := ft.Name() // no `groot:"foo"` redirection.
 		g.genMarshalType(ft.Type(), n)
@@ -191,7 +191,7 @@ func (g *genStreamer) genStreamer(t types.Type, typeName string) {
 	)
 
 	typ := t.Underlying().(*types.Struct)
-	for i := 0; i < typ.NumFields(); i++ {
+	for i := range typ.NumFields() {
 		ft := typ.Field(i)
 		n := ft.Name()
 		if tag := typ.Tag(i); tag != "" {

--- a/groot/rdict/gen_type.go
+++ b/groot/rdict/gen_type.go
@@ -1276,7 +1276,7 @@ func (g *genGoType) genStreamerType(si rbytes.StreamerInfo, i int, se rbytes.Str
 	}
 }
 
-func (g *genGoType) printf(format string, args ...interface{}) {
+func (g *genGoType) printf(format string, args ...any) {
 	fmt.Fprintf(g.buf, format, args...)
 }
 

--- a/groot/rdict/object.go
+++ b/groot/rdict/object.go
@@ -35,7 +35,7 @@ func ObjectFrom(si rbytes.StreamerInfo, sictx rbytes.StreamerInfoContext) *Objec
 //   - rbytes.Marshaler
 //   - rbytes.Unmarshaler
 type Object struct {
-	v interface{}
+	v any
 
 	si    *StreamerInfo
 	rvers int16

--- a/groot/rdict/rstreamer.go
+++ b/groot/rdict/rstreamer.go
@@ -45,7 +45,7 @@ func RStreamerOf(sinfo rbytes.StreamerInfo, i int, kind rbytes.StreamKind) (rbyt
 }
 
 type rstreamerElem struct {
-	recv interface{}
+	recv any
 	rop  *rstreamer
 	i    int // streamer-element index (or -1 for the whole StreamerInfo)
 	kind rbytes.StreamKind
@@ -64,7 +64,7 @@ func newRStreamerElem(i int, si *StreamerInfo, kind rbytes.StreamKind, rops []rs
 	}, nil
 }
 
-func (rr *rstreamerElem) Bind(recv interface{}) error {
+func (rr *rstreamerElem) Bind(recv any) error {
 	rv := reflect.ValueOf(recv)
 	if rv.Kind() != reflect.Ptr {
 		return fmt.Errorf("rdict: invalid kind (got=%T, want=pointer)", recv)
@@ -101,21 +101,21 @@ var (
 )
 
 type rstreamOp interface {
-	rstream(r *rbytes.RBuffer, recv interface{}) error
+	rstream(r *rbytes.RBuffer, recv any) error
 }
 
 // type rstreamBufOp interface {
 // 	rstreamBuf(r *rbytes.RBuffer, recv reflect.Value, descr *elemDescr, beg, end int, n int, offset int, arrmode arrayMode) error
 // }
 
-type ropFunc func(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error
+type ropFunc func(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error
 
 type rstreamer struct {
 	op  ropFunc
 	cfg *streamerConfig
 }
 
-func (rr rstreamer) rstream(r *rbytes.RBuffer, recv interface{}) error {
+func (rr rstreamer) rstream(r *rbytes.RBuffer, recv any) error {
 	return rr.op(r, recv, rr.cfg)
 }
 
@@ -587,7 +587,7 @@ func rstreamSI(si *StreamerInfo) ropFunc {
 		obj := rtypes.Factory.Get(typename)().Interface()
 		_, ok := obj.(rbytes.Unmarshaler)
 		if ok {
-			return func(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+			return func(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 				obj := cfg.adjust(recv).(rbytes.Unmarshaler)
 				return obj.UnmarshalROOT(r)
 			}
@@ -597,7 +597,7 @@ func rstreamSI(si *StreamerInfo) ropFunc {
 }
 
 func rstreamObjPtr(rop ropFunc) ropFunc {
-	return func(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+	return func(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 		obj := r.ReadObjectAny()
 		if r.Err() != nil {
 			return r.Err()
@@ -615,7 +615,7 @@ func rstreamObjPtr(rop ropFunc) ropFunc {
 }
 
 func rstreamAnyPtr(rop ropFunc) ropFunc {
-	return func(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+	return func(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 		obj := r.ReadObjectAny()
 		if r.Err() != nil {
 			return r.Err()
@@ -632,62 +632,62 @@ func rstreamAnyPtr(rop ropFunc) ropFunc {
 	}
 }
 
-func rstreamBool(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamBool(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	*(cfg.adjust(recv).(*bool)) = r.ReadBool()
 	return r.Err()
 }
 
-func rstreamI8(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamI8(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	*(cfg.adjust(recv).(*int8)) = r.ReadI8()
 	return r.Err()
 }
 
-func rstreamI16(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamI16(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	*(cfg.adjust(recv).(*int16)) = r.ReadI16()
 	return r.Err()
 }
 
-func rstreamI32(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamI32(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	*(cfg.adjust(recv).(*int32)) = r.ReadI32()
 	return r.Err()
 }
 
-func rstreamI64(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamI64(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	*(cfg.adjust(recv).(*int64)) = r.ReadI64()
 	return r.Err()
 }
 
-func rstreamU8(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamU8(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	*(cfg.adjust(recv).(*uint8)) = r.ReadU8()
 	return r.Err()
 }
 
-func rstreamU16(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamU16(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	*(cfg.adjust(recv).(*uint16)) = r.ReadU16()
 	return r.Err()
 }
 
-func rstreamU32(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamU32(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	*(cfg.adjust(recv).(*uint32)) = r.ReadU32()
 	return r.Err()
 }
 
-func rstreamU64(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamU64(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	*(cfg.adjust(recv).(*uint64)) = r.ReadU64()
 	return r.Err()
 }
 
-func rstreamF32(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamF32(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	*(cfg.adjust(recv).(*float32)) = r.ReadF32()
 	return r.Err()
 }
 
-func rstreamF64(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamF64(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	*(cfg.adjust(recv).(*float64)) = r.ReadF64()
 	return r.Err()
 }
 
-func rstreamBits(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamBits(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	*(cfg.adjust(recv).(*uint32)) = r.ReadU32()
 	// FIXME(sbinet) handle TObject reference
 	// if (bits&kIsReferenced) != 0 { ... }
@@ -695,7 +695,7 @@ func rstreamBits(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error
 }
 
 func rstreamF16(se rbytes.StreamerElement) ropFunc {
-	return func(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+	return func(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 		recv = cfg.adjust(recv)
 		*(recv.(*root.Float16)) = r.ReadF16(se)
 		return r.Err()
@@ -703,24 +703,24 @@ func rstreamF16(se rbytes.StreamerElement) ropFunc {
 }
 
 func rstreamD32(se rbytes.StreamerElement) ropFunc {
-	return func(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+	return func(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 		recv = cfg.adjust(recv)
 		*(recv.(*root.Double32)) = r.ReadD32(se)
 		return r.Err()
 	}
 }
 
-func rstreamTString(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamTString(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	*(cfg.adjust(recv).(*string)) = r.ReadString()
 	return r.Err()
 }
 
-func rstreamTObject(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamTObject(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	obj := cfg.adjust(recv).(*rbase.Object)
 	return obj.UnmarshalROOT(r)
 }
 
-func rstreamTNamed(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamTNamed(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	named := cfg.adjust(recv).(*rbase.Named)
 	return named.UnmarshalROOT(r)
 }
@@ -747,9 +747,9 @@ func rstreamCnv(to rmeta.Enum, from ropFunc) ropFunc {
 }
 
 func rstreamBasicArray(n int, arr ropFunc) ropFunc {
-	return func(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+	return func(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 		rv := reflect.ValueOf(cfg.adjust(recv)).Elem()
-		for i := 0; i < n; i++ {
+		for i := range n {
 			err := arr(r, rv.Index(i).Addr().Interface(), nil)
 			if err != nil {
 				return fmt.Errorf(
@@ -763,14 +763,14 @@ func rstreamBasicArray(n int, arr ropFunc) ropFunc {
 }
 
 func rstreamBasicSlice(sli ropFunc) ropFunc {
-	return func(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+	return func(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 		_ = r.ReadI8() // is-array
 		n := int(reflect.ValueOf(recv).Elem().FieldByIndex(cfg.descr.method).Int())
 		rv := reflect.ValueOf(cfg.adjust(recv)).Elem()
 		if nn := rv.Len(); nn < n {
 			rv.Set(reflect.AppendSlice(rv, reflect.MakeSlice(rv.Type(), n-nn, n-nn)))
 		}
-		for i := 0; i < n; i++ {
+		for i := range n {
 			err := sli(r, rv.Index(i).Addr().Interface(), nil)
 			if err != nil {
 				return fmt.Errorf(
@@ -802,7 +802,7 @@ func rcheckHeader(r *rbytes.RBuffer, hdr rbytes.Header) error {
 }
 
 func rstreamType(typename string, rop ropFunc) ropFunc {
-	return func(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+	return func(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 		hdr := r.ReadHeader(typename, rvers.StreamerInfo)
 		err := rop(r, recv, cfg)
 		if err != nil {
@@ -818,7 +818,7 @@ func rstreamType(typename string, rop ropFunc) ropFunc {
 
 func rstreamStdSlice(typename string, rop ropFunc) ropFunc {
 	//	const typevers = 1
-	return func(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+	return func(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 		// FIXME(sbinet): use typevers to infer obj-/mbr-wise reading.
 		n := int(r.ReadI32())
 		rv := reflect.ValueOf(cfg.adjust(recv)).Elem()
@@ -826,7 +826,7 @@ func rstreamStdSlice(typename string, rop ropFunc) ropFunc {
 			rv.Set(reflect.AppendSlice(rv, reflect.MakeSlice(rv.Type(), n-nn, n-nn)))
 		}
 		rv.SetLen(n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			err := rop(r, rv.Index(i).Addr().Interface(), nil)
 			if err != nil {
 				return fmt.Errorf(
@@ -853,7 +853,7 @@ func rstreamStdMap(kname, vname string, krop, vrop ropFunc) ropFunc {
 	if strings.HasSuffix(vname, ">") {
 		typename = fmt.Sprintf("map<%s,%s >", kname, vname)
 	}
-	return func(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+	return func(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 		// typevers = int16(cfg.si.ClassVersion())
 		hdr := r.ReadHeader(typename, rvers.StreamerInfo)
 		if hdr.MemberWise {
@@ -874,7 +874,7 @@ func rstreamStdMap(kname, vname string, krop, vrop ropFunc) ropFunc {
 		keys.Set(reflect.AppendSlice(keys, reflect.MakeSlice(keyT, n, n)))
 		if n > 0 {
 			hdr := rstreamHeader(r, kname, -1) // FIXME(sbinet): use -1 passthrough or key-si-classversion ?
-			for i := 0; i < n; i++ {
+			for i := range n {
 				err := krop(r, keys.Index(i).Addr().Interface(), nil)
 				if err != nil {
 					return fmt.Errorf(
@@ -893,7 +893,7 @@ func rstreamStdMap(kname, vname string, krop, vrop ropFunc) ropFunc {
 		vals.Set(reflect.AppendSlice(vals, reflect.MakeSlice(valT, n, n)))
 		if n > 0 {
 			hdr := rstreamHeader(r, vname, -1) // FIXME(sbinet): use -1 passthrough or val-si-classversion
-			for i := 0; i < n; i++ {
+			for i := range n {
 				err := vrop(r, vals.Index(i).Addr().Interface(), nil)
 				if err != nil {
 					return fmt.Errorf(
@@ -911,7 +911,7 @@ func rstreamStdMap(kname, vname string, krop, vrop ropFunc) ropFunc {
 		if rv.IsNil() {
 			rv.Set(reflect.MakeMapWithSize(rv.Type(), n))
 		}
-		for i := 0; i < n; i++ {
+		for i := range n {
 			rv.SetMapIndex(keys.Index(i), vals.Index(i))
 		}
 
@@ -921,7 +921,7 @@ func rstreamStdMap(kname, vname string, krop, vrop ropFunc) ropFunc {
 }
 
 func rstreamStdBitset(typename string, n int) ropFunc {
-	return func(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+	return func(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 		var (
 			bits = int(r.ReadI32())
 			sli  = cfg.adjust(recv).(*[]uint8)
@@ -932,7 +932,7 @@ func rstreamStdBitset(typename string, n int) ropFunc {
 	}
 }
 
-func rstreamBools(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamBools(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	var (
 		_   = r.ReadI8() // is-array
 		n   = cfg.counter(recv)
@@ -943,7 +943,7 @@ func rstreamBools(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) erro
 	return r.Err()
 }
 
-func rstreamU8s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamU8s(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	var (
 		_   = r.ReadI8() // is-array
 		n   = cfg.counter(recv)
@@ -954,7 +954,7 @@ func rstreamU8s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error 
 	return r.Err()
 }
 
-func rstreamU16s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamU16s(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	var (
 		_   = r.ReadI8() // is-array
 		n   = cfg.counter(recv)
@@ -965,7 +965,7 @@ func rstreamU16s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error
 	return r.Err()
 }
 
-func rstreamU32s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamU32s(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	var (
 		_   = r.ReadI8() // is-array
 		n   = cfg.counter(recv)
@@ -976,7 +976,7 @@ func rstreamU32s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error
 	return r.Err()
 }
 
-func rstreamU64s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamU64s(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	var (
 		_   = r.ReadI8() // is-array
 		n   = cfg.counter(recv)
@@ -987,7 +987,7 @@ func rstreamU64s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error
 	return r.Err()
 }
 
-func rstreamI8s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamI8s(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	var (
 		_   = r.ReadI8() // is-array
 		n   = cfg.counter(recv)
@@ -998,7 +998,7 @@ func rstreamI8s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error 
 	return r.Err()
 }
 
-func rstreamI16s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamI16s(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	var (
 		_   = r.ReadI8() // is-array
 		n   = cfg.counter(recv)
@@ -1009,7 +1009,7 @@ func rstreamI16s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error
 	return r.Err()
 }
 
-func rstreamI32s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamI32s(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	var (
 		_   = r.ReadI8() // is-array
 		n   = cfg.counter(recv)
@@ -1020,7 +1020,7 @@ func rstreamI32s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error
 	return r.Err()
 }
 
-func rstreamI64s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamI64s(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	var (
 		_   = r.ReadI8() // is-array
 		n   = cfg.counter(recv)
@@ -1031,7 +1031,7 @@ func rstreamI64s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error
 	return r.Err()
 }
 
-func rstreamF32s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamF32s(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	var (
 		_   = r.ReadI8() // is-array
 		n   = cfg.counter(recv)
@@ -1042,7 +1042,7 @@ func rstreamF32s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error
 	return r.Err()
 }
 
-func rstreamF64s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamF64s(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	var (
 		_   = r.ReadI8() // is-array
 		n   = cfg.counter(recv)
@@ -1053,7 +1053,7 @@ func rstreamF64s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error
 	return r.Err()
 }
 
-func rstreamF16s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamF16s(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	var (
 		_   = r.ReadI8() // is-array
 		n   = cfg.counter(recv)
@@ -1064,7 +1064,7 @@ func rstreamF16s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error
 	return r.Err()
 }
 
-func rstreamD32s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamD32s(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	var (
 		_   = r.ReadI8() // is-array
 		n   = cfg.counter(recv)
@@ -1075,7 +1075,7 @@ func rstreamD32s(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error
 	return r.Err()
 }
 
-func rstreamStrs(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamStrs(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	var (
 		_   = r.ReadI8() // is-array
 		n   = cfg.counter(recv)
@@ -1087,7 +1087,7 @@ func rstreamStrs(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error
 }
 
 func rstreamCat(typename string, typevers int16, rops []rstreamer) ropFunc {
-	return func(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+	return func(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 		hdr := r.ReadHeader(typename, typevers)
 		if hdr.Vers != typevers {
 			r.SetErr(fmt.Errorf(
@@ -1112,13 +1112,13 @@ func rstreamCat(typename string, typevers int16, rops []rstreamer) ropFunc {
 	}
 }
 
-func rstreamStdString(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+func rstreamStdString(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 	*(cfg.adjust(recv).(*string)) = r.ReadString()
 	return r.Err()
 
 }
 
-// func rstreamGeneric(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+// func rstreamGeneric(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 // 	const (
 // 		beg     = 0
 // 		end     = 1
@@ -1128,11 +1128,11 @@ func rstreamStdString(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) 
 // 	return cfg.si.rstream(r, recv, cfg.descr, beg, end, n, cfg.offset, arrmode)
 // }
 
-// type rmbrwiseSTLFunc func(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig, vers int16) error
-// type robjwiseSTLFunc func(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig, vers int16, start int32) error
+// type rmbrwiseSTLFunc func(r *rbytes.RBuffer, recv any, cfg *streamerConfig, vers int16) error
+// type robjwiseSTLFunc func(r *rbytes.RBuffer, recv any, cfg *streamerConfig, vers int16, start int32) error
 //
 // func rstreamSTL(mbrwise rmbrwiseSTLFunc, objwise robjwiseSTLFunc, oclass string) ropFunc {
-// 	return func(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) error {
+// 	return func(r *rbytes.RBuffer, recv any, cfg *streamerConfig) error {
 // 		err := r.Err()
 // 		if err != nil {
 // 			return err
@@ -1151,15 +1151,15 @@ func rstreamStdString(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) 
 // 	}
 // }
 //
-// func rstreamSTLArrayMbrWise(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig, vers int16) error {
+// func rstreamSTLArrayMbrWise(r *rbytes.RBuffer, recv any, cfg *streamerConfig, vers int16) error {
 // 	panic("not implemented")
 // }
 //
-// func rstreamSTLObjWise(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig, vers int16, start int32) error {
+// func rstreamSTLObjWise(r *rbytes.RBuffer, recv any, cfg *streamerConfig, vers int16, start int32) error {
 // 	panic("not implemented")
 // }
 
-// func (si *StreamerInfo) rstream(r *rbytes.RBuffer, recv interface{}, descr *elemDescr, beg, end, n, offset int, mode arrayMode) error {
+// func (si *StreamerInfo) rstream(r *rbytes.RBuffer, recv any, descr *elemDescr, beg, end, n, offset int, mode arrayMode) error {
 // 	needIncr := mode&2 == 0
 // 	mode &= ^2
 //
@@ -1221,7 +1221,7 @@ func rstreamStdString(r *rbytes.RBuffer, recv interface{}, cfg *streamerConfig) 
 // 	panic("not implemented")
 // }
 
-// func ptrAdjust(ptr interface{}, offsets []int) interface{} {
+// func ptrAdjust(ptr any, offsets []int) any {
 // 	recv := ptr
 // 	for _, offset := range offsets {
 // 		rv := reflect.ValueOf(recv).Elem()

--- a/groot/rdict/rwstreamer_test.go
+++ b/groot/rdict/rwstreamer_test.go
@@ -24,7 +24,7 @@ func TestRWStream(t *testing.T) {
 		name string
 		skip bool
 		si   *StreamerInfo
-		ptr  interface{}
+		ptr  any
 		deps []rbytes.StreamerInfo
 		err  error
 	}{
@@ -736,7 +736,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "arr-TObjString",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					F [3]rbase.ObjString
 				}
@@ -766,7 +766,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "arr-Pos",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type Pos struct {
 					X float32
 					Y float64
@@ -1298,7 +1298,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "sli-Pos",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type Pos struct {
 					Px float32
 					Py float64
@@ -1762,7 +1762,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "particle",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type P2 struct {
 					Px float32 `groot:"px"`
 					Py float64 `groot:"py"`
@@ -1823,7 +1823,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "event-objstring",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type Particle struct {
 					Name rbase.ObjString
 				}
@@ -1871,7 +1871,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "event-particle",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type P2 struct {
 					Px float32 `groot:"px"`
 					Py float64 `groot:"py"`
@@ -1952,7 +1952,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "std::vector<P2>",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type P2 struct {
 					Px float32
 					Py float64
@@ -2006,7 +2006,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "event-std::vector<particle>",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type P2 struct {
 					Px float32 `groot:"px"`
 					Py float64 `groot:"py"`
@@ -2086,7 +2086,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "base-object",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					rbase.Object `groot:",base"`
 					F1           float64
@@ -2120,7 +2120,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "base-named",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					rbase.Named `groot:",base"`
 					F1          float64
@@ -2154,7 +2154,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "base-objstring",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					rbase.ObjString `groot:",base"`
 					F1              float64
@@ -2188,7 +2188,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "ptr-to-object",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					F1 *rbase.Named
 					F2 *rbase.Named
@@ -2266,7 +2266,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "event-particles",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type P2 struct {
 					Px float32 `groot:"px"`
 					Py float64 `groot:"py"`
@@ -2349,7 +2349,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "event-particles-tags",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type P2 struct {
 					Px float32 `groot:"px"`
 					Py float64 `groot:"py"`
@@ -2462,7 +2462,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "set<i32>",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					F []int32
 				}
@@ -2486,7 +2486,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "set<TString>",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					F []string
 				}
@@ -2510,7 +2510,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "set<vector<float> >",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					F [][]float32
 				}
@@ -2538,7 +2538,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "set<set<float> >",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					F [][]float32
 				}
@@ -2566,7 +2566,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "unordered_set<i32>",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					F []int32
 				}
@@ -2590,7 +2590,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "unordered_set<TString>",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					F []string
 				}
@@ -2614,7 +2614,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "unordered_set<vector<float> >",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					F [][]float32
 				}
@@ -2642,7 +2642,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "unordered_set<unordered_set<float> >",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					F [][]float32
 				}
@@ -2670,7 +2670,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "map<i32,i32>",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					Map map[int32]int32 `groot:"m"`
 				}
@@ -2698,7 +2698,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "map<i32,string>",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					Map map[int32]string `groot:"m"`
 				}
@@ -2726,7 +2726,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "map<i32,map<i32,string> >",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					Map map[int32]map[int32]string `groot:"m"`
 				}
@@ -2766,7 +2766,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "map<i32,vector<string> >",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					Map map[int32][]string `groot:"m"`
 				}
@@ -2794,7 +2794,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "unordered_map<i32,i32>",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					Map map[int32]int32 `groot:"m"`
 				}
@@ -2822,7 +2822,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "unordered_map<i32,string>",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					Map map[int32]string `groot:"m"`
 				}
@@ -2850,7 +2850,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "unordered_map<i32,unordered_map<i32,string> >",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					Map map[int32]map[int32]string `groot:"m"`
 				}
@@ -2890,7 +2890,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "unordered_map<i32,vector<string> >",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					Map map[int32][]string `groot:"m"`
 				}
@@ -2918,7 +2918,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "list<i32>",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					F []int32
 				}
@@ -2942,7 +2942,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "list<TString>",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					F []string
 				}
@@ -2966,7 +2966,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "list<vector<float> >",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					F [][]float32
 				}
@@ -2994,7 +2994,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "list<list<float> >",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					F [][]float32
 				}
@@ -3022,7 +3022,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "deque<i32>",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					F []int32
 				}
@@ -3046,7 +3046,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "deque<TString>",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					F []string
 				}
@@ -3070,7 +3070,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "deque<vector<float> >",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					F [][]float32
 				}
@@ -3098,7 +3098,7 @@ func TestRWStream(t *testing.T) {
 		},
 		{
 			name: "deque<deque<float> >",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type T struct {
 					F [][]float32
 				}
@@ -3334,13 +3334,13 @@ func TestRWStreamerInfo(t *testing.T) {
 		name string
 		skip bool
 		si   *StreamerInfo
-		ptr  interface{}
+		ptr  any
 		deps []rbytes.StreamerInfo
 		err  error
 	}{
 		{
 			name: "event",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type P2 struct {
 					Px float32 `groot:"px"`
 					Py float64 `groot:"py"`
@@ -3502,13 +3502,13 @@ func TestRWStreamerElem(t *testing.T) {
 		name string
 		skip bool
 		si   *StreamerInfo
-		ptr  interface{}
+		ptr  any
 		deps []rbytes.StreamerInfo
 		err  error
 	}{
 		{
 			name: "event",
-			ptr: func() interface{} {
+			ptr: func() any {
 				type P2 struct {
 					Px float32 `groot:"px"`
 					Py float64 `groot:"py"`

--- a/groot/rdict/streamer.go
+++ b/groot/rdict/streamer.go
@@ -58,7 +58,7 @@ func (bld *streamerBuilder) genStreamer(typ reflect.Type) rbytes.StreamerInfo {
 	switch typ.Kind() {
 	case reflect.Struct:
 		si.elems = make([]rbytes.StreamerElement, 0, typ.NumField())
-		for i := 0; i < typ.NumField(); i++ {
+		for i := range typ.NumField() {
 			ft := typ.Field(i)
 			si.elems = append(si.elems, bld.genField(typ, ft))
 		}
@@ -757,7 +757,7 @@ func typenameOf(typ reflect.Type) string {
 			dims []int
 			et   = typ
 		)
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			dims = append(dims, et.Len())
 			et = et.Elem()
 			if et.Kind() != reflect.Array {

--- a/groot/rdict/streamer_test.go
+++ b/groot/rdict/streamer_test.go
@@ -258,7 +258,7 @@ func TestTypenameOf(t *testing.T) {
 		},
 		{
 			name: "struct-event",
-			typ: reflect.TypeOf(func() interface{} {
+			typ: reflect.TypeOf(func() any {
 				type Event struct{}
 				return Event{}
 			}()),

--- a/groot/rhist/formula.go
+++ b/groot/rhist/formula.go
@@ -121,7 +121,7 @@ func readMapStringInt(r *rbytes.RBuffer) map[string]int32 {
 
 	n := int(r.ReadI32())
 	o := make(map[string]int32, n)
-	for i := 0; i < n; i++ {
+	for range n {
 		k := r.ReadString()
 		v := r.ReadI32()
 		o[k] = v

--- a/groot/rhist/graph.go
+++ b/groot/rhist/graph.go
@@ -261,7 +261,7 @@ func (g *tgraph) UnmarshalYODA(raw []byte) error {
 // Keys implements the ObjectFinder interface.
 func (g *tgraph) Keys() []string {
 	var keys []string
-	for i := 0; i < g.funcs.Len(); i++ {
+	for i := range g.funcs.Len() {
 		o, ok := g.funcs.At(i).(root.Named)
 		if !ok {
 			continue
@@ -273,7 +273,7 @@ func (g *tgraph) Keys() []string {
 
 // Get implements the ObjectFinder interface.
 func (g *tgraph) Get(name string) (root.Object, error) {
-	for i := 0; i < g.funcs.Len(); i++ {
+	for i := range g.funcs.Len() {
 		o, ok := g.funcs.At(i).(root.Named)
 		if !ok {
 			continue
@@ -715,7 +715,7 @@ func newGraphMultiErrs(n, ny int) *tgraphmultierrs {
 		attfills: make([]rbase.AttFill, n),
 		attlines: make([]rbase.AttLine, n),
 	}
-	for i := 0; i < ny; i++ {
+	for i := range ny {
 		g.yerrlo[i].Data = make([]float64, n)
 		g.yerrhi[i].Data = make([]float64, n)
 	}

--- a/groot/rhist/graph_example_test.go
+++ b/groot/rhist/graph_example_test.go
@@ -31,7 +31,7 @@ func ExampleGraph() {
 	fmt.Printf("name:  %q\n", g.Name())
 	fmt.Printf("title: %q\n", g.Title())
 	fmt.Printf("#pts:  %d\n", g.Len())
-	for i := 0; i < g.Len(); i++ {
+	for i := range g.Len() {
 		x, y := g.XY(i)
 		fmt.Printf("(x,y)[%d] = (%+e, %+e)\n", i, x, y)
 	}
@@ -62,7 +62,7 @@ func ExampleGraphErrors() {
 	fmt.Printf("name:  %q\n", g.Name())
 	fmt.Printf("title: %q\n", g.Title())
 	fmt.Printf("#pts:  %d\n", g.Len())
-	for i := 0; i < g.Len(); i++ {
+	for i := range g.Len() {
 		x, y := g.XY(i)
 		xlo, xhi := g.XError(i)
 		ylo, yhi := g.YError(i)
@@ -95,7 +95,7 @@ func ExampleGraphErrors_asymmErrors() {
 	fmt.Printf("name:  %q\n", g.Name())
 	fmt.Printf("title: %q\n", g.Title())
 	fmt.Printf("#pts:  %d\n", g.Len())
-	for i := 0; i < g.Len(); i++ {
+	for i := range g.Len() {
 		x, y := g.XY(i)
 		xlo, xhi := g.XError(i)
 		ylo, yhi := g.YError(i)

--- a/groot/rhist/graph_test.go
+++ b/groot/rhist/graph_test.go
@@ -163,7 +163,7 @@ func TestGraphMultiErrors(t *testing.T) {
 		ylos = []float64{1, 0.5, 1, 0.5, 1}
 		yhis = []float64{0.5, 1, 0.5, 1, 2}
 	)
-	for i := 0; i < g.Len(); i++ {
+	for i := range g.Len() {
 		x, y := g.XY(i)
 		if x != xs[i] {
 			t.Errorf("x[%d]=%v. want=%v", i, x, xs[i])

--- a/groot/rhist/h1_gen.go
+++ b/groot/rhist/h1_gen.go
@@ -238,7 +238,7 @@ func (h *H1F) AsH1D() *hbook.H1D {
 		h.dist1D(nx + 1), // overflow
 	}
 
-	for i := 0; i < nx; i++ {
+	for i := range nx {
 		bin := &hh.Binning.Bins[i]
 		xmin := h.XBinLowEdge(i + 1)
 		xmax := h.XBinWidth(i+1) + xmin
@@ -521,7 +521,7 @@ func (h *H1D) AsH1D() *hbook.H1D {
 		h.dist1D(nx + 1), // overflow
 	}
 
-	for i := 0; i < nx; i++ {
+	for i := range nx {
 		bin := &hh.Binning.Bins[i]
 		xmin := h.XBinLowEdge(i + 1)
 		xmax := h.XBinWidth(i+1) + xmin
@@ -804,7 +804,7 @@ func (h *H1I) AsH1D() *hbook.H1D {
 		h.dist1D(nx + 1), // overflow
 	}
 
-	for i := 0; i < nx; i++ {
+	for i := range nx {
 		bin := &hh.Binning.Bins[i]
 		xmin := h.XBinLowEdge(i + 1)
 		xmax := h.XBinWidth(i+1) + xmin

--- a/groot/rhist/h2_gen.go
+++ b/groot/rhist/h2_gen.go
@@ -67,8 +67,8 @@ func NewH2FFrom(h *hbook.H2D) *H2F {
 
 	ibin := func(ix, iy int) int { return iy*nxbins + ix }
 
-	for ix := 0; ix < h.Binning.Nx; ix++ {
-		for iy := 0; iy < h.Binning.Ny; iy++ {
+	for ix := range h.Binning.Nx {
+		for iy := range h.Binning.Ny {
 			i := ibin(ix, iy)
 			bin := bins[i]
 			if ix == 0 {
@@ -318,8 +318,8 @@ func (h *H2F) AsH2D() *hbook.H2D {
 	hh.Binning.Dist.Y.Stats.SumWX2 = float64(h.SumWY2())
 	hh.Binning.Dist.Stats.SumWXY = h.SumWXY()
 
-	for ix := 0; ix < nx; ix++ {
-		for iy := 0; iy < ny; iy++ {
+	for ix := range nx {
+		for iy := range ny {
 			var (
 				i    = iy*nx + ix
 				xmin = h.XBinLowEdge(ix + 1)
@@ -458,8 +458,8 @@ func NewH2DFrom(h *hbook.H2D) *H2D {
 
 	ibin := func(ix, iy int) int { return iy*nxbins + ix }
 
-	for ix := 0; ix < h.Binning.Nx; ix++ {
-		for iy := 0; iy < h.Binning.Ny; iy++ {
+	for ix := range h.Binning.Nx {
+		for iy := range h.Binning.Ny {
 			i := ibin(ix, iy)
 			bin := bins[i]
 			if ix == 0 {
@@ -709,8 +709,8 @@ func (h *H2D) AsH2D() *hbook.H2D {
 	hh.Binning.Dist.Y.Stats.SumWX2 = float64(h.SumWY2())
 	hh.Binning.Dist.Stats.SumWXY = h.SumWXY()
 
-	for ix := 0; ix < nx; ix++ {
-		for iy := 0; iy < ny; iy++ {
+	for ix := range nx {
+		for iy := range ny {
 			var (
 				i    = iy*nx + ix
 				xmin = h.XBinLowEdge(ix + 1)
@@ -849,8 +849,8 @@ func NewH2IFrom(h *hbook.H2D) *H2I {
 
 	ibin := func(ix, iy int) int { return iy*nxbins + ix }
 
-	for ix := 0; ix < h.Binning.Nx; ix++ {
-		for iy := 0; iy < h.Binning.Ny; iy++ {
+	for ix := range h.Binning.Nx {
+		for iy := range h.Binning.Ny {
 			i := ibin(ix, iy)
 			bin := bins[i]
 			if ix == 0 {
@@ -1100,8 +1100,8 @@ func (h *H2I) AsH2D() *hbook.H2D {
 	hh.Binning.Dist.Y.Stats.SumWX2 = float64(h.SumWY2())
 	hh.Binning.Dist.Stats.SumWXY = h.SumWXY()
 
-	for ix := 0; ix < nx; ix++ {
-		for iy := 0; iy < ny; iy++ {
+	for ix := range nx {
+		for iy := range ny {
 			var (
 				i    = iy*nx + ix
 				xmin = h.XBinLowEdge(ix + 1)

--- a/groot/rhist/hist.go
+++ b/groot/rhist/hist.go
@@ -237,7 +237,7 @@ func (h *th1) RMembers() (mbrs []rbytes.Member) {
 // Keys implements the ObjectFinder interface.
 func (h *th1) Keys() []string {
 	var keys []string
-	for i := 0; i < h.funcs.Len(); i++ {
+	for i := range h.funcs.Len() {
 		o, ok := h.funcs.At(i).(root.Named)
 		if !ok {
 			continue
@@ -249,7 +249,7 @@ func (h *th1) Keys() []string {
 
 // Get implements the ObjectFinder interface.
 func (h *th1) Get(name string) (root.Object, error) {
-	for i := 0; i < h.funcs.Len(); i++ {
+	for i := range h.funcs.Len() {
 		o, ok := h.funcs.At(i).(root.Named)
 		if !ok {
 			continue

--- a/groot/rhist/hist_example_test.go
+++ b/groot/rhist/hist_example_test.go
@@ -44,7 +44,7 @@ func ExampleCreate_histo1D() {
 	// Draw some random values from the standard
 	// normal distribution.
 	h := hbook.NewH1D(20, -4, +4)
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		v := dist.Rand()
 		h.Fill(v, 1)
 	}
@@ -117,7 +117,7 @@ func ExampleCreate_histo2D() {
 	// Draw some random values from the standard
 	// normal distribution.
 	h := hbook.NewH2D(5, -4, +4, 6, -4, +4)
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		x := dist.Rand()
 		y := dist.Rand()
 		h.Fill(x, y, 1)
@@ -191,7 +191,7 @@ func TestH1(t *testing.T) {
 	// Draw some random values from the standard
 	// normal distribution.
 	h := hbook.NewH1D(20, -4, +4)
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		v := dist.Rand()
 		h.Fill(v, 1)
 	}
@@ -291,7 +291,7 @@ func TestH2(t *testing.T) {
 	// Draw some random values from the standard
 	// normal distribution.
 	h := hbook.NewH2D(5, -4, +4, 6, -4, +4)
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		x := dist.Rand()
 		y := dist.Rand()
 		h.Fill(x, y, 1)

--- a/groot/rhist/multigraph.go
+++ b/groot/rhist/multigraph.go
@@ -116,7 +116,7 @@ func (o *tmultigraph) UnmarshalROOT(r *rbytes.RBuffer) error {
 // MarshalYODA implements the YODAMarshaler interface.
 func (mg *tmultigraph) MarshalYODA() ([]byte, error) {
 	out := new(bytes.Buffer)
-	for i := 0; i < mg.graphs.Len(); i++ {
+	for i := range mg.graphs.Len() {
 		g := mg.graphs.At(i).(yodacnv.Marshaler)
 		raw, err := g.MarshalYODA()
 		if err != nil {

--- a/groot/riofs/blocks.go
+++ b/groot/riofs/blocks.go
@@ -6,6 +6,7 @@ package riofs
 
 import (
 	"reflect"
+	"slices"
 	"sort"
 
 	"go-hep.org/x/hep/groot/rbytes"
@@ -159,7 +160,7 @@ func (fl *freeList) consolidate() {
 
 func (fl *freeList) remove(i int) {
 	list := *fl
-	*fl = append(list[:i], list[i+1:]...)
+	*fl = slices.Delete(list, i, i+1)
 }
 
 // best returns the best free segment where to store nbytes.

--- a/groot/riofs/file.go
+++ b/groot/riofs/file.go
@@ -520,7 +520,7 @@ func (f *File) readStreamerInfo() error {
 
 	objs := f.siKey.Value().(root.List)
 	f.sinfos = make([]rbytes.StreamerInfo, 0, objs.Len())
-	for i := 0; i < objs.Len(); i++ {
+	for i := range objs.Len() {
 		obj, ok := objs.At(i).(rbytes.StreamerInfo)
 		if !ok {
 			continue
@@ -651,10 +651,7 @@ func (f *File) markFree(beg, end int64) {
 	if span == nil {
 		return
 	}
-	nbytes := span.free()
-	if nbytes > 2000000000 {
-		nbytes = 2000000000
-	}
+	nbytes := min(span.free(), 2000000000)
 	buf := rbytes.NewWBuffer(make([]byte, 4), nil, 0, f)
 	buf.WriteI32(-int32(nbytes))
 	if end == f.end-1 {

--- a/groot/riofs/key.go
+++ b/groot/riofs/key.go
@@ -379,7 +379,7 @@ func (k *Key) ObjectType() reflect.Type {
 }
 
 // Value returns the data corresponding to the Key's value
-func (k *Key) Value() interface{} {
+func (k *Key) Value() any {
 	v, err := k.Object()
 	if err != nil {
 		panic(fmt.Errorf("error loading payload for %q: %w", k.Name(), err))

--- a/groot/riofs/plugin/http/preader.go
+++ b/groot/riofs/plugin/http/preader.go
@@ -65,7 +65,7 @@ func (r *preader) pread(p []byte, off int64) (int, error) {
 
 	var wg sync.WaitGroup
 	wg.Add(r.n)
-	for i := 0; i < r.n; i++ {
+	for range r.n {
 		go func() {
 			defer wg.Done()
 			for i := range wrk {

--- a/groot/riofs/plugin/http/span.go
+++ b/groot/riofs/plugin/http/span.go
@@ -4,7 +4,10 @@
 
 package http
 
-import "sort"
+import (
+	"slices"
+	"sort"
+)
 
 type span struct {
 	off int64
@@ -93,7 +96,7 @@ func (p *spans) consolidate() {
 
 func (p *spans) remove(i int) {
 	list := *p
-	*p = append(list[:i], list[i+1:]...)
+	*p = slices.Delete(list, i, i+1)
 }
 
 func (p *spans) add(sp span) {

--- a/groot/riofs/walk.go
+++ b/groot/riofs/walk.go
@@ -247,7 +247,7 @@ func Dir(dir Directory) Directory {
 
 func fileOf(d Directory) *File {
 	const max = 1<<31 - 1
-	for i := 0; i < max; i++ {
+	for range max {
 		p := d.Parent()
 		if p == nil {
 			switch d := d.(type) {

--- a/groot/rjson/rjson.go
+++ b/groot/rjson/rjson.go
@@ -52,7 +52,7 @@ func (enc *encoder) encode(v any) error {
 		if err != nil {
 			return err
 		}
-		for i := 0; i < rv.Len(); i++ {
+		for i := range rv.Len() {
 			if i > 0 {
 				_, err := w.Write([]byte(","))
 				if err != nil {

--- a/groot/rnpy/arrow.go
+++ b/groot/rnpy/arrow.go
@@ -136,10 +136,10 @@ func (rec *Record) read(r *npy.Reader, nelem int64, bldr array.Builder) {
 		panic(fmt.Errorf("npy2root: could not read numpy data: %w", err))
 	}
 
-	ch := make(chan interface{}, nelem/2)
+	ch := make(chan any, nelem/2)
 	go func() {
 		defer close(ch)
-		for i := 0; i < rv.Len(); i++ {
+		for i := range rv.Len() {
 			ch <- rv.Index(i).Interface()
 		}
 	}()
@@ -306,7 +306,7 @@ func dtypeFrom(dt arrow.DataType) reflect.Type {
 	}
 }
 
-func appendData(bldr array.Builder, ch <-chan interface{}, dt arrow.DataType) {
+func appendData(bldr array.Builder, ch <-chan any, dt arrow.DataType) {
 	switch bldr := bldr.(type) {
 	case *array.BooleanBuilder:
 		v := <-ch
@@ -347,7 +347,7 @@ func appendData(bldr array.Builder, ch <-chan interface{}, dt arrow.DataType) {
 		n := int(dt.Len())
 		sub.Reserve(n)
 		bldr.Append(true)
-		for i := 0; i < n; i++ {
+		for range n {
 			appendData(sub, ch, dt.Elem())
 		}
 	default:

--- a/groot/rnpy/arrow_test.go
+++ b/groot/rnpy/arrow_test.go
@@ -16,7 +16,7 @@ func TestRecord(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		forder bool // Fortran order
-		want   interface{}
+		want   any
 	}{
 		{
 			name: "float64_4x3x2-c-order",

--- a/groot/rnpy/column.go
+++ b/groot/rnpy/column.go
@@ -96,7 +96,7 @@ func (col Column) Name() string {
 
 // Slice reads the whole data slice from the underlying ROOT Tree
 // into memory.
-func (col Column) Slice() (sli interface{}, err error) {
+func (col Column) Slice() (sli any, err error) {
 	r, err := rtree.NewReader(col.tree, []rtree.ReadVar{col.rvar})
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/groot/rnpy/column_test.go
+++ b/groot/rnpy/column_test.go
@@ -18,7 +18,7 @@ func TestColumn(t *testing.T) {
 		fname string
 		tname string
 		aname rtree.ReadVar
-		want  interface{}
+		want  any
 		err   error
 	}{
 		{
@@ -43,7 +43,7 @@ func TestColumn(t *testing.T) {
 			fname: "../testdata/leaves.root",
 			tname: "tree",
 			aname: rtree.ReadVar{Name: "ArrF64"},
-			want: func() interface{} {
+			want: func() any {
 				o := make([][10]float64, 10)
 				for i := range o {
 					for j := range o[i] {
@@ -115,7 +115,7 @@ func TestColumn(t *testing.T) {
 			}
 			tree := obj.(rtree.Tree)
 
-			var sli interface{}
+			var sli any
 
 			col, err := NewColumn(tree, tc.aname)
 			if err == nil {

--- a/groot/root/root.go
+++ b/groot/root/root.go
@@ -72,8 +72,8 @@ type ObjArray interface {
 // Array describes ROOT abstract array type.
 type Array interface {
 	Len() int // number of array elements
-	Get(i int) interface{}
-	Set(i int, v interface{})
+	Get(i int) any
+	Set(i int, v any)
 }
 
 // ObjString is a ROOT string that implements ROOT TObject.

--- a/groot/rpad/pad.go
+++ b/groot/rpad/pad.go
@@ -206,7 +206,7 @@ func (p *Pad) UnmarshalROOT(r *rbytes.RBuffer) error {
 func (pad *Pad) Keys() []string {
 	var keys []string
 	if pad.fPrimitives != nil && pad.fPrimitives.Len() > 0 {
-		for i := 0; i < pad.fPrimitives.Len(); i++ {
+		for i := range pad.fPrimitives.Len() {
 			o, ok := pad.fPrimitives.At(i).(root.Named)
 			if !ok {
 				continue
@@ -219,7 +219,7 @@ func (pad *Pad) Keys() []string {
 
 // Get implements the ObjectFinder interface.
 func (pad *Pad) Get(name string) (root.Object, error) {
-	for i := 0; i < pad.fPrimitives.Len(); i++ {
+	for i := range pad.fPrimitives.Len() {
 		v := pad.fPrimitives.At(i)
 		o, ok := v.(root.Named)
 		if !ok {

--- a/groot/rsql/rsqldrv/driver_test.go
+++ b/groot/rsql/rsqldrv/driver_test.go
@@ -138,7 +138,7 @@ func TestQuery(t *testing.T) {
 	}
 	for _, tc := range []struct {
 		query string
-		args  []interface{}
+		args  []any
 		cols  []string
 		want  []data
 	}{
@@ -175,7 +175,7 @@ func TestQuery(t *testing.T) {
 		{
 			query: `SELECT (one+?, two+?, ?+three+"--") FROM tree`,
 			cols:  []string{"", "", ""},
-			args:  []interface{}{int32(10), 20.0, "++"},
+			args:  []any{int32(10), 20.0, "++"},
 			want: []data{
 				{11, 21.1, "++uno--"},
 				{12, 22.2, "++dos--"},
@@ -202,7 +202,7 @@ func TestQuery(t *testing.T) {
 		{
 			query: `SELECT (one, two, three) FROM tree WHERE (one <= ?)`,
 			cols:  []string{"one", "two", "three"},
-			args:  []interface{}{int32(2)},
+			args:  []any{int32(2)},
 			want: []data{
 				{1, 1.1, "uno"},
 				{2, 2.2, "dos"},
@@ -211,7 +211,7 @@ func TestQuery(t *testing.T) {
 		{
 			query: `SELECT (one, two, three) FROM tree WHERE (one <= ?)`,
 			cols:  []string{"one", "two", "three"},
-			args:  []interface{}{2},
+			args:  []any{2},
 			want: []data{
 				{1, 1.1, "uno"},
 				{2, 2.2, "dos"},
@@ -220,7 +220,7 @@ func TestQuery(t *testing.T) {
 		{
 			query: `SELECT (one, two, three) FROM tree WHERE (two <= ?)`,
 			cols:  []string{"one", "two", "three"},
-			args:  []interface{}{2.2},
+			args:  []any{2.2},
 			want: []data{
 				{1, 1.1, "uno"},
 				{2, 2.2, "dos"},
@@ -229,7 +229,7 @@ func TestQuery(t *testing.T) {
 		{
 			query: `SELECT (one, two, three) FROM tree WHERE (two <= ?)`,
 			cols:  []string{"one", "two", "three"},
-			args:  []interface{}{3},
+			args:  []any{3},
 			want: []data{
 				{1, 1.1, "uno"},
 				{2, 2.2, "dos"},
@@ -238,7 +238,7 @@ func TestQuery(t *testing.T) {
 		{
 			query: `SELECT (one, two, three) FROM tree WHERE (three != ? && three != ?)`,
 			cols:  []string{"one", "two", "three"},
-			args:  []interface{}{"tres", "quatro"},
+			args:  []any{"tres", "quatro"},
 			want: []data{
 				{1, 1.1, "uno"},
 				{2, 2.2, "dos"},
@@ -327,7 +327,7 @@ func TestQuery(t *testing.T) {
 		{
 			query: `SELECT (one, two, three) FROM tree WHERE (three = ?)`,
 			cols:  []string{"one", "two", "three"},
-			args:  []interface{}{"quatro"},
+			args:  []any{"quatro"},
 			want: []data{
 				{4, 4.4, "quatro"},
 			},
@@ -459,7 +459,7 @@ func (eventData) want(i int64) (data eventData) {
 	data.SliF64 = make([]float64, int(data.N))
 	data.SliD16 = make([]root.Float16, int(data.N))
 	data.SliD32 = make([]root.Double32, int(data.N))
-	for ii := 0; ii < int(data.N); ii++ {
+	for ii := range int(data.N) {
 		data.SliBs[ii] = (ii + 1) == int(i)
 		data.SliI8[ii] = int8(-i)
 		data.SliI16[ii] = int16(-i)

--- a/groot/rsql/rsqldrv/expr_test.go
+++ b/groot/rsql/rsqldrv/expr_test.go
@@ -12,19 +12,19 @@ import (
 	"github.com/xwb1989/sqlparser"
 )
 
-type vctxType map[interface{}]interface{}
+type vctxType map[any]any
 
 func TestExpr(t *testing.T) {
 	for _, tc := range []struct {
 		expr string
 		vctx vctxType
-		want interface{}
+		want any
 		err  error
 	}{
 		{
 			expr: `select (x, y) from tbl`,
 			vctx: vctxType{"x": int32(1), "y": int32(2)},
-			want: []interface{}{int32(1), int32(2)},
+			want: []any{int32(1), int32(2)},
 		},
 		{
 			expr: `select (x + "foo") from tbl`,
@@ -810,20 +810,18 @@ func TestSelectColumns(t *testing.T) {
 	}
 	defer db.Close()
 
-	type eface = interface{}
-
 	for _, tc := range []struct {
 		query string
 		cols  []string
-		types []interface{}
-		args  []interface{}
-		vals  [][]eface
+		types []any
+		args  []any
+		vals  [][]any
 	}{
 		{
 			query: `select one from tree`,
 			cols:  []string{"one"},
-			types: []interface{}{int32(0)},
-			vals: [][]eface{
+			types: []any{int32(0)},
+			vals: [][]any{
 				{int32(1)},
 				{int32(2)},
 				{int32(3)},
@@ -833,8 +831,8 @@ func TestSelectColumns(t *testing.T) {
 		{
 			query: `select (one) from tree`,
 			cols:  []string{"one"},
-			types: []interface{}{int32(0)},
-			vals: [][]eface{
+			types: []any{int32(0)},
+			vals: [][]any{
 				{int32(1)},
 				{int32(2)},
 				{int32(3)},
@@ -844,8 +842,8 @@ func TestSelectColumns(t *testing.T) {
 		{
 			query: `select (one, two) from tree`,
 			cols:  []string{"one", "two"},
-			types: []interface{}{int32(0), 0.0},
-			vals: [][]eface{
+			types: []any{int32(0), 0.0},
+			vals: [][]any{
 				{int32(1), 1.1},
 				{int32(2), 2.2},
 				{int32(3), 3.3},
@@ -855,8 +853,8 @@ func TestSelectColumns(t *testing.T) {
 		{
 			query: `select (one, (two)) from tree`,
 			cols:  []string{"one", "two"},
-			types: []interface{}{int32(0), 0.0},
-			vals: [][]eface{
+			types: []any{int32(0), 0.0},
+			vals: [][]any{
 				{int32(1), 1.1},
 				{int32(2), 2.2},
 				{int32(3), 3.3},
@@ -866,8 +864,8 @@ func TestSelectColumns(t *testing.T) {
 		{
 			query: `select (one, ((two))) from tree`,
 			cols:  []string{"one", "two"},
-			types: []interface{}{int32(0), 0.0},
-			vals: [][]eface{
+			types: []any{int32(0), 0.0},
+			vals: [][]any{
 				{int32(1), 1.1},
 				{int32(2), 2.2},
 				{int32(3), 3.3},
@@ -877,8 +875,8 @@ func TestSelectColumns(t *testing.T) {
 		{
 			query: `select (((one), ((two)))) from tree`,
 			cols:  []string{"one", "two"},
-			types: []interface{}{int32(0), 0.0},
-			vals: [][]eface{
+			types: []any{int32(0), 0.0},
+			vals: [][]any{
 				{int32(1), 1.1},
 				{int32(2), 2.2},
 				{int32(3), 3.3},
@@ -888,8 +886,8 @@ func TestSelectColumns(t *testing.T) {
 		{
 			query: `select three from tree`,
 			cols:  []string{"three"},
-			types: []interface{}{""},
-			vals: [][]eface{
+			types: []any{""},
+			vals: [][]any{
 				{"uno"},
 				{"dos"},
 				{"tres"},
@@ -899,8 +897,8 @@ func TestSelectColumns(t *testing.T) {
 		{
 			query: `select (one, two, three) from tree`,
 			cols:  []string{"one", "two", "three"},
-			types: []interface{}{int32(0), 0.0, ""},
-			vals: [][]eface{
+			types: []any{int32(0), 0.0, ""},
+			vals: [][]any{
 				{int32(1), 1.1, "uno"},
 				{int32(2), 2.2, "dos"},
 				{int32(3), 3.3, "tres"},
@@ -910,9 +908,9 @@ func TestSelectColumns(t *testing.T) {
 		{
 			query: `select (?, two, ?) from tree`,
 			cols:  []string{"", "two", ""},
-			types: []interface{}{"", 0.0, ""},
-			args:  []interface{}{"one", "three"},
-			vals: [][]eface{
+			types: []any{"", 0.0, ""},
+			args:  []any{"one", "three"},
+			vals: [][]any{
 				{"one", 1.1, "three"},
 				{"one", 2.2, "three"},
 				{"one", 3.3, "three"},
@@ -922,9 +920,9 @@ func TestSelectColumns(t *testing.T) {
 		{
 			query: `select (:v1, two, :v2) from tree`,
 			cols:  []string{"", "two", ""},
-			types: []interface{}{"", 0.0, ""},
-			args:  []interface{}{"one", "three"},
-			vals: [][]eface{
+			types: []any{"", 0.0, ""},
+			args:  []any{"one", "three"},
+			vals: [][]any{
 				{"one", 1.1, "three"},
 				{"one", 2.2, "three"},
 				{"one", 3.3, "three"},
@@ -934,9 +932,9 @@ func TestSelectColumns(t *testing.T) {
 		{
 			query: `select (:v2, two, :v1) from tree`,
 			cols:  []string{"", "two", ""},
-			types: []interface{}{"", 0.0, ""},
-			args:  []interface{}{"three", "one"},
-			vals: [][]eface{
+			types: []any{"", 0.0, ""},
+			args:  []any{"three", "one"},
+			vals: [][]any{
 				{"one", 1.1, "three"},
 				{"one", 2.2, "three"},
 				{"one", 3.3, "three"},
@@ -946,9 +944,9 @@ func TestSelectColumns(t *testing.T) {
 		{
 			query: `select (:v2, two+:v3, :v1) from tree`,
 			cols:  []string{"", "", ""},
-			types: []interface{}{"", 0.0, ""},
-			args:  []interface{}{"three", "one", 10},
-			vals: [][]eface{
+			types: []any{"", 0.0, ""},
+			args:  []any{"three", "one", 10},
+			vals: [][]any{
 				{"one", 11.1, "three"},
 				{"one", 12.2, "three"},
 				{"one", 13.3, "three"},
@@ -958,8 +956,8 @@ func TestSelectColumns(t *testing.T) {
 		{
 			query: `select (one) from tree where (two > 3)`,
 			cols:  []string{"one"},
-			types: []interface{}{int32(0)},
-			vals: [][]eface{
+			types: []any{int32(0)},
+			vals: [][]any{
 				{int32(3)},
 				{int32(4)},
 			},
@@ -967,25 +965,25 @@ func TestSelectColumns(t *testing.T) {
 		{
 			query: `select (one) from tree where (3 <= two && two < 4)`,
 			cols:  []string{"one"},
-			types: []interface{}{int32(0)},
-			vals: [][]eface{
+			types: []any{int32(0)},
+			vals: [][]any{
 				{int32(3)},
 			},
 		},
 		{
 			query: `select (one, two) from tree where (three="quatro")`,
 			cols:  []string{"one", "two"},
-			types: []interface{}{int32(0), 0.0},
-			vals: [][]eface{
+			types: []any{int32(0), 0.0},
+			vals: [][]any{
 				{int32(4), 4.4},
 			},
 		},
 		{
 			query: `select (one, two, ?+:v2) from tree where (three="quatro")`,
 			cols:  []string{"one", "two", ""},
-			types: []interface{}{int32(0), 0.0, uint64(0)},
-			args:  []interface{}{idealUint(5), idealUint(10)},
-			vals: [][]eface{
+			types: []any{int32(0), 0.0, uint64(0)},
+			args:  []any{idealUint(5), idealUint(10)},
+			vals: [][]any{
 				{int32(4), 4.4, uint64(15)},
 			},
 		},
@@ -1006,9 +1004,9 @@ func TestSelectColumns(t *testing.T) {
 				t.Fatalf("invalid columns.\ngot= %q\nwant=%q", got, want)
 			}
 
-			var got [][]eface
+			var got [][]any
 			for rows.Next() {
-				vars := make([]interface{}, len(tc.types))
+				vars := make([]any, len(tc.types))
 				for i, v := range tc.types {
 					vars[i] = reflect.New(reflect.TypeOf(v)).Interface()
 				}
@@ -1016,7 +1014,7 @@ func TestSelectColumns(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				row := make([]eface, len(vars))
+				row := make([]any, len(vars))
 				for i, v := range vars {
 					row[i] = reflect.Indirect(reflect.ValueOf(v)).Interface()
 				}

--- a/groot/rsql/rsqldrv/types.go
+++ b/groot/rsql/rsqldrv/types.go
@@ -18,7 +18,7 @@ type (
 	idealUint  uint64
 )
 
-func coerce(a, b interface{}) (x, y interface{}) {
+func coerce(a, b any) (x, y any) {
 	if reflect.TypeOf(a) == reflect.TypeOf(b) {
 		return a, b
 	}
@@ -46,7 +46,7 @@ func coerce(a, b interface{}) (x, y interface{}) {
 	}
 }
 
-func coerce1(inVal, otherVal interface{}) (coercedInVal interface{}) {
+func coerce1(inVal, otherVal any) (coercedInVal any) {
 	coercedInVal = inVal
 	if otherVal == nil {
 		return

--- a/groot/rsql/rsqldrv/types_test.go
+++ b/groot/rsql/rsqldrv/types_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestCoerce(t *testing.T) {
 	for _, tc := range []struct {
-		v1, v2 interface{}
-		w1, w2 interface{}
+		v1, v2 any
+		w1, w2 any
 	}{
 		{
 			v1: int32(0),
@@ -79,8 +79,8 @@ func TestCoerce(t *testing.T) {
 
 func TestCoerce1(t *testing.T) {
 	for _, tc := range []struct {
-		v1, v2 interface{}
-		want   interface{}
+		v1, v2 any
+		want   any
 	}{
 		{
 			v1:   nil,

--- a/groot/rsql/scan.go
+++ b/groot/rsql/scan.go
@@ -18,7 +18,7 @@ import (
 
 // Scan executes a query against the given tree and runs the function f
 // within that context.
-func Scan(tree rtree.Tree, query string, f interface{}) error {
+func Scan(tree rtree.Tree, query string, f any) error {
 	if f == nil {
 		return fmt.Errorf("groot/rsql: nil func")
 	}
@@ -31,7 +31,7 @@ func Scan(tree rtree.Tree, query string, f interface{}) error {
 		return fmt.Errorf("groot/rsql: expected a func returning an error. got %T", f)
 	}
 	vargs := make([]reflect.Value, rt.NumIn())
-	args := make([]interface{}, rt.NumIn())
+	args := make([]any, rt.NumIn())
 	for i := range args {
 		ptr := reflect.New(rt.In(i))
 		args[i] = ptr.Interface()

--- a/groot/rsrv/plot.go
+++ b/groot/rsrv/plot.go
@@ -53,7 +53,7 @@ func (srv *Server) render(p *hplot.Plot, opt PlotOptions) ([]byte, error) {
 
 type floats struct {
 	leaf rtree.Leaf
-	ptr  interface{}
+	ptr  any
 	vals func() []float64
 }
 

--- a/groot/rtree/basket.go
+++ b/groot/rtree/basket.go
@@ -143,10 +143,7 @@ func (b *Basket) MarshalROOT(w *rbytes.WBuffer) (int, error) {
 		}
 		if b.wbuf != nil && b.wbuf.Len() > 0 {
 			raw := b.wbuf.Bytes()
-			n := b.last
-			if len(raw) < n {
-				n = len(raw)
-			}
+			n := min(len(raw), b.last)
 			_, err := w.Write(raw[:n])
 			if err != nil {
 				return int(w.Pos() - beg), err
@@ -281,10 +278,7 @@ func (b *Basket) update(offset int64) {
 	offset += int64(b.key.KeyLen())
 	if len(b.offsets) > 0 {
 		if b.nevbuf+1 >= b.nevsize {
-			nevsize := 10
-			if nevsize < 2*b.nevsize {
-				nevsize = 2 * b.nevsize
-			}
+			nevsize := max(10, 2*b.nevsize)
 			b.nevsize = nevsize
 			delta := len(b.offsets) - nevsize
 			if delta < 0 {

--- a/groot/rtree/bkreader.go
+++ b/groot/rtree/bkreader.go
@@ -90,7 +90,7 @@ func newBkReader(b Branch, n int, beg, end int64) *bkreader {
 		}
 	}
 
-	for i := 0; i < n; i++ {
+	for range n {
 		bkr.reuse <- bkReq{bkt: new(rbasket), err: nil}
 	}
 

--- a/groot/rtree/branch.go
+++ b/groot/rtree/branch.go
@@ -244,10 +244,7 @@ func (b *tbranch) MarshalROOT(w *rbytes.WBuffer) (int, error) {
 
 	maxBaskets := b.maxBaskets
 	defer func() { b.maxBaskets = maxBaskets }()
-	b.maxBaskets = b.writeBasket + 1
-	if b.maxBaskets < defaultMaxBaskets {
-		b.maxBaskets = defaultMaxBaskets
-	}
+	b.maxBaskets = max(b.writeBasket+1, defaultMaxBaskets)
 
 	hdr := w.WriteHeader(b.Class(), b.RVersion())
 	w.WriteObject(&b.named)
@@ -1117,7 +1114,7 @@ func btopOf(b Branch) Branch {
 		return nil
 	}
 	const max = 1<<31 - 1
-	for i := 0; i < max; i++ {
+	for range max {
 		switch bb := b.(type) {
 		case *tbranch:
 			if bb.bup == nil {

--- a/groot/rtree/chain_test.go
+++ b/groot/rtree/chain_test.go
@@ -199,12 +199,9 @@ func TestChain(t *testing.T) {
 			}
 			{
 				brs := chain.Branches()
-				n := len(tc.brs)
-				if len(brs) < n {
-					n = len(brs)
-				}
+				n := min(len(brs), len(tc.brs))
 
-				for i := 0; i < n; i++ {
+				for i := range n {
 					if got, want := brs[i].Name(), tc.brs[i]; got != want {
 						t.Fatalf("invalid branch name[%d]: got=%q, want=%q", i, got, want)
 					}
@@ -231,12 +228,9 @@ func TestChain(t *testing.T) {
 			}
 			{
 				lvs := chain.Leaves()
-				n := len(tc.lvs)
-				if len(lvs) < n {
-					n = len(lvs)
-				}
+				n := min(len(lvs), len(tc.lvs))
 
-				for i := 0; i < n; i++ {
+				for i := range n {
 					if got, want := lvs[i].Name(), tc.lvs[i]; got != want {
 						t.Fatalf("invalid leaf name[%d]: got=%q, want=%q", i, got, want)
 					}
@@ -411,7 +405,7 @@ func TestChainReaderStruct(t *testing.T) {
 			evt.StlVecF64 = make([]float64, int(evt.N))
 			evt.StlVecStr = make([]string, int(evt.N))
 		}
-		for ii := 0; ii < int(evt.N); ii++ {
+		for ii := range int(evt.N) {
 			evt.SliF64[ii] = float64(i)
 			evt.StlVecF64[ii] = float64(i)
 			evt.StlVecStr[ii] = fmt.Sprintf("vec-%03d", i)

--- a/groot/rtree/formula.go
+++ b/groot/rtree/formula.go
@@ -16,7 +16,7 @@ func newFormula(r *Reader, f rfunc.Formula) (rfunc.Formula, error) {
 	if len(rvs) != len(names) {
 		return nil, fmt.Errorf("rtree: could not find all needed ReadVars (missing: %v)", missing)
 	}
-	args := make([]interface{}, len(rvs))
+	args := make([]any, len(rvs))
 	for i, rv := range rvs {
 		args[i] = rv.Value
 	}

--- a/groot/rtree/formula_test.go
+++ b/groot/rtree/formula_test.go
@@ -19,9 +19,9 @@ func TestFormulaFunc(t *testing.T) {
 		fname    string
 		tname    string
 		rvars    int
-		fct      interface{}
+		fct      any
 		branches []string
-		want     []interface{}
+		want     []any
 		err      error
 	}{
 		{
@@ -30,7 +30,7 @@ func TestFormulaFunc(t *testing.T) {
 			rvars:    -1,
 			fct:      func(x int32) int32 { return x },
 			branches: []string{"one"},
-			want:     []interface{}{int32(1), int32(2)},
+			want:     []any{int32(1), int32(2)},
 		},
 		{
 			fname: "../testdata/simple.root",
@@ -40,7 +40,7 @@ func TestFormulaFunc(t *testing.T) {
 				return float64(x1) + float64(x2*100)
 			},
 			branches: []string{"one", "two"},
-			want:     []interface{}{float64(111), float64(222)},
+			want:     []any{float64(111), float64(222)},
 		},
 		{
 			fname: "../testdata/simple.root",
@@ -50,7 +50,7 @@ func TestFormulaFunc(t *testing.T) {
 				return float64(x1) + float64(x2*100)
 			},
 			branches: []string{"one", "two"},
-			want:     []interface{}{float64(111), float64(222)},
+			want:     []any{float64(111), float64(222)},
 		},
 		{
 			fname: "../testdata/simple.root",
@@ -60,7 +60,7 @@ func TestFormulaFunc(t *testing.T) {
 				return float64(x1) + float64(x2*100)
 			},
 			branches: []string{"one", "two"},
-			want:     []interface{}{float64(111), float64(222)},
+			want:     []any{float64(111), float64(222)},
 		},
 		{
 			fname: "../testdata/simple.root",
@@ -70,7 +70,7 @@ func TestFormulaFunc(t *testing.T) {
 				return x1 * x1
 			},
 			branches: []string{"one"},
-			want:     []interface{}{int32(1), int32(4)},
+			want:     []any{int32(1), int32(4)},
 		},
 		{
 			fname: "../testdata/simple.root",
@@ -80,7 +80,7 @@ func TestFormulaFunc(t *testing.T) {
 				return math.Sqrt(float64(x1 * x1))
 			},
 			branches: []string{"one"},
-			want:     []interface{}{float64(1), float64(2)},
+			want:     []any{float64(1), float64(2)},
 		},
 		{
 			fname: "../testdata/simple.root",
@@ -90,7 +90,7 @@ func TestFormulaFunc(t *testing.T) {
 				return fmt.Sprintf("%d", x1)
 			},
 			branches: []string{"one"},
-			want:     []interface{}{"1", "2"},
+			want:     []any{"1", "2"},
 		},
 		{
 			fname: "../testdata/leaves.root",
@@ -100,7 +100,7 @@ func TestFormulaFunc(t *testing.T) {
 				return x
 			},
 			branches: []string{"ArrU64"},
-			want:     []interface{}{[10]uint64{}, [10]uint64{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}},
+			want:     []any{[10]uint64{}, [10]uint64{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}},
 		},
 		{
 			fname: "../testdata/leaves.root",
@@ -110,7 +110,7 @@ func TestFormulaFunc(t *testing.T) {
 				return x[0]
 			},
 			branches: []string{"ArrU64"},
-			want:     []interface{}{uint64(0), uint64(1)},
+			want:     []any{uint64(0), uint64(1)},
 		},
 		{
 			fname: "../testdata/leaves.root",
@@ -124,7 +124,7 @@ func TestFormulaFunc(t *testing.T) {
 				return o
 			},
 			branches: []string{"SliF32"},
-			want:     []interface{}{[]float64{}, []float64{2}},
+			want:     []any{[]float64{}, []float64{2}},
 		},
 		{
 			fname: "../testdata/small-evnt-tree-fullsplit.root",
@@ -138,7 +138,7 @@ func TestFormulaFunc(t *testing.T) {
 				return o
 			},
 			branches: []string{"evt.SliceF32"},
-			want:     []interface{}{[]float64{}, []float64{2}},
+			want:     []any{[]float64{}, []float64{2}},
 		},
 		{
 			fname: "../testdata/small-evnt-tree-fullsplit.root",
@@ -152,7 +152,7 @@ func TestFormulaFunc(t *testing.T) {
 				return o
 			},
 			branches: []string{"evt.StlVecF32"},
-			want:     []interface{}{[]float64{}, []float64{2}},
+			want:     []any{[]float64{}, []float64{2}},
 		},
 		{
 			fname: "../testdata/embedded-std-vector.root",
@@ -166,7 +166,7 @@ func TestFormulaFunc(t *testing.T) {
 				return o
 			},
 			branches: []string{"hits_time_mc"},
-			want: []interface{}{
+			want: []any{
 				[]float64{
 					24.412797927856445, 23.422243118286133,
 					23.469839096069336, 24.914079666137695,
@@ -192,7 +192,7 @@ func TestFormulaFunc(t *testing.T) {
 				return x
 			},
 			branches: []string{"D16"},
-			want:     []interface{}{root.Float16(0.0), root.Float16(1.0)},
+			want:     []any{root.Float16(0.0), root.Float16(1.0)},
 		},
 		{
 			fname: "../testdata/leaves.root",
@@ -202,7 +202,7 @@ func TestFormulaFunc(t *testing.T) {
 				return x
 			},
 			branches: []string{"D32"},
-			want:     []interface{}{root.Double32(0.0), root.Double32(1.0)},
+			want:     []any{root.Double32(0.0), root.Double32(1.0)},
 		},
 		{
 			fname: "../testdata/leaves.root",
@@ -212,7 +212,7 @@ func TestFormulaFunc(t *testing.T) {
 				return x[0]
 			},
 			branches: []string{"ArrD32"},
-			want:     []interface{}{root.Double32(0), root.Double32(1)},
+			want:     []any{root.Double32(0), root.Double32(1)},
 		},
 		{
 			fname: "../testdata/leaves.root",
@@ -222,7 +222,7 @@ func TestFormulaFunc(t *testing.T) {
 				return float64(x1) + float64(len(x2))
 			},
 			branches: []string{"D32", "SliI64"},
-			want:     []interface{}{0.0, 2.0},
+			want:     []any{0.0, 2.0},
 		},
 		{
 			fname: "../testdata/leaves.root",
@@ -232,7 +232,7 @@ func TestFormulaFunc(t *testing.T) {
 				return 42.0
 			},
 			branches: nil,
-			want:     []interface{}{42.0, 42.0},
+			want:     []any{42.0, 42.0},
 		},
 		{
 			fname:    "../testdata/leaves.root",
@@ -240,7 +240,7 @@ func TestFormulaFunc(t *testing.T) {
 			rvars:    -1,
 			fct:      func(v bool) bool { return v },
 			branches: []string{"B"},
-			want:     []interface{}{true, false},
+			want:     []any{true, false},
 		},
 		{
 			fname:    "../testdata/leaves.root",
@@ -248,7 +248,7 @@ func TestFormulaFunc(t *testing.T) {
 			rvars:    -1,
 			fct:      func(v int8) int8 { return v },
 			branches: []string{"I8"},
-			want:     []interface{}{int8(0), int8(-1)},
+			want:     []any{int8(0), int8(-1)},
 		},
 		{
 			fname:    "../testdata/leaves.root",
@@ -256,7 +256,7 @@ func TestFormulaFunc(t *testing.T) {
 			rvars:    -1,
 			fct:      func(v int16) int16 { return v },
 			branches: []string{"I16"},
-			want:     []interface{}{int16(0), int16(-1)},
+			want:     []any{int16(0), int16(-1)},
 		},
 		{
 			fname:    "../testdata/leaves.root",
@@ -264,7 +264,7 @@ func TestFormulaFunc(t *testing.T) {
 			rvars:    -1,
 			fct:      func(v int32) int32 { return v },
 			branches: []string{"I32"},
-			want:     []interface{}{int32(0), int32(-1)},
+			want:     []any{int32(0), int32(-1)},
 		},
 		{
 			fname:    "../testdata/leaves.root",
@@ -272,7 +272,7 @@ func TestFormulaFunc(t *testing.T) {
 			rvars:    -1,
 			fct:      func(v int64) int64 { return v },
 			branches: []string{"I64"},
-			want:     []interface{}{int64(0), int64(-1)},
+			want:     []any{int64(0), int64(-1)},
 		},
 		{
 			fname:    "../testdata/leaves.root",
@@ -280,7 +280,7 @@ func TestFormulaFunc(t *testing.T) {
 			rvars:    -1,
 			fct:      func(v uint8) uint8 { return v },
 			branches: []string{"U8"},
-			want:     []interface{}{uint8(0), uint8(1)},
+			want:     []any{uint8(0), uint8(1)},
 		},
 		{
 			fname:    "../testdata/leaves.root",
@@ -288,7 +288,7 @@ func TestFormulaFunc(t *testing.T) {
 			rvars:    -1,
 			fct:      func(v uint16) uint16 { return v },
 			branches: []string{"U16"},
-			want:     []interface{}{uint16(0), uint16(1)},
+			want:     []any{uint16(0), uint16(1)},
 		},
 		{
 			fname:    "../testdata/leaves.root",
@@ -296,7 +296,7 @@ func TestFormulaFunc(t *testing.T) {
 			rvars:    -1,
 			fct:      func(v uint32) uint32 { return v },
 			branches: []string{"U32"},
-			want:     []interface{}{uint32(0), uint32(1)},
+			want:     []any{uint32(0), uint32(1)},
 		},
 		{
 			fname:    "../testdata/leaves.root",
@@ -304,7 +304,7 @@ func TestFormulaFunc(t *testing.T) {
 			rvars:    -1,
 			fct:      func(v uint64) uint64 { return v },
 			branches: []string{"U64"},
-			want:     []interface{}{uint64(0), uint64(1)},
+			want:     []any{uint64(0), uint64(1)},
 		},
 		{
 			fname:    "../testdata/leaves.root",
@@ -312,7 +312,7 @@ func TestFormulaFunc(t *testing.T) {
 			rvars:    -1,
 			fct:      func(v float32) float32 { return v },
 			branches: []string{"F32"},
-			want:     []interface{}{float32(0), float32(1)},
+			want:     []any{float32(0), float32(1)},
 		},
 		{
 			fname:    "../testdata/leaves.root",
@@ -320,7 +320,7 @@ func TestFormulaFunc(t *testing.T) {
 			rvars:    -1,
 			fct:      func(v float64) float64 { return v },
 			branches: []string{"F64"},
-			want:     []interface{}{float64(0), float64(1)},
+			want:     []any{float64(0), float64(1)},
 		},
 		{
 			fname:    "../testdata/leaves.root",
@@ -328,7 +328,7 @@ func TestFormulaFunc(t *testing.T) {
 			rvars:    -1,
 			fct:      func(v string) string { return v },
 			branches: []string{"Str"},
-			want:     []interface{}{"str-0", "str-1"},
+			want:     []any{"str-0", "str-1"},
 		},
 		{
 			fname:    "../testdata/leaves.root",
@@ -336,7 +336,7 @@ func TestFormulaFunc(t *testing.T) {
 			rvars:    -1,
 			fct:      func(v string) [1]string { return [1]string{v} },
 			branches: []string{"Str"},
-			want:     []interface{}{[1]string{"str-0"}, [1]string{"str-1"}},
+			want:     []any{[1]string{"str-0"}, [1]string{"str-1"}},
 		},
 		{
 			fname:    "../testdata/simple.root",
@@ -466,7 +466,7 @@ var sumBenchFormulaFunc float64
 func BenchmarkFormulaFunc(b *testing.B) {
 	for _, tc := range []struct {
 		name string
-		fct  interface{}
+		fct  any
 		brs  []string
 	}{
 		{

--- a/groot/rtree/join_test.go
+++ b/groot/rtree/join_test.go
@@ -337,12 +337,9 @@ func TestJoin(t *testing.T) {
 			}
 			{
 				rvars := NewReadVars(tree)
-				n := len(tc.rvars)
-				if len(rvars) < n {
-					n = len(rvars)
-				}
+				n := min(len(rvars), len(tc.rvars))
 
-				for i := 0; i < n; i++ {
+				for i := range n {
 					got := rvars[i]
 					want := tc.rvars[i]
 					if got.Name != want.Name {
@@ -362,12 +359,9 @@ func TestJoin(t *testing.T) {
 			}
 			{
 				brs := tree.Branches()
-				n := len(tc.brs)
-				if len(brs) < n {
-					n = len(brs)
-				}
+				n := min(len(brs), len(tc.brs))
 
-				for i := 0; i < n; i++ {
+				for i := range n {
 					if got, want := brs[i].Name(), tc.brs[i]; got != want {
 						t.Fatalf("invalid branch name[%d]: got=%q, want=%q", i, got, want)
 					}
@@ -392,12 +386,9 @@ func TestJoin(t *testing.T) {
 			}
 			{
 				lvs := tree.Leaves()
-				n := len(tc.lvs)
-				if len(lvs) < n {
-					n = len(lvs)
-				}
+				n := min(len(lvs), len(tc.lvs))
 
-				for i := 0; i < n; i++ {
+				for i := range n {
 					if got, want := lvs[i].Name(), tc.lvs[i]; got != want {
 						t.Fatalf("invalid leaf name[%d]: got=%q, want=%q", i, got, want)
 					}

--- a/groot/rtree/leaf.go
+++ b/groot/rtree/leaf.go
@@ -136,7 +136,7 @@ func (leaf *tleaf) readFromBuffer(r *rbytes.RBuffer) error {
 	panic("not implemented: " + leaf.Name())
 }
 
-func (leaf *tleaf) setAddress(ptr interface{}) error {
+func (leaf *tleaf) setAddress(ptr any) error {
 	panic("not implemented: " + leaf.Name())
 }
 
@@ -211,7 +211,7 @@ func (leaf *tleaf) computeOffsetArray(base, nevts int) []int32 {
 		sz            int
 		offset        = int32(base)
 	)
-	for i := 0; i < nevts; i++ {
+	for i := range nevts {
 		o[i] = offset
 		leaf.count.Branch().getEntry(origEntry + int64(i))
 		sz = leaf.count.ivalue()
@@ -292,7 +292,7 @@ type tleafElement struct {
 	id    int32 // element serial number in fInfo
 	ltype int32 // leaf type
 
-	ptr       interface{}
+	ptr       any
 	src       reflect.Value
 	rstreamer rbytes.RStreamer
 	wstreamer rbytes.WStreamer
@@ -377,7 +377,7 @@ func (leaf *tleafElement) readFromBuffer(r *rbytes.RBuffer) error {
 	return nil
 }
 
-func (leaf *tleafElement) setAddress(ptr interface{}) error {
+func (leaf *tleafElement) setAddress(ptr any) error {
 	leaf.ptr = ptr
 	leaf.src = reflect.ValueOf(leaf.ptr).Elem()
 
@@ -392,7 +392,7 @@ func (leaf *tleafElement) setAddress(ptr interface{}) error {
 	return fmt.Errorf("rtree: leaf %q is neither read nor write", leaf.Name())
 }
 
-func (leaf *tleafElement) setReadAddress(ptr interface{}) error {
+func (leaf *tleafElement) setReadAddress(ptr any) error {
 	err := leaf.rstreamer.(rbytes.Binder).Bind(ptr)
 	if err != nil {
 		return fmt.Errorf("rtree: could not bind read-streamer for leaf=%q (type=%s) to ptr=%T: %w",
@@ -418,7 +418,7 @@ func (leaf *tleafElement) setReadAddress(ptr interface{}) error {
 	return nil
 }
 
-func (leaf *tleafElement) setWriteAddress(ptr interface{}) error {
+func (leaf *tleafElement) setWriteAddress(ptr any) error {
 	err := leaf.wstreamer.(rbytes.Binder).Bind(ptr)
 	if err != nil {
 		return fmt.Errorf("rtree: could not bind write-streamer for leaf=%q (type=%s) to ptr=%T: %w",
@@ -475,7 +475,7 @@ func (leaf *tleafElement) computeOffsetArray(base, nevts int) []int32 {
 		sz            int
 		offset        = int32(base)
 	)
-	for i := 0; i < nevts; i++ {
+	for i := range nevts {
 		o[i] = offset
 		leaf.count.Branch().getEntry(origEntry + int64(i))
 		sz = leaf.count.ivalue()

--- a/groot/rtree/leaf_gen.go
+++ b/groot/rtree/leaf_gen.go
@@ -129,14 +129,14 @@ func (leaf *LeafO) readFromBuffer(r *rbytes.RBuffer) error {
 	return r.Err()
 }
 
-func (leaf *LeafO) unsafeDecayArray(ptr interface{}) interface{} {
+func (leaf *LeafO) unsafeDecayArray(ptr any) any {
 	rv := reflect.ValueOf(ptr).Elem()
 	sz := rv.Type().Size() / 1
 	sli := unsafe.Slice((*bool)(unsafe.Pointer(rv.UnsafeAddr())), sz)
 	return &sli
 }
 
-func (leaf *LeafO) setAddress(ptr interface{}) error {
+func (leaf *LeafO) setAddress(ptr any) error {
 	if ptr == nil {
 		return leaf.setAddress(newValue(leaf))
 	}
@@ -336,14 +336,14 @@ func (leaf *LeafB) readFromBuffer(r *rbytes.RBuffer) error {
 	return r.Err()
 }
 
-func (leaf *LeafB) unsafeDecayArray(ptr interface{}) interface{} {
+func (leaf *LeafB) unsafeDecayArray(ptr any) any {
 	rv := reflect.ValueOf(ptr).Elem()
 	sz := rv.Type().Size() / 1
 	sli := unsafe.Slice((*int8)(unsafe.Pointer(rv.UnsafeAddr())), sz)
 	return &sli
 }
 
-func (leaf *LeafB) setAddress(ptr interface{}) error {
+func (leaf *LeafB) setAddress(ptr any) error {
 	if ptr == nil {
 		return leaf.setAddress(newValue(leaf))
 	}
@@ -555,14 +555,14 @@ func (leaf *LeafS) readFromBuffer(r *rbytes.RBuffer) error {
 	return r.Err()
 }
 
-func (leaf *LeafS) unsafeDecayArray(ptr interface{}) interface{} {
+func (leaf *LeafS) unsafeDecayArray(ptr any) any {
 	rv := reflect.ValueOf(ptr).Elem()
 	sz := rv.Type().Size() / 2
 	sli := unsafe.Slice((*int16)(unsafe.Pointer(rv.UnsafeAddr())), sz)
 	return &sli
 }
 
-func (leaf *LeafS) setAddress(ptr interface{}) error {
+func (leaf *LeafS) setAddress(ptr any) error {
 	if ptr == nil {
 		return leaf.setAddress(newValue(leaf))
 	}
@@ -774,14 +774,14 @@ func (leaf *LeafI) readFromBuffer(r *rbytes.RBuffer) error {
 	return r.Err()
 }
 
-func (leaf *LeafI) unsafeDecayArray(ptr interface{}) interface{} {
+func (leaf *LeafI) unsafeDecayArray(ptr any) any {
 	rv := reflect.ValueOf(ptr).Elem()
 	sz := rv.Type().Size() / 4
 	sli := unsafe.Slice((*int32)(unsafe.Pointer(rv.UnsafeAddr())), sz)
 	return &sli
 }
 
-func (leaf *LeafI) setAddress(ptr interface{}) error {
+func (leaf *LeafI) setAddress(ptr any) error {
 	if ptr == nil {
 		return leaf.setAddress(newValue(leaf))
 	}
@@ -993,14 +993,14 @@ func (leaf *LeafL) readFromBuffer(r *rbytes.RBuffer) error {
 	return r.Err()
 }
 
-func (leaf *LeafL) unsafeDecayArray(ptr interface{}) interface{} {
+func (leaf *LeafL) unsafeDecayArray(ptr any) any {
 	rv := reflect.ValueOf(ptr).Elem()
 	sz := rv.Type().Size() / 8
 	sli := unsafe.Slice((*int64)(unsafe.Pointer(rv.UnsafeAddr())), sz)
 	return &sli
 }
 
-func (leaf *LeafL) setAddress(ptr interface{}) error {
+func (leaf *LeafL) setAddress(ptr any) error {
 	if ptr == nil {
 		return leaf.setAddress(newValue(leaf))
 	}
@@ -1212,14 +1212,14 @@ func (leaf *LeafG) readFromBuffer(r *rbytes.RBuffer) error {
 	return r.Err()
 }
 
-func (leaf *LeafG) unsafeDecayArray(ptr interface{}) interface{} {
+func (leaf *LeafG) unsafeDecayArray(ptr any) any {
 	rv := reflect.ValueOf(ptr).Elem()
 	sz := rv.Type().Size() / 8
 	sli := unsafe.Slice((*int64)(unsafe.Pointer(rv.UnsafeAddr())), sz)
 	return &sli
 }
 
-func (leaf *LeafG) setAddress(ptr interface{}) error {
+func (leaf *LeafG) setAddress(ptr any) error {
 	if ptr == nil {
 		return leaf.setAddress(newValue(leaf))
 	}
@@ -1411,14 +1411,14 @@ func (leaf *LeafF) readFromBuffer(r *rbytes.RBuffer) error {
 	return r.Err()
 }
 
-func (leaf *LeafF) unsafeDecayArray(ptr interface{}) interface{} {
+func (leaf *LeafF) unsafeDecayArray(ptr any) any {
 	rv := reflect.ValueOf(ptr).Elem()
 	sz := rv.Type().Size() / 4
 	sli := unsafe.Slice((*float32)(unsafe.Pointer(rv.UnsafeAddr())), sz)
 	return &sli
 }
 
-func (leaf *LeafF) setAddress(ptr interface{}) error {
+func (leaf *LeafF) setAddress(ptr any) error {
 	if ptr == nil {
 		return leaf.setAddress(newValue(leaf))
 	}
@@ -1601,14 +1601,14 @@ func (leaf *LeafD) readFromBuffer(r *rbytes.RBuffer) error {
 	return r.Err()
 }
 
-func (leaf *LeafD) unsafeDecayArray(ptr interface{}) interface{} {
+func (leaf *LeafD) unsafeDecayArray(ptr any) any {
 	rv := reflect.ValueOf(ptr).Elem()
 	sz := rv.Type().Size() / 8
 	sli := unsafe.Slice((*float64)(unsafe.Pointer(rv.UnsafeAddr())), sz)
 	return &sli
 }
 
-func (leaf *LeafD) setAddress(ptr interface{}) error {
+func (leaf *LeafD) setAddress(ptr any) error {
 	if ptr == nil {
 		return leaf.setAddress(newValue(leaf))
 	}
@@ -1802,14 +1802,14 @@ func (leaf *LeafF16) readFromBuffer(r *rbytes.RBuffer) error {
 	return r.Err()
 }
 
-func (leaf *LeafF16) unsafeDecayArray(ptr interface{}) interface{} {
+func (leaf *LeafF16) unsafeDecayArray(ptr any) any {
 	rv := reflect.ValueOf(ptr).Elem()
 	sz := rv.Type().Size() / 4
 	sli := unsafe.Slice((*root.Float16)(unsafe.Pointer(rv.UnsafeAddr())), sz)
 	return &sli
 }
 
-func (leaf *LeafF16) setAddress(ptr interface{}) error {
+func (leaf *LeafF16) setAddress(ptr any) error {
 	if ptr == nil {
 		return leaf.setAddress(newValue(leaf))
 	}
@@ -2003,14 +2003,14 @@ func (leaf *LeafD32) readFromBuffer(r *rbytes.RBuffer) error {
 	return r.Err()
 }
 
-func (leaf *LeafD32) unsafeDecayArray(ptr interface{}) interface{} {
+func (leaf *LeafD32) unsafeDecayArray(ptr any) any {
 	rv := reflect.ValueOf(ptr).Elem()
 	sz := rv.Type().Size() / 8
 	sli := unsafe.Slice((*root.Double32)(unsafe.Pointer(rv.UnsafeAddr())), sz)
 	return &sli
 }
 
-func (leaf *LeafD32) setAddress(ptr interface{}) error {
+func (leaf *LeafD32) setAddress(ptr any) error {
 	if ptr == nil {
 		return leaf.setAddress(newValue(leaf))
 	}
@@ -2193,14 +2193,14 @@ func (leaf *LeafC) readFromBuffer(r *rbytes.RBuffer) error {
 	return r.Err()
 }
 
-func (leaf *LeafC) unsafeDecayArray(ptr interface{}) interface{} {
+func (leaf *LeafC) unsafeDecayArray(ptr any) any {
 	rv := reflect.ValueOf(ptr).Elem()
 	sz := rv.Type().Size() / 16
 	sli := unsafe.Slice((*string)(unsafe.Pointer(rv.UnsafeAddr())), sz)
 	return &sli
 }
 
-func (leaf *LeafC) setAddress(ptr interface{}) error {
+func (leaf *LeafC) setAddress(ptr any) error {
 	if ptr == nil {
 		return leaf.setAddress(newValue(leaf))
 	}

--- a/groot/rtree/leaf_test.go
+++ b/groot/rtree/leaf_test.go
@@ -57,7 +57,7 @@ func TestLeafReadWriteBasket(t *testing.T) {
 	for _, tc := range []struct {
 		leaf Leaf
 		lcnt Leaf
-		data interface{}
+		data any
 	}{
 		{
 			leaf: newLeafO(br, "BoolTrue", nil, signed, nil),
@@ -465,7 +465,7 @@ func TestLeafAPI(t *testing.T) {
 		typ      reflect.Type
 		class    string
 		typename string
-		ptrs     []interface{}
+		ptrs     []any
 	}{
 		{
 			leaf:     newLeafO(b, "leaf", shape, unsigned, count),
@@ -478,7 +478,7 @@ func TestLeafAPI(t *testing.T) {
 			typ:      reflect.TypeOf(false),
 			class:    "TLeafO",
 			typename: "bool",
-			ptrs: []interface{}{
+			ptrs: []any{
 				new(bool),
 				&[]bool{},
 				&[1][2][3][4][5]bool{},
@@ -495,7 +495,7 @@ func TestLeafAPI(t *testing.T) {
 			typ:      reflect.TypeOf(uint8(0)),
 			class:    "TLeafB",
 			typename: "uint8",
-			ptrs: []interface{}{
+			ptrs: []any{
 				new(int8),
 				&[]int8{},
 				&[1][2][3][4][5]int8{},
@@ -515,7 +515,7 @@ func TestLeafAPI(t *testing.T) {
 			typ:      reflect.TypeOf(int8(0)),
 			class:    "TLeafB",
 			typename: "int8",
-			ptrs: []interface{}{
+			ptrs: []any{
 				new(int8),
 				&[]int8{},
 				&[1][2][3][4][5]int8{},
@@ -535,7 +535,7 @@ func TestLeafAPI(t *testing.T) {
 			typ:      reflect.TypeOf(uint16(0)),
 			class:    "TLeafS",
 			typename: "uint16",
-			ptrs: []interface{}{
+			ptrs: []any{
 				new(int16),
 				&[]int16{},
 				&[1][2][3][4][5]int16{},
@@ -555,7 +555,7 @@ func TestLeafAPI(t *testing.T) {
 			typ:      reflect.TypeOf(int16(0)),
 			class:    "TLeafS",
 			typename: "int16",
-			ptrs: []interface{}{
+			ptrs: []any{
 				new(int16),
 				&[]int16{},
 				&[1][2][3][4][5]int16{},
@@ -575,7 +575,7 @@ func TestLeafAPI(t *testing.T) {
 			typ:      reflect.TypeOf(uint32(0)),
 			class:    "TLeafI",
 			typename: "uint32",
-			ptrs: []interface{}{
+			ptrs: []any{
 				new(int32),
 				&[]int32{},
 				&[1][2][3][4][5]int32{},
@@ -595,7 +595,7 @@ func TestLeafAPI(t *testing.T) {
 			typ:      reflect.TypeOf(int32(0)),
 			class:    "TLeafI",
 			typename: "int32",
-			ptrs: []interface{}{
+			ptrs: []any{
 				new(int32),
 				&[]int32{},
 				&[1][2][3][4][5]int32{},
@@ -615,7 +615,7 @@ func TestLeafAPI(t *testing.T) {
 			typ:      reflect.TypeOf(uint64(0)),
 			class:    "TLeafL",
 			typename: "uint64",
-			ptrs: []interface{}{
+			ptrs: []any{
 				new(int64),
 				&[]int64{},
 				&[1][2][3][4][5]int64{},
@@ -635,7 +635,7 @@ func TestLeafAPI(t *testing.T) {
 			typ:      reflect.TypeOf(int64(0)),
 			class:    "TLeafL",
 			typename: "int64",
-			ptrs: []interface{}{
+			ptrs: []any{
 				new(int64),
 				&[]int64{},
 				&[1][2][3][4][5]int64{},
@@ -655,7 +655,7 @@ func TestLeafAPI(t *testing.T) {
 			typ:      reflect.TypeOf(float32(0)),
 			class:    "TLeafF",
 			typename: "float32",
-			ptrs: []interface{}{
+			ptrs: []any{
 				new(float32),
 				&[]float32{},
 				&[1][2][3][4][5]float32{},
@@ -672,7 +672,7 @@ func TestLeafAPI(t *testing.T) {
 			typ:      reflect.TypeOf(float64(0)),
 			class:    "TLeafD",
 			typename: "float64",
-			ptrs: []interface{}{
+			ptrs: []any{
 				new(float64),
 				&[]float64{},
 				&[1][2][3][4][5]float64{},
@@ -689,7 +689,7 @@ func TestLeafAPI(t *testing.T) {
 			typ:      reflect.TypeOf(root.Float16(0)),
 			class:    "TLeafF16",
 			typename: "root.Float16",
-			ptrs: []interface{}{
+			ptrs: []any{
 				new(root.Float16),
 				&[]root.Float16{},
 				&[1][2][3][4][5]root.Float16{},
@@ -706,7 +706,7 @@ func TestLeafAPI(t *testing.T) {
 			typ:      reflect.TypeOf(root.Double32(0)),
 			class:    "TLeafD32",
 			typename: "root.Double32",
-			ptrs: []interface{}{
+			ptrs: []any{
 				new(root.Double32),
 				&[]root.Double32{},
 				&[1][2][3][4][5]root.Double32{},
@@ -723,7 +723,7 @@ func TestLeafAPI(t *testing.T) {
 			typ:      reflect.TypeOf(""),
 			class:    "TLeafC",
 			typename: "string",
-			ptrs: []interface{}{
+			ptrs: []any{
 				new(string),
 				&[]string{},
 				&[1][2][3][4][5]string{},

--- a/groot/rtree/reader.go
+++ b/groot/rtree/reader.go
@@ -167,7 +167,7 @@ func (r *Reader) Reset(opts ...ReadOption) error {
 
 // FormulaFunc creates a new formula based on the provided function and
 // the list of branches as inputs.
-func (r *Reader) FormulaFunc(branches []string, fct interface{}) (rfunc.Formula, error) {
+func (r *Reader) FormulaFunc(branches []string, fct any) (rfunc.Formula, error) {
 	f, err := rfunc.NewGenericFormula(branches, fct)
 	if err != nil {
 		return nil, fmt.Errorf("rtree: could not create formula: %w", err)
@@ -284,7 +284,7 @@ func newRTree(t *ttree, rvars []ReadVar, n int, beg, end int64) *rtree {
 		leaf := t.Branch(rvar.Name).Leaf(rvar.Leaf).LeafCount()
 		name := leaf.Branch().Name() + "." + leaf.Name()
 		if _, ok := usr[name]; !ok {
-			var ptr interface{}
+			var ptr any
 			switch leaf := leaf.(type) {
 			case *LeafB:
 				ptr = new(int8)

--- a/groot/rtree/reader_example_test.go
+++ b/groot/rtree/reader_example_test.go
@@ -293,7 +293,7 @@ var (
 )
 
 func (usr *UsrF64) RVars() []string { return usr.rvars }
-func (usr *UsrF64) Bind(args []interface{}) error {
+func (usr *UsrF64) Bind(args []any) error {
 	if got, want := len(args), 3; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -306,7 +306,7 @@ func (usr *UsrF64) Bind(args []interface{}) error {
 	return nil
 }
 
-func (usr *UsrF64) Func() interface{} {
+func (usr *UsrF64) Func() any {
 	return func() float64 {
 		return usr.fct(*usr.v1, *usr.v2, *usr.v3)
 	}
@@ -325,7 +325,7 @@ var (
 )
 
 func (usr *UsrStr) RVars() []string { return usr.rvars }
-func (usr *UsrStr) Bind(args []interface{}) error {
+func (usr *UsrStr) Bind(args []any) error {
 	if got, want := len(args), 3; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -338,7 +338,7 @@ func (usr *UsrStr) Bind(args []interface{}) error {
 	return nil
 }
 
-func (usr *UsrStr) Func() interface{} {
+func (usr *UsrStr) Func() any {
 	return func() string {
 		return usr.fct(*usr.v1, *usr.v2, *usr.v3)
 	}

--- a/groot/rtree/reader_test.go
+++ b/groot/rtree/reader_test.go
@@ -255,7 +255,7 @@ func (ScannerData) want(i int64) (data ScannerData) {
 	data.SliF64 = make([]float64, int(data.N))
 	data.SliD16 = make([]root.Float16, int(data.N))
 	data.SliD32 = make([]root.Double32, int(data.N))
-	for ii := 0; ii < int(data.N); ii++ {
+	for ii := range int(data.N) {
 		data.SliBs[ii] = (ii + 1) == int(i)
 		data.SliI8[ii] = int8(-i)
 		data.SliI16[ii] = int16(-i)
@@ -392,7 +392,7 @@ func TestReaderVarsMultipleTimes(t *testing.T) {
 			}
 			tree := obj.(Tree)
 
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				var (
 					data  []float32
 					rvars = []ReadVar{
@@ -448,7 +448,7 @@ func TestReaderStructWithCounterLeaf(t *testing.T) {
 				var data Data
 				n := int32(i) % 10
 				data.Sli = make([]int32, int(n))
-				for ii := 0; ii < int(n); ii++ {
+				for ii := range int(n) {
 					data.Sli[ii] = int32(-i)
 				}
 				return data
@@ -502,7 +502,7 @@ func TestReaderVarsWithCounterLeaf(t *testing.T) {
 			want := func(i int64) []int32 {
 				n := int32(i) % 10
 				data := make([]int32, int(n))
-				for ii := 0; ii < int(n); ii++ {
+				for ii := range int(n) {
 					data[ii] = int32(-i)
 				}
 				return data
@@ -585,7 +585,7 @@ func TestScannerStructWithStdVectorBool(t *testing.T) {
 					data.SliBool = make([]bool, int(data.N))
 					data.StlBool = make([]bool, int(data.N))
 				}
-				for ii := 0; ii < int(data.N); ii++ {
+				for ii := range int(data.N) {
 					data.SliBool[ii] = i%2 == 0
 					data.StlBool[ii] = i%2 == 0
 				}
@@ -683,12 +683,9 @@ func TestNewReadVarsLeaves(t *testing.T) {
 		{Name: "SliD32", Leaf: "SliD32", Value: new([]root.Double32)},
 	}
 
-	n := len(want)
-	if len(vars) < n {
-		n = len(vars)
-	}
+	n := min(len(vars), len(want))
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		got := vars[i]
 		if got.Name != want[i].Name {
 			t.Fatalf("invalid read-var name[%d]: got=%q, want=%q", i, got.Name, want[i].Name)

--- a/groot/rtree/rfunc/rfunc.go
+++ b/groot/rtree/rfunc/rfunc.go
@@ -25,23 +25,23 @@ type Formula interface {
 	// Bind provides the arguments to the user function.
 	// ptrs is a slice of pointers to the rtree.ReadVars, in the same order
 	// than requested by RVars.
-	Bind(ptrs []interface{}) error
+	Bind(ptrs []any) error
 
 	// Func returns the user function closing on the bound pointer-to-arguments
 	// and returning the expected evaluated value.
-	Func() interface{}
+	Func() any
 }
 
 // NewGenericFormula returns a new formula from the provided list of needed
 // tree variables and the provided user function.
 // NewGenericFormula uses reflect to bind read-vars and the generic function.
-func NewGenericFormula(rvars []string, fct interface{}) (Formula, error) {
+func NewGenericFormula(rvars []string, fct any) (Formula, error) {
 	return newGenericFormula(rvars, fct)
 }
 
 type genericFormula struct {
 	names []string
-	fct   interface{}
+	fct   any
 
 	ptrs []reflect.Value
 	args []reflect.Value
@@ -51,7 +51,7 @@ type genericFormula struct {
 	ufct reflect.Value // user-provided function
 }
 
-func newGenericFormula(names []string, fct interface{}) (*genericFormula, error) {
+func newGenericFormula(names []string, fct any) (*genericFormula, error) {
 	rv := reflect.ValueOf(fct)
 	if rv.Kind() != reflect.Func {
 		return nil, fmt.Errorf("rfunc: formula expects a func")
@@ -93,7 +93,7 @@ func newGenericFormula(names []string, fct interface{}) (*genericFormula, error)
 }
 
 func (f *genericFormula) RVars() []string { return f.names }
-func (f *genericFormula) Bind(args []interface{}) error {
+func (f *genericFormula) Bind(args []any) error {
 	if got, want := len(args), len(f.ptrs); got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -128,7 +128,7 @@ func (f *genericFormula) eval() {
 	f.out = f.ufct.Call(f.args)
 }
 
-func (f *genericFormula) Func() interface{} {
+func (f *genericFormula) Func() any {
 	return f.rfct.Interface()
 }
 

--- a/groot/rtree/rfunc/rfunc_bool_gen.go
+++ b/groot/rtree/rfunc/rfunc_bool_gen.go
@@ -26,7 +26,7 @@ func NewFuncToBool(rvars []string, fct func() bool) *FuncToBool {
 func (f *FuncToBool) RVars() []string { return nil }
 
 // Bind implements rfunc.Formula
-func (f *FuncToBool) Bind(args []interface{}) error {
+func (f *FuncToBool) Bind(args []any) error {
 	if got, want := len(args), 0; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -37,7 +37,7 @@ func (f *FuncToBool) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncToBool) Func() interface{} {
+func (f *FuncToBool) Func() any {
 	return func() bool {
 		return f.fct()
 	}
@@ -66,7 +66,7 @@ func NewFuncF32ToBool(rvars []string, fct func(arg00 float32) bool) *FuncF32ToBo
 func (f *FuncF32ToBool) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncF32ToBool) Bind(args []interface{}) error {
+func (f *FuncF32ToBool) Bind(args []any) error {
 	if got, want := len(args), 1; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -87,7 +87,7 @@ func (f *FuncF32ToBool) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncF32ToBool) Func() interface{} {
+func (f *FuncF32ToBool) Func() any {
 	return func() bool {
 		return f.fct(
 			*f.arg0,
@@ -119,7 +119,7 @@ func NewFuncF32F32ToBool(rvars []string, fct func(arg00 float32, arg01 float32) 
 func (f *FuncF32F32ToBool) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncF32F32ToBool) Bind(args []interface{}) error {
+func (f *FuncF32F32ToBool) Bind(args []any) error {
 	if got, want := len(args), 2; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -150,7 +150,7 @@ func (f *FuncF32F32ToBool) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncF32F32ToBool) Func() interface{} {
+func (f *FuncF32F32ToBool) Func() any {
 	return func() bool {
 		return f.fct(
 			*f.arg0,
@@ -184,7 +184,7 @@ func NewFuncF32F32F32ToBool(rvars []string, fct func(arg00 float32, arg01 float3
 func (f *FuncF32F32F32ToBool) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncF32F32F32ToBool) Bind(args []interface{}) error {
+func (f *FuncF32F32F32ToBool) Bind(args []any) error {
 	if got, want := len(args), 3; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -225,7 +225,7 @@ func (f *FuncF32F32F32ToBool) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncF32F32F32ToBool) Func() interface{} {
+func (f *FuncF32F32F32ToBool) Func() any {
 	return func() bool {
 		return f.fct(
 			*f.arg0,
@@ -258,7 +258,7 @@ func NewFuncF64ToBool(rvars []string, fct func(arg00 float64) bool) *FuncF64ToBo
 func (f *FuncF64ToBool) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncF64ToBool) Bind(args []interface{}) error {
+func (f *FuncF64ToBool) Bind(args []any) error {
 	if got, want := len(args), 1; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -279,7 +279,7 @@ func (f *FuncF64ToBool) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncF64ToBool) Func() interface{} {
+func (f *FuncF64ToBool) Func() any {
 	return func() bool {
 		return f.fct(
 			*f.arg0,
@@ -311,7 +311,7 @@ func NewFuncF64F64ToBool(rvars []string, fct func(arg00 float64, arg01 float64) 
 func (f *FuncF64F64ToBool) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncF64F64ToBool) Bind(args []interface{}) error {
+func (f *FuncF64F64ToBool) Bind(args []any) error {
 	if got, want := len(args), 2; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -342,7 +342,7 @@ func (f *FuncF64F64ToBool) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncF64F64ToBool) Func() interface{} {
+func (f *FuncF64F64ToBool) Func() any {
 	return func() bool {
 		return f.fct(
 			*f.arg0,
@@ -376,7 +376,7 @@ func NewFuncF64F64F64ToBool(rvars []string, fct func(arg00 float64, arg01 float6
 func (f *FuncF64F64F64ToBool) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncF64F64F64ToBool) Bind(args []interface{}) error {
+func (f *FuncF64F64F64ToBool) Bind(args []any) error {
 	if got, want := len(args), 3; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -417,7 +417,7 @@ func (f *FuncF64F64F64ToBool) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncF64F64F64ToBool) Func() interface{} {
+func (f *FuncF64F64F64ToBool) Func() any {
 	return func() bool {
 		return f.fct(
 			*f.arg0,

--- a/groot/rtree/rfunc/rfunc_bool_gen_test.go
+++ b/groot/rtree/rfunc/rfunc_bool_gen_test.go
@@ -25,10 +25,10 @@ func TestFuncToBool(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	var ptrs []interface{}
+	var ptrs []any
 
 	{
-		bad := make([]interface{}, 1)
+		bad := make([]any, 1)
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -61,20 +61,20 @@ func TestFuncF32ToBool(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 1)
+	ptrs := make([]any, 1)
 	ptrs[0] = new(float32)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -108,21 +108,21 @@ func TestFuncF32F32ToBool(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 2)
+	ptrs := make([]any, 2)
 	ptrs[0] = new(float32)
 	ptrs[1] = new(float32)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -157,22 +157,22 @@ func TestFuncF32F32F32ToBool(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 3)
+	ptrs := make([]any, 3)
 	ptrs[0] = new(float32)
 	ptrs[1] = new(float32)
 	ptrs[2] = new(float32)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -205,20 +205,20 @@ func TestFuncF64ToBool(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 1)
+	ptrs := make([]any, 1)
 	ptrs[0] = new(float64)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -252,21 +252,21 @@ func TestFuncF64F64ToBool(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 2)
+	ptrs := make([]any, 2)
 	ptrs[0] = new(float64)
 	ptrs[1] = new(float64)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -301,22 +301,22 @@ func TestFuncF64F64F64ToBool(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 3)
+	ptrs := make([]any, 3)
 	ptrs[0] = new(float64)
 	ptrs[1] = new(float64)
 	ptrs[2] = new(float64)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")

--- a/groot/rtree/rfunc/rfunc_f32_gen.go
+++ b/groot/rtree/rfunc/rfunc_f32_gen.go
@@ -26,7 +26,7 @@ func NewFuncToF32(rvars []string, fct func() float32) *FuncToF32 {
 func (f *FuncToF32) RVars() []string { return nil }
 
 // Bind implements rfunc.Formula
-func (f *FuncToF32) Bind(args []interface{}) error {
+func (f *FuncToF32) Bind(args []any) error {
 	if got, want := len(args), 0; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -37,7 +37,7 @@ func (f *FuncToF32) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncToF32) Func() interface{} {
+func (f *FuncToF32) Func() any {
 	return func() float32 {
 		return f.fct()
 	}
@@ -66,7 +66,7 @@ func NewFuncF32ToF32(rvars []string, fct func(arg00 float32) float32) *FuncF32To
 func (f *FuncF32ToF32) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncF32ToF32) Bind(args []interface{}) error {
+func (f *FuncF32ToF32) Bind(args []any) error {
 	if got, want := len(args), 1; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -87,7 +87,7 @@ func (f *FuncF32ToF32) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncF32ToF32) Func() interface{} {
+func (f *FuncF32ToF32) Func() any {
 	return func() float32 {
 		return f.fct(
 			*f.arg0,
@@ -119,7 +119,7 @@ func NewFuncF32F32ToF32(rvars []string, fct func(arg00 float32, arg01 float32) f
 func (f *FuncF32F32ToF32) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncF32F32ToF32) Bind(args []interface{}) error {
+func (f *FuncF32F32ToF32) Bind(args []any) error {
 	if got, want := len(args), 2; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -150,7 +150,7 @@ func (f *FuncF32F32ToF32) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncF32F32ToF32) Func() interface{} {
+func (f *FuncF32F32ToF32) Func() any {
 	return func() float32 {
 		return f.fct(
 			*f.arg0,
@@ -184,7 +184,7 @@ func NewFuncF32F32F32ToF32(rvars []string, fct func(arg00 float32, arg01 float32
 func (f *FuncF32F32F32ToF32) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncF32F32F32ToF32) Bind(args []interface{}) error {
+func (f *FuncF32F32F32ToF32) Bind(args []any) error {
 	if got, want := len(args), 3; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -225,7 +225,7 @@ func (f *FuncF32F32F32ToF32) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncF32F32F32ToF32) Func() interface{} {
+func (f *FuncF32F32F32ToF32) Func() any {
 	return func() float32 {
 		return f.fct(
 			*f.arg0,

--- a/groot/rtree/rfunc/rfunc_f32_gen_test.go
+++ b/groot/rtree/rfunc/rfunc_f32_gen_test.go
@@ -25,10 +25,10 @@ func TestFuncToF32(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	var ptrs []interface{}
+	var ptrs []any
 
 	{
-		bad := make([]interface{}, 1)
+		bad := make([]any, 1)
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -61,20 +61,20 @@ func TestFuncF32ToF32(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 1)
+	ptrs := make([]any, 1)
 	ptrs[0] = new(float32)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -108,21 +108,21 @@ func TestFuncF32F32ToF32(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 2)
+	ptrs := make([]any, 2)
 	ptrs[0] = new(float32)
 	ptrs[1] = new(float32)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -157,22 +157,22 @@ func TestFuncF32F32F32ToF32(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 3)
+	ptrs := make([]any, 3)
 	ptrs[0] = new(float32)
 	ptrs[1] = new(float32)
 	ptrs[2] = new(float32)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")

--- a/groot/rtree/rfunc/rfunc_f64_gen.go
+++ b/groot/rtree/rfunc/rfunc_f64_gen.go
@@ -29,7 +29,7 @@ func NewFuncI32ToF64(rvars []string, fct func(arg00 int32) float64) *FuncI32ToF6
 func (f *FuncI32ToF64) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncI32ToF64) Bind(args []interface{}) error {
+func (f *FuncI32ToF64) Bind(args []any) error {
 	if got, want := len(args), 1; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -50,7 +50,7 @@ func (f *FuncI32ToF64) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncI32ToF64) Func() interface{} {
+func (f *FuncI32ToF64) Func() any {
 	return func() float64 {
 		return f.fct(
 			*f.arg0,
@@ -81,7 +81,7 @@ func NewFuncF32ToF64(rvars []string, fct func(arg00 float32) float64) *FuncF32To
 func (f *FuncF32ToF64) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncF32ToF64) Bind(args []interface{}) error {
+func (f *FuncF32ToF64) Bind(args []any) error {
 	if got, want := len(args), 1; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -102,7 +102,7 @@ func (f *FuncF32ToF64) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncF32ToF64) Func() interface{} {
+func (f *FuncF32ToF64) Func() any {
 	return func() float64 {
 		return f.fct(
 			*f.arg0,
@@ -130,7 +130,7 @@ func NewFuncToF64(rvars []string, fct func() float64) *FuncToF64 {
 func (f *FuncToF64) RVars() []string { return nil }
 
 // Bind implements rfunc.Formula
-func (f *FuncToF64) Bind(args []interface{}) error {
+func (f *FuncToF64) Bind(args []any) error {
 	if got, want := len(args), 0; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -141,7 +141,7 @@ func (f *FuncToF64) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncToF64) Func() interface{} {
+func (f *FuncToF64) Func() any {
 	return func() float64 {
 		return f.fct()
 	}
@@ -170,7 +170,7 @@ func NewFuncF64ToF64(rvars []string, fct func(arg00 float64) float64) *FuncF64To
 func (f *FuncF64ToF64) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncF64ToF64) Bind(args []interface{}) error {
+func (f *FuncF64ToF64) Bind(args []any) error {
 	if got, want := len(args), 1; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -191,7 +191,7 @@ func (f *FuncF64ToF64) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncF64ToF64) Func() interface{} {
+func (f *FuncF64ToF64) Func() any {
 	return func() float64 {
 		return f.fct(
 			*f.arg0,
@@ -223,7 +223,7 @@ func NewFuncF64F64ToF64(rvars []string, fct func(arg00 float64, arg01 float64) f
 func (f *FuncF64F64ToF64) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncF64F64ToF64) Bind(args []interface{}) error {
+func (f *FuncF64F64ToF64) Bind(args []any) error {
 	if got, want := len(args), 2; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -254,7 +254,7 @@ func (f *FuncF64F64ToF64) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncF64F64ToF64) Func() interface{} {
+func (f *FuncF64F64ToF64) Func() any {
 	return func() float64 {
 		return f.fct(
 			*f.arg0,
@@ -288,7 +288,7 @@ func NewFuncF64F64F64ToF64(rvars []string, fct func(arg00 float64, arg01 float64
 func (f *FuncF64F64F64ToF64) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncF64F64F64ToF64) Bind(args []interface{}) error {
+func (f *FuncF64F64F64ToF64) Bind(args []any) error {
 	if got, want := len(args), 3; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -329,7 +329,7 @@ func (f *FuncF64F64F64ToF64) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncF64F64F64ToF64) Func() interface{} {
+func (f *FuncF64F64F64ToF64) Func() any {
 	return func() float64 {
 		return f.fct(
 			*f.arg0,

--- a/groot/rtree/rfunc/rfunc_f64_gen_test.go
+++ b/groot/rtree/rfunc/rfunc_f64_gen_test.go
@@ -26,20 +26,20 @@ func TestFuncI32ToF64(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 1)
+	ptrs := make([]any, 1)
 	ptrs[0] = new(int32)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -72,20 +72,20 @@ func TestFuncF32ToF64(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 1)
+	ptrs := make([]any, 1)
 	ptrs[0] = new(float32)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -117,10 +117,10 @@ func TestFuncToF64(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	var ptrs []interface{}
+	var ptrs []any
 
 	{
-		bad := make([]interface{}, 1)
+		bad := make([]any, 1)
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -153,20 +153,20 @@ func TestFuncF64ToF64(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 1)
+	ptrs := make([]any, 1)
 	ptrs[0] = new(float64)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -200,21 +200,21 @@ func TestFuncF64F64ToF64(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 2)
+	ptrs := make([]any, 2)
 	ptrs[0] = new(float64)
 	ptrs[1] = new(float64)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -249,22 +249,22 @@ func TestFuncF64F64F64ToF64(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 3)
+	ptrs := make([]any, 3)
 	ptrs[0] = new(float64)
 	ptrs[1] = new(float64)
 	ptrs[2] = new(float64)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")

--- a/groot/rtree/rfunc/rfunc_f64s_gen.go
+++ b/groot/rtree/rfunc/rfunc_f64s_gen.go
@@ -29,7 +29,7 @@ func NewFuncF32sToF64s(rvars []string, fct func(arg00 []float32) []float64) *Fun
 func (f *FuncF32sToF64s) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncF32sToF64s) Bind(args []interface{}) error {
+func (f *FuncF32sToF64s) Bind(args []any) error {
 	if got, want := len(args), 1; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -50,7 +50,7 @@ func (f *FuncF32sToF64s) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncF32sToF64s) Func() interface{} {
+func (f *FuncF32sToF64s) Func() any {
 	return func() []float64 {
 		return f.fct(
 			*f.arg0,
@@ -81,7 +81,7 @@ func NewFuncF64sToF64s(rvars []string, fct func(arg00 []float64) []float64) *Fun
 func (f *FuncF64sToF64s) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncF64sToF64s) Bind(args []interface{}) error {
+func (f *FuncF64sToF64s) Bind(args []any) error {
 	if got, want := len(args), 1; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -102,7 +102,7 @@ func (f *FuncF64sToF64s) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncF64sToF64s) Func() interface{} {
+func (f *FuncF64sToF64s) Func() any {
 	return func() []float64 {
 		return f.fct(
 			*f.arg0,

--- a/groot/rtree/rfunc/rfunc_f64s_gen_test.go
+++ b/groot/rtree/rfunc/rfunc_f64s_gen_test.go
@@ -26,20 +26,20 @@ func TestFuncF32sToF64s(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 1)
+	ptrs := make([]any, 1)
 	ptrs[0] = new([]float32)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -72,20 +72,20 @@ func TestFuncF64sToF64s(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 1)
+	ptrs := make([]any, 1)
 	ptrs[0] = new([]float64)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")

--- a/groot/rtree/rfunc/rfunc_i32_gen.go
+++ b/groot/rtree/rfunc/rfunc_i32_gen.go
@@ -26,7 +26,7 @@ func NewFuncToI32(rvars []string, fct func() int32) *FuncToI32 {
 func (f *FuncToI32) RVars() []string { return nil }
 
 // Bind implements rfunc.Formula
-func (f *FuncToI32) Bind(args []interface{}) error {
+func (f *FuncToI32) Bind(args []any) error {
 	if got, want := len(args), 0; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -37,7 +37,7 @@ func (f *FuncToI32) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncToI32) Func() interface{} {
+func (f *FuncToI32) Func() any {
 	return func() int32 {
 		return f.fct()
 	}
@@ -66,7 +66,7 @@ func NewFuncI32ToI32(rvars []string, fct func(arg00 int32) int32) *FuncI32ToI32 
 func (f *FuncI32ToI32) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncI32ToI32) Bind(args []interface{}) error {
+func (f *FuncI32ToI32) Bind(args []any) error {
 	if got, want := len(args), 1; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -87,7 +87,7 @@ func (f *FuncI32ToI32) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncI32ToI32) Func() interface{} {
+func (f *FuncI32ToI32) Func() any {
 	return func() int32 {
 		return f.fct(
 			*f.arg0,
@@ -119,7 +119,7 @@ func NewFuncI32I32ToI32(rvars []string, fct func(arg00 int32, arg01 int32) int32
 func (f *FuncI32I32ToI32) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncI32I32ToI32) Bind(args []interface{}) error {
+func (f *FuncI32I32ToI32) Bind(args []any) error {
 	if got, want := len(args), 2; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -150,7 +150,7 @@ func (f *FuncI32I32ToI32) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncI32I32ToI32) Func() interface{} {
+func (f *FuncI32I32ToI32) Func() any {
 	return func() int32 {
 		return f.fct(
 			*f.arg0,
@@ -184,7 +184,7 @@ func NewFuncI32I32I32ToI32(rvars []string, fct func(arg00 int32, arg01 int32, ar
 func (f *FuncI32I32I32ToI32) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncI32I32I32ToI32) Bind(args []interface{}) error {
+func (f *FuncI32I32I32ToI32) Bind(args []any) error {
 	if got, want := len(args), 3; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -225,7 +225,7 @@ func (f *FuncI32I32I32ToI32) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncI32I32I32ToI32) Func() interface{} {
+func (f *FuncI32I32I32ToI32) Func() any {
 	return func() int32 {
 		return f.fct(
 			*f.arg0,

--- a/groot/rtree/rfunc/rfunc_i32_gen_test.go
+++ b/groot/rtree/rfunc/rfunc_i32_gen_test.go
@@ -25,10 +25,10 @@ func TestFuncToI32(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	var ptrs []interface{}
+	var ptrs []any
 
 	{
-		bad := make([]interface{}, 1)
+		bad := make([]any, 1)
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -61,20 +61,20 @@ func TestFuncI32ToI32(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 1)
+	ptrs := make([]any, 1)
 	ptrs[0] = new(int32)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -108,21 +108,21 @@ func TestFuncI32I32ToI32(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 2)
+	ptrs := make([]any, 2)
 	ptrs[0] = new(int32)
 	ptrs[1] = new(int32)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -157,22 +157,22 @@ func TestFuncI32I32I32ToI32(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 3)
+	ptrs := make([]any, 3)
 	ptrs[0] = new(int32)
 	ptrs[1] = new(int32)
 	ptrs[2] = new(int32)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")

--- a/groot/rtree/rfunc/rfunc_i64_gen.go
+++ b/groot/rtree/rfunc/rfunc_i64_gen.go
@@ -26,7 +26,7 @@ func NewFuncToI64(rvars []string, fct func() int64) *FuncToI64 {
 func (f *FuncToI64) RVars() []string { return nil }
 
 // Bind implements rfunc.Formula
-func (f *FuncToI64) Bind(args []interface{}) error {
+func (f *FuncToI64) Bind(args []any) error {
 	if got, want := len(args), 0; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -37,7 +37,7 @@ func (f *FuncToI64) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncToI64) Func() interface{} {
+func (f *FuncToI64) Func() any {
 	return func() int64 {
 		return f.fct()
 	}
@@ -66,7 +66,7 @@ func NewFuncI64ToI64(rvars []string, fct func(arg00 int64) int64) *FuncI64ToI64 
 func (f *FuncI64ToI64) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncI64ToI64) Bind(args []interface{}) error {
+func (f *FuncI64ToI64) Bind(args []any) error {
 	if got, want := len(args), 1; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -87,7 +87,7 @@ func (f *FuncI64ToI64) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncI64ToI64) Func() interface{} {
+func (f *FuncI64ToI64) Func() any {
 	return func() int64 {
 		return f.fct(
 			*f.arg0,
@@ -119,7 +119,7 @@ func NewFuncI64I64ToI64(rvars []string, fct func(arg00 int64, arg01 int64) int64
 func (f *FuncI64I64ToI64) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncI64I64ToI64) Bind(args []interface{}) error {
+func (f *FuncI64I64ToI64) Bind(args []any) error {
 	if got, want := len(args), 2; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -150,7 +150,7 @@ func (f *FuncI64I64ToI64) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncI64I64ToI64) Func() interface{} {
+func (f *FuncI64I64ToI64) Func() any {
 	return func() int64 {
 		return f.fct(
 			*f.arg0,
@@ -184,7 +184,7 @@ func NewFuncI64I64I64ToI64(rvars []string, fct func(arg00 int64, arg01 int64, ar
 func (f *FuncI64I64I64ToI64) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncI64I64I64ToI64) Bind(args []interface{}) error {
+func (f *FuncI64I64I64ToI64) Bind(args []any) error {
 	if got, want := len(args), 3; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -225,7 +225,7 @@ func (f *FuncI64I64I64ToI64) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncI64I64I64ToI64) Func() interface{} {
+func (f *FuncI64I64I64ToI64) Func() any {
 	return func() int64 {
 		return f.fct(
 			*f.arg0,

--- a/groot/rtree/rfunc/rfunc_i64_gen_test.go
+++ b/groot/rtree/rfunc/rfunc_i64_gen_test.go
@@ -25,10 +25,10 @@ func TestFuncToI64(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	var ptrs []interface{}
+	var ptrs []any
 
 	{
-		bad := make([]interface{}, 1)
+		bad := make([]any, 1)
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -61,20 +61,20 @@ func TestFuncI64ToI64(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 1)
+	ptrs := make([]any, 1)
 	ptrs[0] = new(int64)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -108,21 +108,21 @@ func TestFuncI64I64ToI64(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 2)
+	ptrs := make([]any, 2)
 	ptrs[0] = new(int64)
 	ptrs[1] = new(int64)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -157,22 +157,22 @@ func TestFuncI64I64I64ToI64(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 3)
+	ptrs := make([]any, 3)
 	ptrs[0] = new(int64)
 	ptrs[1] = new(int64)
 	ptrs[2] = new(int64)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")

--- a/groot/rtree/rfunc/rfunc_u32_gen.go
+++ b/groot/rtree/rfunc/rfunc_u32_gen.go
@@ -26,7 +26,7 @@ func NewFuncToU32(rvars []string, fct func() uint32) *FuncToU32 {
 func (f *FuncToU32) RVars() []string { return nil }
 
 // Bind implements rfunc.Formula
-func (f *FuncToU32) Bind(args []interface{}) error {
+func (f *FuncToU32) Bind(args []any) error {
 	if got, want := len(args), 0; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -37,7 +37,7 @@ func (f *FuncToU32) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncToU32) Func() interface{} {
+func (f *FuncToU32) Func() any {
 	return func() uint32 {
 		return f.fct()
 	}
@@ -66,7 +66,7 @@ func NewFuncU32ToU32(rvars []string, fct func(arg00 uint32) uint32) *FuncU32ToU3
 func (f *FuncU32ToU32) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncU32ToU32) Bind(args []interface{}) error {
+func (f *FuncU32ToU32) Bind(args []any) error {
 	if got, want := len(args), 1; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -87,7 +87,7 @@ func (f *FuncU32ToU32) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncU32ToU32) Func() interface{} {
+func (f *FuncU32ToU32) Func() any {
 	return func() uint32 {
 		return f.fct(
 			*f.arg0,
@@ -119,7 +119,7 @@ func NewFuncU32U32ToU32(rvars []string, fct func(arg00 uint32, arg01 uint32) uin
 func (f *FuncU32U32ToU32) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncU32U32ToU32) Bind(args []interface{}) error {
+func (f *FuncU32U32ToU32) Bind(args []any) error {
 	if got, want := len(args), 2; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -150,7 +150,7 @@ func (f *FuncU32U32ToU32) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncU32U32ToU32) Func() interface{} {
+func (f *FuncU32U32ToU32) Func() any {
 	return func() uint32 {
 		return f.fct(
 			*f.arg0,
@@ -184,7 +184,7 @@ func NewFuncU32U32U32ToU32(rvars []string, fct func(arg00 uint32, arg01 uint32, 
 func (f *FuncU32U32U32ToU32) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncU32U32U32ToU32) Bind(args []interface{}) error {
+func (f *FuncU32U32U32ToU32) Bind(args []any) error {
 	if got, want := len(args), 3; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -225,7 +225,7 @@ func (f *FuncU32U32U32ToU32) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncU32U32U32ToU32) Func() interface{} {
+func (f *FuncU32U32U32ToU32) Func() any {
 	return func() uint32 {
 		return f.fct(
 			*f.arg0,

--- a/groot/rtree/rfunc/rfunc_u32_gen_test.go
+++ b/groot/rtree/rfunc/rfunc_u32_gen_test.go
@@ -25,10 +25,10 @@ func TestFuncToU32(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	var ptrs []interface{}
+	var ptrs []any
 
 	{
-		bad := make([]interface{}, 1)
+		bad := make([]any, 1)
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -61,20 +61,20 @@ func TestFuncU32ToU32(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 1)
+	ptrs := make([]any, 1)
 	ptrs[0] = new(uint32)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -108,21 +108,21 @@ func TestFuncU32U32ToU32(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 2)
+	ptrs := make([]any, 2)
 	ptrs[0] = new(uint32)
 	ptrs[1] = new(uint32)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -157,22 +157,22 @@ func TestFuncU32U32U32ToU32(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 3)
+	ptrs := make([]any, 3)
 	ptrs[0] = new(uint32)
 	ptrs[1] = new(uint32)
 	ptrs[2] = new(uint32)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")

--- a/groot/rtree/rfunc/rfunc_u64_gen.go
+++ b/groot/rtree/rfunc/rfunc_u64_gen.go
@@ -26,7 +26,7 @@ func NewFuncToU64(rvars []string, fct func() uint64) *FuncToU64 {
 func (f *FuncToU64) RVars() []string { return nil }
 
 // Bind implements rfunc.Formula
-func (f *FuncToU64) Bind(args []interface{}) error {
+func (f *FuncToU64) Bind(args []any) error {
 	if got, want := len(args), 0; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -37,7 +37,7 @@ func (f *FuncToU64) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncToU64) Func() interface{} {
+func (f *FuncToU64) Func() any {
 	return func() uint64 {
 		return f.fct()
 	}
@@ -66,7 +66,7 @@ func NewFuncU64ToU64(rvars []string, fct func(arg00 uint64) uint64) *FuncU64ToU6
 func (f *FuncU64ToU64) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncU64ToU64) Bind(args []interface{}) error {
+func (f *FuncU64ToU64) Bind(args []any) error {
 	if got, want := len(args), 1; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -87,7 +87,7 @@ func (f *FuncU64ToU64) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncU64ToU64) Func() interface{} {
+func (f *FuncU64ToU64) Func() any {
 	return func() uint64 {
 		return f.fct(
 			*f.arg0,
@@ -119,7 +119,7 @@ func NewFuncU64U64ToU64(rvars []string, fct func(arg00 uint64, arg01 uint64) uin
 func (f *FuncU64U64ToU64) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncU64U64ToU64) Bind(args []interface{}) error {
+func (f *FuncU64U64ToU64) Bind(args []any) error {
 	if got, want := len(args), 2; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -150,7 +150,7 @@ func (f *FuncU64U64ToU64) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncU64U64ToU64) Func() interface{} {
+func (f *FuncU64U64ToU64) Func() any {
 	return func() uint64 {
 		return f.fct(
 			*f.arg0,
@@ -184,7 +184,7 @@ func NewFuncU64U64U64ToU64(rvars []string, fct func(arg00 uint64, arg01 uint64, 
 func (f *FuncU64U64U64ToU64) RVars() []string { return f.rvars }
 
 // Bind implements rfunc.Formula
-func (f *FuncU64U64U64ToU64) Bind(args []interface{}) error {
+func (f *FuncU64U64U64ToU64) Bind(args []any) error {
 	if got, want := len(args), 3; got != want {
 		return fmt.Errorf(
 			"rfunc: invalid number of bind arguments (got=%d, want=%d)",
@@ -225,7 +225,7 @@ func (f *FuncU64U64U64ToU64) Bind(args []interface{}) error {
 }
 
 // Func implements rfunc.Formula
-func (f *FuncU64U64U64ToU64) Func() interface{} {
+func (f *FuncU64U64U64ToU64) Func() any {
 	return func() uint64 {
 		return f.fct(
 			*f.arg0,

--- a/groot/rtree/rfunc/rfunc_u64_gen_test.go
+++ b/groot/rtree/rfunc/rfunc_u64_gen_test.go
@@ -25,10 +25,10 @@ func TestFuncToU64(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	var ptrs []interface{}
+	var ptrs []any
 
 	{
-		bad := make([]interface{}, 1)
+		bad := make([]any, 1)
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -61,20 +61,20 @@ func TestFuncU64ToU64(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 1)
+	ptrs := make([]any, 1)
 	ptrs[0] = new(uint64)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -108,21 +108,21 @@ func TestFuncU64U64ToU64(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 2)
+	ptrs := make([]any, 2)
 	ptrs[0] = new(uint64)
 	ptrs[1] = new(uint64)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")
@@ -157,22 +157,22 @@ func TestFuncU64U64U64ToU64(t *testing.T) {
 		t.Fatalf("invalid rvars: got=%#v, want=%#v", got, want)
 	}
 
-	ptrs := make([]interface{}, 3)
+	ptrs := make([]any, 3)
 	ptrs[0] = new(uint64)
 	ptrs[1] = new(uint64)
 	ptrs[2] = new(uint64)
 
 	{
-		bad := make([]interface{}, len(ptrs))
+		bad := make([]any, len(ptrs))
 		copy(bad, ptrs)
 		for i := len(ptrs) - 1; i >= 0; i-- {
-			bad[i] = interface{}(nil)
+			bad[i] = any(nil)
 			err := form.Bind(bad)
 			if err == nil {
 				t.Fatalf("expected an error for empty iface")
 			}
 		}
-		bad = append(bad, interface{}(nil))
+		bad = append(bad, any(nil))
 		err := form.Bind(bad)
 		if err == nil {
 			t.Fatalf("expected an error for invalid args length")

--- a/groot/rtree/rleaf.go
+++ b/groot/rtree/rleaf.go
@@ -281,7 +281,7 @@ func newRLeafElem(leaf *tleafElement, rvar ReadVar, rctx rleafCtx) rleaf {
 
 type rleafElem struct {
 	base     *tleafElement
-	v        interface{}
+	v        any
 	n        func() int
 	streamer rbytes.RStreamer
 }

--- a/groot/rtree/rtree.go
+++ b/groot/rtree/rtree.go
@@ -70,7 +70,7 @@ type Leaf interface {
 
 	setBranch(Branch)
 	readFromBuffer(r *rbytes.RBuffer) error
-	setAddress(ptr interface{}) error
+	setAddress(ptr any) error
 
 	// write interface part
 	writeToBuffer(w *rbytes.WBuffer) (int, error)

--- a/groot/rtree/rvar.go
+++ b/groot/rtree/rvar.go
@@ -22,9 +22,9 @@ func toTitle(s string) string {
 
 // ReadVar describes a variable to be read out of a tree.
 type ReadVar struct {
-	Name  string      // name of the branch to read
-	Leaf  string      // name of the leaf to read
-	Value interface{} // pointer to the value to fill
+	Name  string // name of the branch to read
+	Leaf  string // name of the leaf to read
+	Value any    // pointer to the value to fill
 
 	count string // name of the leaf-count, if any
 	leaf  Leaf   // leaf to which this read-var is bound
@@ -49,7 +49,7 @@ func NewReadVars(t Tree) []ReadVar {
 }
 
 // Deref returns the value pointed at by this read-var.
-func (rv ReadVar) Deref() interface{} {
+func (rv ReadVar) Deref() any {
 	return reflect.ValueOf(rv.Value).Elem().Interface()
 }
 
@@ -58,7 +58,7 @@ func (rv ReadVar) Deref() interface{} {
 //
 // ReadVarsFromStruct panicks if the provided value is not a pointer to
 // a struct value.
-func ReadVarsFromStruct(ptr interface{}) []ReadVar {
+func ReadVarsFromStruct(ptr any) []ReadVar {
 	rv := reflect.ValueOf(ptr)
 	if rv.Kind() != reflect.Ptr {
 		panic(fmt.Errorf("rtree: expect a pointer value, got %T", ptr))
@@ -74,7 +74,7 @@ func ReadVarsFromStruct(ptr interface{}) []ReadVar {
 		rvars = make([]ReadVar, 0, rt.NumField())
 	)
 
-	for i := 0; i < rt.NumField(); i++ {
+	for i := range rt.NumField() {
 		var (
 			ft = rt.Field(i)
 			fv = rv.Field(i)
@@ -238,7 +238,7 @@ func bindRVarsTo(t Tree, rvars []ReadVar) []ReadVar {
 		rv := reflect.ValueOf(rvar.Value).Elem()
 		get := func(name string) int {
 			rt := rv.Type()
-			for i := 0; i < rt.NumField(); i++ {
+			for i := range rt.NumField() {
 				ft := rt.Field(i)
 				nn := nameOf(ft)
 				if nn == name {
@@ -321,7 +321,7 @@ func bindRVarsTo(t Tree, rvars []ReadVar) []ReadVar {
 	return ors
 }
 
-func newValue(leaf Leaf) interface{} {
+func newValue(leaf Leaf) any {
 	etype := leaf.Type()
 	unsigned := leaf.IsUnsigned()
 

--- a/groot/rtree/rvar_test.go
+++ b/groot/rtree/rvar_test.go
@@ -79,12 +79,9 @@ func TestNewReadVars(t *testing.T) {
 		{Name: "SliD32", Leaf: "SliD32", Value: new([]root.Double32)},
 	}
 
-	n := len(want)
-	if len(vars) < n {
-		n = len(vars)
-	}
+	n := min(len(vars), len(want))
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		got := vars[i]
 		if got.Name != want[i].Name {
 			t.Fatalf("invalid read-var name[%d]: got=%q, want=%q", i, got.Name, want[i].Name)
@@ -105,7 +102,7 @@ func TestNewReadVars(t *testing.T) {
 func TestReadVarsFromStruct(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
-		ptr    interface{}
+		ptr    any
 		want   []ReadVar
 		panics string
 	}{
@@ -315,7 +312,7 @@ func TestReadVarsFromStruct(t *testing.T) {
 
 func TestNameOf(t *testing.T) {
 	for _, tc := range []struct {
-		ptr  interface{}
+		ptr  any
 		want string
 	}{
 		{

--- a/groot/rtree/rw_test.go
+++ b/groot/rtree/rw_test.go
@@ -146,7 +146,7 @@ func TestBasketRW(t *testing.T) {
 
 			for _, tt := range []struct {
 				name      string
-				got, want interface{}
+				got, want any
 			}{
 				{"bufsize", b.bufsize, tc.basket.bufsize},
 				{"nevsize", b.nevsize, tc.basket.nevsize},
@@ -548,7 +548,7 @@ func TestBranchRW(t *testing.T) {
 				}
 			}
 
-			asTBranch := func(b interface{}) *tbranch {
+			asTBranch := func(b any) *tbranch {
 				switch b := b.(type) {
 				case *tbranch:
 					return b
@@ -558,7 +558,7 @@ func TestBranchRW(t *testing.T) {
 				panic("impossible")
 			}
 
-			setupInput := func(b interface{}) {
+			setupInput := func(b any) {
 				if b := asTBranch(b); len(b.leaves) != 0 {
 					for i := range b.leaves {
 						b.leaves[i].setBranch(b)
@@ -635,7 +635,7 @@ func TestBranchRW(t *testing.T) {
 					}
 
 					for i, v := range []struct {
-						got, want interface{}
+						got, want any
 					}{
 						{got.tbranch, want.tbranch},
 						{got.class, want.class},
@@ -689,7 +689,7 @@ func TestTreeRW(t *testing.T) {
 		btitles []string
 		ltitles []string
 		total   int
-		want    func(i int) interface{}
+		want    func(i int) any
 		scan    []string // list of branches to use for ROOT TTree::Scan
 		cxx     string   // expected ROOT-TTree::Scan
 	}{
@@ -700,7 +700,7 @@ func TestTreeRW(t *testing.T) {
 			btitles: []string{},
 			ltitles: []string{},
 			total:   5 * (0),
-			want:    func(i int) interface{} { return nil },
+			want:    func(i int) any { return nil },
 			cxx: `************
 *    Row   *
 ************
@@ -722,7 +722,7 @@ func TestTreeRW(t *testing.T) {
 			btitles: []string{"i32/I", "f64/D"},
 			ltitles: []string{"i32", "f64"},
 			total:   5 * (4 + 8),
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				return struct {
 					I32 int32
 					F64 float64
@@ -773,7 +773,7 @@ func TestTreeRW(t *testing.T) {
 				"F32", "F64", "D16", "D32",
 			},
 			total: 5 * 50,
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				return struct {
 					B   bool
 					I8  int8
@@ -826,7 +826,7 @@ func TestTreeRW(t *testing.T) {
 			btitles: []string{"i32/I", "f64/D", "str/C"},
 			ltitles: []string{"i32", "f64", "str"},
 			total:   5 * (4 + 8 + (3 + 1)), // 3: strings are "xxx" + 1:string-size
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				return struct {
 					I32 int32
 					F64 float64
@@ -858,7 +858,7 @@ func TestTreeRW(t *testing.T) {
 			btitles: []string{"s1/C", "s2/C"},
 			ltitles: []string{"s1", "s2"},
 			total:   30,
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				return struct {
 					S1 string
 					S2 string
@@ -907,7 +907,7 @@ func TestTreeRW(t *testing.T) {
 				"ArrF32[5]", "ArrF64[5]",
 			},
 			total: 5 * 215,
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				return struct {
 					ArrBool [5]bool
 					ArrI8   [5]int8
@@ -1000,7 +1000,7 @@ func TestTreeRW(t *testing.T) {
 				"ArrF32[2][3]", "ArrF64[2][3]",
 			},
 			total: 5 * 258,
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				return struct {
 					ArrBool [2][3]bool
 					ArrI8   [2][3]int8
@@ -1121,7 +1121,7 @@ func TestTreeRW(t *testing.T) {
 				"SliU8[N]", "SliU16[N]", "SliU32[N]", "SliU64[N]",
 			},
 			total: 170,
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				type Data struct {
 					N      int32
 					SliU8  []uint8
@@ -1176,7 +1176,7 @@ func TestTreeRW(t *testing.T) {
 				"SliI16[N]", "SliI32[N]", "SliI64[N]",
 			},
 			total: 160,
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				type Data struct {
 					N      int32
 					SliI16 []int16
@@ -1226,7 +1226,7 @@ func TestTreeRW(t *testing.T) {
 				"N", "SliI8[N]",
 			},
 			total: 30,
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				type Data struct {
 					N     int32
 					SliI8 []int8
@@ -1276,7 +1276,7 @@ func TestTreeRW(t *testing.T) {
 				"SliF32[N]", "SliF64[N]",
 			},
 			total: 150,
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				type Data struct {
 					N       int32
 					SliBool []bool
@@ -1328,7 +1328,7 @@ func TestTreeRW(t *testing.T) {
 				"SliI64[N]",
 			},
 			total: 400000,
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				type Data struct {
 					N      int32
 					SliI64 []int64
@@ -1355,7 +1355,7 @@ func TestTreeRW(t *testing.T) {
 			btitles: []string{"i32/I", "f64/D"},
 			ltitles: []string{"i32", "f64"},
 			total:   500 * (4 + 8),
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				return struct {
 					I32 int32
 					F64 float64
@@ -1376,7 +1376,7 @@ func TestTreeRW(t *testing.T) {
 			btitles: []string{"i32/I", "f64/D"},
 			ltitles: []string{"i32", "f64"},
 			total:   500 * (4 + 8),
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				return struct {
 					I32 int32
 					F64 float64
@@ -1397,7 +1397,7 @@ func TestTreeRW(t *testing.T) {
 			btitles: []string{"i32/I", "f64/D"},
 			ltitles: []string{"i32", "f64"},
 			total:   500 * (4 + 8),
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				return struct {
 					I32 int32
 					F64 float64
@@ -1418,7 +1418,7 @@ func TestTreeRW(t *testing.T) {
 			btitles: []string{"i32/I", "f64/D"},
 			ltitles: []string{"i32", "f64"},
 			total:   500 * (4 + 8),
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				return struct {
 					I32 int32
 					F64 float64
@@ -1439,7 +1439,7 @@ func TestTreeRW(t *testing.T) {
 			btitles: []string{"i32/I", "f64/D"},
 			ltitles: []string{"i32", "f64"},
 			total:   500 * (4 + 8),
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				return struct {
 					I32 int32
 					F64 float64
@@ -1489,7 +1489,7 @@ func TestTreeRW(t *testing.T) {
 				}
 
 				total := 0
-				for i := 0; i < int(tc.nevts); i++ {
+				for i := range int(tc.nevts) {
 					want := tc.want(i)
 					for j, wvar := range tc.wvars {
 						v := reflect.ValueOf(wvar.Value).Elem()
@@ -1678,7 +1678,7 @@ func TestNestedTreeRW(t *testing.T) {
 		btitles []string
 		ltitles []string
 		total   int
-		want    func(i int) interface{}
+		want    func(i int) any
 		macro   string // ROOT macro to execute to read back ROOT file
 		cxx     string // expected ROOT-TTree::Scan
 		sinfos  []rbytes.StreamerInfo
@@ -1699,7 +1699,7 @@ func TestNestedTreeRW(t *testing.T) {
 			btitles: []string{"evt"},
 			ltitles: []string{"evt"},
 			total:   460,
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				var evt struct {
 					Data TNestedStruct1
 				}
@@ -1783,7 +1783,7 @@ evt[9]: run=19, evt=9, p3(19, 29, 39)
 			btitles: []string{"evt"},
 			ltitles: []string{"evt"},
 			total:   46 * 1000,
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				var evt struct {
 					Data TNestedStruct1
 				}
@@ -1815,7 +1815,7 @@ evt[9]: run=19, evt=9, p3(19, 29, 39)
 			btitles: []string{"evt"},
 			ltitles: []string{"evt"},
 			total:   740,
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				var evt struct {
 					Data TNestedStruct2
 				}
@@ -1830,7 +1830,7 @@ evt[9]: run=19, evt=9, p3(19, 29, 39)
 				default:
 					evt.Data.F32s = make([]float32, 0, i)
 				}
-				for j := 0; j < i; j++ {
+				for j := range i {
 					evt.Data.F32s = append(evt.Data.F32s, float32((i+1)*10+j))
 				}
 
@@ -1932,7 +1932,7 @@ evt[9]: run=19, evt=9, p3(19, 29, 39) f32s([100, 101, 102, 103, 104, 105, 106, 1
 			btitles: []string{"runnbr/L", "evtnbr/L", "p3", "f32s"},
 			ltitles: []string{"runnbr", "evtnbr", "p3", "f32s"},
 			total:   680,
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				var evt struct {
 					Data TNestedStruct3
 				}
@@ -1947,7 +1947,7 @@ evt[9]: run=19, evt=9, p3(19, 29, 39) f32s([100, 101, 102, 103, 104, 105, 106, 1
 				default:
 					evt.Data.F32s = make([]float32, 0, i)
 				}
-				for j := 0; j < i; j++ {
+				for j := range i {
 					evt.Data.F32s = append(evt.Data.F32s, float32((i+1)*10+j))
 				}
 
@@ -2056,7 +2056,7 @@ evt[9]: run=19, evt=9, p3(19, 29, 39) f32s([100, 101, 102, 103, 104, 105, 106, 1
 			btitles: []string{"N/I", "vec"}, // "sli[N]/F"},
 			ltitles: []string{"N", "vec"},   // "sli[N]"},
 			total:   360,
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				var evt struct {
 					N   int32
 					Vec []float32
@@ -2066,7 +2066,7 @@ evt[9]: run=19, evt=9, p3(19, 29, 39) f32s([100, 101, 102, 103, 104, 105, 106, 1
 				evt.N = int32(i) + 1
 				evt.Vec = make([]float32, evt.N)
 				//				evt.Sli = make([]float32, evt.N)
-				for j := 0; j < int(evt.N); j++ {
+				for j := range int(evt.N) {
 					evt.Vec[j] = -float32((i+1)*10 + j)
 					//					evt.Sli[j] = +float32((i+1)*10 + j)
 				}
@@ -2171,7 +2171,7 @@ evt[9]: 10 [-100 -101 -102 -103 -104 -105 -106 -107 -108 -109]
 			btitles: []string{"evt"},
 			ltitles: []string{"evt"},
 			total:   25520,
-			want: func(i int) interface{} {
+			want: func(i int) any {
 				var evt struct {
 					Event TNestedEvent1
 				}
@@ -2625,7 +2625,7 @@ void scan(const char *fname, const char *tname, const char *oname) {
 				}
 
 				total := 0
-				for i := 0; i < int(tc.nevts); i++ {
+				for i := range int(tc.nevts) {
 					want := tc.want(i)
 					for j, wvar := range tc.wvars {
 						v := reflect.ValueOf(wvar.Value).Elem()
@@ -2794,7 +2794,7 @@ func TestTreeWriteSubdir(t *testing.T) {
 	}
 	defer ntup.Close()
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		data.I32 = int32(i)
 		data.F64 = float64(i)
 		_, err = ntup.Write()
@@ -2903,7 +2903,7 @@ func BenchmarkReadTreeF64(b *testing.B) {
 		defer tree.Close()
 
 		rnd := rand.New(rand.NewSource(1234))
-		for i := 0; i < nevts; i++ {
+		for range nevts {
 			data.F64 = rnd.Float64() * 10
 
 			_, err = tree.Write()
@@ -3005,7 +3005,7 @@ func BenchmarkReadTreeSliF64(b *testing.B) {
 			defer tree.Close()
 
 			rnd := rand.New(rand.NewSource(1234))
-			for i := 0; i < nevts; i++ {
+			for range nevts {
 				data.N = int32(rnd.Float64() * 100)
 				data.Sli = make([]float64, int(data.N))
 				for j := range data.Sli {
@@ -3262,7 +3262,7 @@ func (TNestedEvent1) want(i int64) (data TNestedEvent1) {
 		//		data.SliP2 = make([]TNestedP2, int(data.N))
 		//		data.SliObj = make([]rbase.ObjString, int(data.N))
 	}
-	for ii := 0; ii < int(data.N); ii++ {
+	for ii := range int(data.N) {
 		data.SliBs[ii] = (ii + 1) == int(i)
 		//		data.SliStr[ii] = fmt.Sprintf("sli-%03d", i)
 		data.SliI8[ii] = int8(-i)
@@ -3320,7 +3320,7 @@ func (TNestedEvent1) want(i int64) (data TNestedEvent1) {
 		data.StdVecP2 = make([]TNestedP2, int(data.N))
 		data.StdVecObj = make([]rbase.ObjString, int(data.N))
 	}
-	for ii := 0; ii < int(data.N); ii++ {
+	for ii := range int(data.N) {
 		data.StdVecBs[ii] = (ii + 1) == int(i)
 		data.StdVecStr[ii] = fmt.Sprintf("std-%03d", i)
 		data.StdVecI8[ii] = int8(-i)
@@ -3352,7 +3352,7 @@ func (TNestedEvent1) want(i int64) (data TNestedEvent1) {
 		data.StdVecVecStr = make([][]string, data.N)
 		data.StdVecVecP2 = make([][]TNestedP2, data.N)
 	}
-	for ii := 0; ii < int(data.N); ii++ {
+	for ii := range int(data.N) {
 		data.StdVecVecF64[ii] = []float64{
 			float64(ii),
 			float64(ii + 1),

--- a/groot/rtree/tree_test.go
+++ b/groot/rtree/tree_test.go
@@ -167,7 +167,7 @@ func (EventType) want(i int64) EventType {
 	data.Evt.SliU64 = make([]uint64, int(data.Evt.N))
 	data.Evt.SliF32 = make([]float32, int(data.Evt.N))
 	data.Evt.SliF64 = make([]float64, int(data.Evt.N))
-	for ii := 0; ii < int(data.Evt.N); ii++ {
+	for ii := range int(data.Evt.N) {
 		data.Evt.SliI16[ii] = int16(i)
 		data.Evt.SliI32[ii] = int32(i)
 		data.Evt.SliI64[ii] = int64(i)
@@ -188,7 +188,7 @@ func (EventType) want(i int64) EventType {
 	data.Evt.VecF32 = make([]float32, int(data.Evt.N))
 	data.Evt.VecF64 = make([]float64, int(data.Evt.N))
 	data.Evt.VecStr = make([]string, int(data.Evt.N))
-	for ii := 0; ii < int(data.Evt.N); ii++ {
+	for ii := range int(data.Evt.N) {
 		data.Evt.VecI16[ii] = int16(i)
 		data.Evt.VecI32[ii] = int32(i)
 		data.Evt.VecI64[ii] = int64(i)

--- a/groot/rtree/writer.go
+++ b/groot/rtree/writer.go
@@ -246,7 +246,7 @@ func (w *wtree) Close() error {
 
 func fileOf(d riofs.Directory) *riofs.File {
 	const max = 1<<31 - 1
-	for i := 0; i < max; i++ {
+	for range max {
 		p := d.Parent()
 		if p == nil {
 			return d.(*riofs.File)
@@ -262,7 +262,7 @@ func flattenArrayType(rt reflect.Type) (reflect.Type, []int) {
 		kind  = rt.Kind()
 	)
 	const max = 1<<31 - 1
-	for i := 0; i < max; i++ {
+	for range max {
 		if kind != reflect.Array {
 			return rt, shape
 		}

--- a/groot/rtree/writer_example_test.go
+++ b/groot/rtree/writer_example_test.go
@@ -58,7 +58,7 @@ func Example_createFlatNtuple() {
 			fmt.Printf("branch[%d]: name=%q, title=%q\n", i, b.Name(), b.Title())
 		}
 
-		for i := 0; i < nevts; i++ {
+		for i := range nevts {
 			evt.I32 = int32(i)
 			evt.F64 = float64(i)
 			evt.Str = fmt.Sprintf("evt-%0d", i)
@@ -173,7 +173,7 @@ func Example_createFlatNtupleWithLZMA() {
 			fmt.Printf("branch[%d]: name=%q, title=%q\n", i, b.Name(), b.Title())
 		}
 
-		for i := 0; i < nevts; i++ {
+		for i := range nevts {
 			evt.I32 = int32(i)
 			evt.F64 = float64(i)
 			evt.Str = fmt.Sprintf("evt-%0d", i)
@@ -280,7 +280,7 @@ func Example_createFlatNtupleFromStruct() {
 			fmt.Printf("branch[%d]: name=%q, title=%q\n", i, b.Name(), b.Title())
 		}
 
-		for i := 0; i < nevts; i++ {
+		for i := range nevts {
 			evt.I32 = int32(i)
 			evt.F64 = float64(i)
 			evt.Str = fmt.Sprintf("evt-%0d", i)
@@ -420,7 +420,7 @@ func Example_createEventNtupleNoSplit() {
 			fmt.Printf("branch[%d]: name=%q, title=%q\n", i, b.Name(), b.Title())
 		}
 
-		for i := 0; i < nevts; i++ {
+		for i := range nevts {
 			evt.I32 = int32(i)
 			evt.F64 = float64(i)
 			evt.Str = fmt.Sprintf("evt-%0d", i)
@@ -559,7 +559,7 @@ func Example_createEventNtupleFullSplit() {
 			fmt.Printf("branch[%d]: name=%q, title=%q\n", i, b.Name(), b.Title())
 		}
 
-		for i := 0; i < nevts; i++ {
+		for i := range nevts {
 			evt.I32 = int32(i)
 			evt.F64 = float64(i)
 			evt.Str = fmt.Sprintf("evt-%0d", i)

--- a/groot/rtree/writer_test.go
+++ b/groot/rtree/writer_test.go
@@ -21,8 +21,8 @@ import (
 
 func TestFlattenArrayType(t *testing.T) {
 	for _, tc := range []struct {
-		typ   interface{}
-		want  interface{}
+		typ   any
+		want  any
 		shape []int
 	}{
 		{
@@ -119,7 +119,7 @@ func TestConcurrentWrite(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(N)
 
-	for i := 0; i < N; i++ {
+	for i := range N {
 		go func(i int) {
 			defer wg.Done()
 			f, err := riofs.Create(filepath.Join(tmp, fmt.Sprintf("file-%03d.root", i)))
@@ -144,10 +144,10 @@ func TestConcurrentWrite(t *testing.T) {
 			defer w.Close()
 
 			rng := rand.New(rand.NewSource(1234))
-			for i := 0; i < 100; i++ {
+			for i := range 100 {
 				evt.N = rng.Int31n(10) + 1
 				evt.Sli = evt.Sli[:0]
-				for j := 0; j < int(evt.N); j++ {
+				for range int(evt.N) {
 					evt.Sli = append(evt.Sli, rng.Float64())
 				}
 				_, err = w.Write()
@@ -200,7 +200,7 @@ func TestWriteThisStreamers(t *testing.T) {
 		t.Fatalf("could not create output ROOT tree %q: %+v", "tree", err)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		evt.F1 = []float64{float64(i)}
 		evt.F2 = []float64{float64(i), float64(i)}
 		evt.F3 = []int64{int64(i)}
@@ -289,10 +289,10 @@ func TestWriterWithCompression(t *testing.T) {
 			defer w.Close()
 
 			rng := rand.New(rand.NewSource(1234))
-			for i := 0; i < 100; i++ {
+			for i := range 100 {
 				evt.N = rng.Int31n(10) + 1
 				evt.Sli = evt.Sli[:0]
-				for j := 0; j < int(evt.N); j++ {
+				for range int(evt.N) {
 					evt.Sli = append(evt.Sli, rng.Float64())
 				}
 				_, err = w.Write()

--- a/groot/rtree/wvar.go
+++ b/groot/rtree/wvar.go
@@ -13,15 +13,15 @@ import (
 
 // WriteVar describes a variable to be written out to a tree.
 type WriteVar struct {
-	Name  string      // name of the variable
-	Value interface{} // pointer to the value to write
-	Count string      // name of the branch holding the count-leaf value for slices
+	Name  string // name of the variable
+	Value any    // pointer to the value to write
+	Count string // name of the branch holding the count-leaf value for slices
 }
 
 // WriteVarsFromStruct creates a slice of WriteVars from the ptr value.
 // WriteVarsFromStruct panics if ptr is not a pointer to a struct value.
 // WriteVarsFromStruct ignores fields that are not exported.
-func WriteVarsFromStruct(ptr interface{}, opts ...WriteOption) []WriteVar {
+func WriteVarsFromStruct(ptr any, opts ...WriteOption) []WriteVar {
 	cfg := wopt{
 		splitlvl: defaultSplitLevel,
 	}
@@ -75,7 +75,7 @@ func WriteVarsFromStruct(ptr interface{}, opts ...WriteOption) []WriteVar {
 		wvars = make([]WriteVar, 0, rt.NumField())
 	)
 
-	for i := 0; i < rt.NumField(); i++ {
+	for i := range rt.NumField() {
 		var (
 			ft = rt.Field(i)
 			fv = rv.Field(i)

--- a/groot/rtree/wvar_test.go
+++ b/groot/rtree/wvar_test.go
@@ -9,7 +9,7 @@ import "testing"
 func TestWriteVarsFromStruct(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
-		ptr    interface{}
+		ptr    any
 		wopts  []WriteOption
 		want   []WriteVar
 		panics string

--- a/hbook/ann.go
+++ b/hbook/ann.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Annotation is a bag of attributes that are attached to a histogram.
-type Annotation map[string]interface{}
+type Annotation map[string]any
 
 func (ann Annotation) clone() Annotation {
 	buf := new(bytes.Buffer)
@@ -90,7 +90,7 @@ func (ann *Annotation) unmarshalYODAv2(data []byte) error {
 
 // MarshalBinary implements encoding.BinaryMarshaler
 func (ann *Annotation) MarshalBinary() ([]byte, error) {
-	var v map[string]interface{} = *ann
+	var v map[string]any = *ann
 	buf := new(bytes.Buffer)
 	err := gob.NewEncoder(buf).Encode(v)
 	return buf.Bytes(), err
@@ -98,7 +98,7 @@ func (ann *Annotation) MarshalBinary() ([]byte, error) {
 
 // UnmarshalBinary implements encoding.BinaryUnmarshaler
 func (ann *Annotation) UnmarshalBinary(data []byte) error {
-	var v = make(map[string]interface{})
+	var v = make(map[string]any)
 	buf := bytes.NewReader(data)
 	err := gob.NewDecoder(buf).Decode(&v)
 	if err != nil {

--- a/hbook/binning1d.go
+++ b/hbook/binning1d.go
@@ -71,7 +71,7 @@ func newBinning1DFromBins(xbins []Range) Binning1D {
 		bin.Range = xbin
 	}
 	sort.Sort(Bin1Ds(bng.Bins))
-	for i := 0; i < len(bng.Bins)-1; i++ {
+	for i := range len(bng.Bins) - 1 {
 		b0 := bng.Bins[i]
 		b1 := bng.Bins[i+1]
 		if b0.Range.Max > b1.Range.Min {

--- a/hbook/h1d_bench_test.go
+++ b/hbook/h1d_bench_test.go
@@ -70,7 +70,7 @@ func BenchmarkH1DFillFlatGo(b *testing.B) {
 
 func st_process_evts(n int, hists []*H1D, process func(hists []*H1D)) {
 	var wg sync.WaitGroup
-	for i := 0; i < n; i++ {
+	for range n {
 		wg.Add(1)
 		go func() {
 			process(hists)
@@ -88,7 +88,7 @@ func st_process_evts_const(hists []*H1D) {
 func BenchmarkNH1DFillConst(b *testing.B) {
 	b.StopTimer()
 	hists := make([]*H1D, 100)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		hists[i] = NewH1D(100, 0., 100.)
 	}
 	b.StartTimer()
@@ -107,7 +107,7 @@ func st_process_evts_flat(hists []*H1D) {
 func BenchmarkNH1DFillFlat(b *testing.B) {
 	b.StopTimer()
 	hists := make([]*H1D, 100)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		hists[i] = NewH1D(100, 0., 100.)
 	}
 	b.StartTimer()

--- a/hbook/h1d_example_test.go
+++ b/hbook/h1d_example_test.go
@@ -26,7 +26,7 @@ func ExampleH1D() {
 	// Draw some random values from the standard
 	// normal distribution.
 	h := hbook.NewH1D(20, -4, +4)
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		v := dist.Rand()
 		h.Fill(v, 1)
 	}
@@ -70,7 +70,7 @@ func ExampleAddH1D() {
 
 	hsum := hbook.AddH1D(h1, h2)
 	fmt.Printf("Under: %.1f +/- %.1f\n", hsum.Binning.Outflows[0].SumW(), math.Sqrt(hsum.Binning.Outflows[0].SumW2()))
-	for i := 0; i < hsum.Len(); i++ {
+	for i := range hsum.Len() {
 		fmt.Printf("Bin %v: %.1f +/- %.1f\n", i, hsum.Binning.Bins[i].SumW(), math.Sqrt(hsum.Binning.Bins[i].SumW2()))
 	}
 	fmt.Printf("Over : %.1f +/- %.1f\n", hsum.Binning.Outflows[1].SumW(), math.Sqrt(hsum.Binning.Outflows[1].SumW2()))
@@ -110,7 +110,7 @@ func ExampleAddScaledH1D() {
 
 	hsum := hbook.AddScaledH1D(h1, 10, h2)
 	fmt.Printf("Under: %.1f +/- %.1f\n", hsum.Binning.Outflows[0].SumW(), math.Sqrt(hsum.Binning.Outflows[0].SumW2()))
-	for i := 0; i < hsum.Len(); i++ {
+	for i := range hsum.Len() {
 		fmt.Printf("Bin %v: %.1f +/- %.1f\n", i, hsum.Binning.Bins[i].SumW(), math.Sqrt(hsum.Binning.Bins[i].SumW2()))
 	}
 	fmt.Printf("Over : %.1f +/- %.1f\n", hsum.Binning.Outflows[1].SumW(), math.Sqrt(hsum.Binning.Outflows[1].SumW2()))

--- a/hbook/h1d_test.go
+++ b/hbook/h1d_test.go
@@ -459,7 +459,7 @@ func TestH1DNegativeWeights(t *testing.T) {
 func TestH1DSerialization(t *testing.T) {
 	const nentries = 50
 	href := NewH1D(100, 0., 100.)
-	for i := 0; i < nentries; i++ {
+	for range nentries {
 		href.Fill(rnd()*100., 1.)
 	}
 	href.Annotation()["title"] = "histo title"

--- a/hbook/h2d.go
+++ b/hbook/h2d.go
@@ -349,8 +349,8 @@ func (h *H2D) marshalYODAv1() ([]byte, error) {
 
 	// bins
 	fmt.Fprintf(buf, "# xlow\t xhigh\t ylow\t yhigh\t sumw\t sumw2\t sumwx\t sumwx2\t sumwy\t sumwy2\t sumwxy\t numEntries\n")
-	for ix := 0; ix < h.Binning.Nx; ix++ {
-		for iy := 0; iy < h.Binning.Ny; iy++ {
+	for ix := range h.Binning.Nx {
+		for iy := range h.Binning.Ny {
 			bin := h.Binning.Bins[iy*h.Binning.Nx+ix]
 			d := bin.Dist
 			fmt.Fprintf(
@@ -392,8 +392,8 @@ func (h *H2D) marshalYODAv2() ([]byte, error) {
 
 	// bins
 	fmt.Fprintf(buf, "# xlow\t xhigh\t ylow\t yhigh\t sumw\t sumw2\t sumwx\t sumwx2\t sumwy\t sumwy2\t sumwxy\t numEntries\n")
-	for ix := 0; ix < h.Binning.Nx; ix++ {
-		for iy := 0; iy < h.Binning.Ny; iy++ {
+	for ix := range h.Binning.Nx {
+		for iy := range h.Binning.Ny {
 			bin := h.Binning.Bins[iy*h.Binning.Nx+ix]
 			d := bin.Dist
 			fmt.Fprintf(
@@ -515,8 +515,8 @@ scanLoop:
 	h.Binning = newBinning2D(len(xset), xmin, xmax, len(yset), ymin, ymax)
 	h.Binning.Dist = dist
 	// YODA bins are transposed wrt ours
-	for ix := 0; ix < h.Binning.Nx; ix++ {
-		for iy := 0; iy < h.Binning.Ny; iy++ {
+	for ix := range h.Binning.Nx {
+		for iy := range h.Binning.Ny {
 			h.Binning.Bins[iy*h.Binning.Nx+ix] = bins[ix*h.Binning.Ny+iy]
 		}
 	}
@@ -617,8 +617,8 @@ scanLoop:
 	h.Binning = newBinning2D(len(xset), xmin, xmax, len(yset), ymin, ymax)
 	h.Binning.Dist = dist
 	// YODA bins are transposed wrt ours
-	for ix := 0; ix < h.Binning.Nx; ix++ {
-		for iy := 0; iy < h.Binning.Ny; iy++ {
+	for ix := range h.Binning.Nx {
+		for iy := range h.Binning.Ny {
 			h.Binning.Bins[iy*h.Binning.Nx+ix] = bins[ix*h.Binning.Ny+iy]
 		}
 	}

--- a/hbook/h2d_example_test.go
+++ b/hbook/h2d_example_test.go
@@ -30,7 +30,7 @@ func ExampleH2D() {
 	v := make([]float64, 2)
 	// Draw some random values from the standard
 	// normal distribution.
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		v = dist.Rand(v)
 		h.Fill(v[0], v[1], 1)
 	}

--- a/hbook/ntup/ntuple.go
+++ b/hbook/ntup/ntuple.go
@@ -69,7 +69,7 @@ func Open(db *sql.DB, name string) (*Ntuple, error) {
 //
 //	nt, err := ntup.Create(db, "nt", struct{X float64 `hbook:"x"`}{})
 //	nt, err := ntup.Create(db, "nt", int64(0), float64(0))
-func Create(db *sql.DB, name string, cols ...interface{}) (*Ntuple, error) {
+func Create(db *sql.DB, name string, cols ...any) (*Ntuple, error) {
 	var err error
 	nt := &Ntuple{
 		db:   db,
@@ -136,7 +136,7 @@ func (col *columnDescr) Type() reflect.Type {
 func schemaFromStruct(rt reflect.Type) ([]Descriptor, error) {
 	var schema []Descriptor
 	var err error
-	for i := 0; i < rt.NumField(); i++ {
+	for i := range rt.NumField() {
 		f := rt.Field(i)
 		if !ast.IsExported(f.Name) {
 			continue
@@ -163,7 +163,7 @@ func schemaFromStruct(rt reflect.Type) ([]Descriptor, error) {
 	return schema, err
 }
 
-func schemaFrom(src ...interface{}) ([]Descriptor, error) {
+func schemaFrom(src ...any) ([]Descriptor, error) {
 	var schema []Descriptor
 	var err error
 	for i, col := range src {
@@ -204,7 +204,7 @@ func getTag(tag reflect.StructTag, keys ...string) string {
 //	  h2.Fill(y, 1)
 //	  return nil
 //	})
-func (nt *Ntuple) Scan(query string, f interface{}) error {
+func (nt *Ntuple) Scan(query string, f any) error {
 	if f == nil {
 		return fmt.Errorf("hbook/ntup: nil func")
 	}
@@ -217,7 +217,7 @@ func (nt *Ntuple) Scan(query string, f interface{}) error {
 		return fmt.Errorf("hbook/ntup: expected a func returning an error. got %T", f)
 	}
 	vargs := make([]reflect.Value, rt.NumIn())
-	args := make([]interface{}, rt.NumIn())
+	args := make([]any, rt.NumIn())
 	for i := range args {
 		ptr := reflect.New(rt.In(i))
 		args[i] = ptr.Interface()

--- a/hbook/ntup/ntuple_test.go
+++ b/hbook/ntup/ntuple_test.go
@@ -42,7 +42,7 @@ func TestScanH1D(t *testing.T) {
 		t.Errorf("error. got %v bins. want=%d\n", h.Len(), want.len)
 	}
 
-	for i := 0; i < h.Len(); i++ {
+	for i := range h.Len() {
 		v := h.Value(i)
 		if v != 1 {
 			t.Errorf("error bin(%d)=%v. want=1\n", i, v)
@@ -59,7 +59,7 @@ func TestScanH1D(t *testing.T) {
 
 func TestScanH1DWithoutH1(t *testing.T) {
 	want := hbook.NewH1D(100, 0, nextULP(9))
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		want.Fill(float64(i), 1)
 	}
 
@@ -74,7 +74,7 @@ func TestScanH1DWithoutH1(t *testing.T) {
 		t.Errorf("error. got %v bins. want=%d\n", h.Len(), want.Len())
 	}
 
-	for i := 0; i < h.Len(); i++ {
+	for i := range h.Len() {
 		v := h.Value(i)
 		if v != want.Value(i) {
 			t.Errorf("error bin(%d)=%v. want=%v\n", i, v, want.Value(i))
@@ -124,7 +124,7 @@ func TestScanH1DWhere(t *testing.T) {
 				t.Errorf("error. got %v bins. want=%d\n", h.Len(), want.len)
 			}
 
-			for i := 0; i < h.Len(); i++ {
+			for i := range h.Len() {
 				v := h.Value(i)
 				want := float64(0)
 				if i > 4 {
@@ -170,7 +170,7 @@ func TestScanH1DInt(t *testing.T) {
 		t.Errorf("error. got %v bins. want=%d\n", h.Len(), want.len)
 	}
 
-	for i := 0; i < h.Len(); i++ {
+	for i := range h.Len() {
 		v := h.Value(i)
 		if v != 1 {
 			t.Errorf("error bin(%d)=%v. want=1\n", i, v)
@@ -187,7 +187,7 @@ func TestScanH1DInt(t *testing.T) {
 
 func TestScanH2D(t *testing.T) {
 	want := hbook.NewH2D(10, 0, 10, 10, 0, 10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		v := float64(i)
 		want.Fill(v, v, 1)
 	}
@@ -218,13 +218,13 @@ func TestScanH2D(t *testing.T) {
 		if ar != br {
 			t.Fatalf("got=%d want=%d", ar, br)
 		}
-		for i := 0; i < ar; i++ {
+		for i := range ar {
 			ay := a.Y(i)
 			by := b.Y(i)
 			if ay != by {
 				t.Fatalf("got=%v. want=%v", ay, by)
 			}
-			for j := 0; j < ac; j++ {
+			for j := range ac {
 				if i == 0 {
 					ax := a.X(j)
 					bx := b.X(j)
@@ -253,7 +253,7 @@ func TestScanH2D(t *testing.T) {
 
 func TestScanH2DWithoutH2D(t *testing.T) {
 	want := hbook.NewH2D(100, 0, nextULP(9), 100, 0, nextULP(9))
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		v := float64(i)
 		want.Fill(v, v, 1)
 	}
@@ -283,13 +283,13 @@ func TestScanH2DWithoutH2D(t *testing.T) {
 		if ar != br {
 			t.Fatalf("got=%d want=%d", ar, br)
 		}
-		for i := 0; i < ar; i++ {
+		for i := range ar {
 			ay := a.Y(i)
 			by := b.Y(i)
 			if ay != by {
 				t.Fatalf("got=%v. want=%v", ay, by)
 			}
-			for j := 0; j < ac; j++ {
+			for j := range ac {
 				if i == 0 {
 					ax := a.X(j)
 					bx := b.X(j)
@@ -344,7 +344,7 @@ func TestScan(t *testing.T) {
 		t.Errorf("error. got %v bins. want=%d\n", h.Len(), want.len)
 	}
 
-	for i := 0; i < h.Len(); i++ {
+	for i := range h.Len() {
 		v := h.Value(i)
 		if v != 1 {
 			t.Errorf("error bin(%d)=%v. want=1\n", i, v)
@@ -395,7 +395,7 @@ func TestScanH1DFromCSVWithCommas(t *testing.T) {
 		t.Errorf("error. got %v bins. want=%d\n", h.Len(), want.len)
 	}
 
-	for i := 0; i < h.Len(); i++ {
+	for i := range h.Len() {
 		v := h.Value(i)
 		if v != 1 {
 			t.Errorf("error bin(%d)=%v. want=1\n", i, v)
@@ -450,7 +450,7 @@ func TestScanH1DFromCSV(t *testing.T) {
 		t.Errorf("error. got %v bins. want=%d\n", h.Len(), want.len)
 	}
 
-	for i := 0; i < h.Len(); i++ {
+	for i := range h.Len() {
 		v := h.Value(i)
 		if v != 1 {
 			t.Errorf("error bin(%d)=%v. want=1\n", i, v)
@@ -468,7 +468,7 @@ func TestScanH1DFromCSV(t *testing.T) {
 func TestScanInvalid(t *testing.T) {
 	for _, tc := range []struct {
 		name string
-		fct  interface{}
+		fct  any
 	}{
 		{
 			name: "nil func",
@@ -534,7 +534,7 @@ func TestCreate(t *testing.T) {
 		t.Fatalf("invalid cols. got=%d. want=%d\n", len(nt.Cols()), len(descr))
 	}
 
-	for i := 0; i < len(descr); i++ {
+	for i := range descr {
 		col := nt.Cols()[i]
 		exp := descr[i]
 		if col.Name() != exp.n {
@@ -599,7 +599,7 @@ func TestCreateFromStruct(t *testing.T) {
 		t.Fatalf("invalid cols. got=%d. want=%d\n", len(nt.Cols()), len(descr))
 	}
 
-	for i := 0; i < len(descr); i++ {
+	for i := range descr {
 		col := nt.Cols()[i]
 		exp := descr[i]
 		if col.Name() != exp.n {
@@ -619,7 +619,7 @@ func TestCreateInvalid(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		err  error
-		cols []interface{}
+		cols []any
 	}{
 		{
 			name: "missing-col-def.db",
@@ -627,16 +627,16 @@ func TestCreateInvalid(t *testing.T) {
 		},
 		{
 			name: "one-value.db",
-			cols: []interface{}{int64(0)},
+			cols: []any{int64(0)},
 		},
 		{
 			name: "err-chan.db",
-			cols: []interface{}{make(chan int)},
+			cols: []any{make(chan int)},
 			err:  errChanType,
 		},
 		{
 			name: "err-struct-chan.db",
-			cols: []interface{}{func() interface{} {
+			cols: []any{func() any {
 				type Person struct {
 					Field chan int
 				}
@@ -647,22 +647,22 @@ func TestCreateInvalid(t *testing.T) {
 		},
 		//		{
 		//			name: "err-iface.db",
-		//			cols: []interface{}{(io.Writer)(os.Stdout)},
+		//			cols: []any{(io.Writer)(os.Stdout)},
 		//			err:  errIfaceType,
 		//		},
 		//		{
 		//			name: "err-eface.db",
-		//			cols: []interface{}{interface{}(nil)},
+		//			cols: []any{any(nil)},
 		//			err:  errIfaceType,
 		//		},
 		{
 			name: "err-map.db",
-			cols: []interface{}{make(map[string]int)},
+			cols: []any{make(map[string]int)},
 			err:  errMapType,
 		},
 		{
 			name: "err-struct-map.db",
-			cols: []interface{}{func() interface{} {
+			cols: []any{func() any {
 				type Person struct {
 					Field map[string]int
 				}
@@ -673,12 +673,12 @@ func TestCreateInvalid(t *testing.T) {
 		},
 		{
 			name: "err-slice.db",
-			cols: []interface{}{make([]int, 2)},
+			cols: []any{make([]int, 2)},
 			err:  errSliceType,
 		},
 		{
 			name: "err-struct-slice.db",
-			cols: []interface{}{func() interface{} {
+			cols: []any{func() any {
 				type Person struct {
 					Field []int
 				}
@@ -689,7 +689,7 @@ func TestCreateInvalid(t *testing.T) {
 		},
 		{
 			name: "err-struct.db",
-			cols: []interface{}{func() interface{} {
+			cols: []any{func() any {
 				type Name struct {
 					Name string
 				}
@@ -705,7 +705,7 @@ func TestCreateInvalid(t *testing.T) {
 		},
 		{
 			name: "err-estruct.db",
-			cols: []interface{}{func() interface{} {
+			cols: []any{func() any {
 				type Name struct{}
 				type Anon struct {
 					Name Name
@@ -760,7 +760,7 @@ func init() {
 		panic(err)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		x := float64(i)
 		_, err = tx.Exec("insert into data values($1, $2);", i, x)
 		if err != nil {

--- a/hbook/ops_test.go
+++ b/hbook/ops_test.go
@@ -82,7 +82,7 @@ func ExampleDivideH1D() {
 func TestDivideH1D(t *testing.T) {
 	h1 := NewH1D(5, 0, 5)
 	h2 := NewH1D(5, 0, 5)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		h1.Fill(float64(i), float64(i+1))
 		h2.Fill(float64(i), float64(i+3))
 	}

--- a/hbook/p1d_example_test.go
+++ b/hbook/p1d_example_test.go
@@ -30,7 +30,7 @@ func ExampleP1D() {
 	v := make([]float64, 2)
 	// Draw some random values from the standard
 	// normal distribution.
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		v = dist.Rand(v)
 		p.Fill(v[0], v[1], 1)
 	}

--- a/hbook/p1d_test.go
+++ b/hbook/p1d_test.go
@@ -23,7 +23,7 @@ func TestP1D(t *testing.T) {
 
 	p.Annotation()["name"] = "p1d"
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		v := float64(i)
 		p.Fill(v, v*2, 1)
 	}
@@ -97,7 +97,7 @@ func TestP1DWriteYODA(t *testing.T) {
 		t.Fatalf("nil pointer to P1D")
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		v := float64(i)
 		p.Fill(v, v*2, 1)
 	}
@@ -188,7 +188,7 @@ func TestP1DSerialization(t *testing.T) {
 		t.Fatalf("nil pointer to P1D")
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		v := float64(i)
 		pref.Fill(v, v*2, 1)
 	}

--- a/hbook/rand_h1d_example_test.go
+++ b/hbook/rand_h1d_example_test.go
@@ -32,7 +32,7 @@ func ExampleRand1D() {
 		}
 	)
 
-	for i := 0; i < N; i++ {
+	for range N {
 		h1.Fill(rnd.Rand(), 1)
 	}
 
@@ -41,7 +41,7 @@ func ExampleRand1D() {
 		hr = hbook.NewRand1D(h1, rand.NewSource(5678))
 	)
 
-	for i := 0; i < N; i++ {
+	for range N {
 		h2.Fill(hr.Rand(), 1)
 	}
 

--- a/hbook/rand_h1d_test.go
+++ b/hbook/rand_h1d_test.go
@@ -39,7 +39,7 @@ func TestRand1D(t *testing.T) {
 	}
 
 	const N = 1000
-	for i := 0; i < N; i++ {
+	for range N {
 		h2.Fill(hr.Rand(), 1)
 	}
 

--- a/hbook/rootcnv/root_test.go
+++ b/hbook/rootcnv/root_test.go
@@ -389,7 +389,7 @@ func TestFromH1D(t *testing.T) {
 	// Draw some random values from the standard
 	// normal distribution.
 	h := hbook.NewH1D(20, -4, +4)
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		v := dist.Rand()
 		h.Fill(v, 1)
 	}
@@ -473,7 +473,7 @@ func TestFromH2D(t *testing.T) {
 	// Draw some random values from the standard
 	// normal distribution.
 	h := hbook.NewH2D(5, -4, +4, 6, -4, +4)
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		x := dist.Rand()
 		y := dist.Rand()
 		h.Fill(x, y, 1)

--- a/hbook/s2d.go
+++ b/hbook/s2d.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"sort"
 	"strings"
@@ -64,9 +65,7 @@ type S2DOpts struct {
 // only the first element is considered.
 func NewS2DFromH1D(h *H1D, opts ...S2DOpts) *S2D {
 	s := NewS2D()
-	for k, v := range h.Ann {
-		s.ann[k] = v
-	}
+	maps.Copy(s.ann, h.Ann)
 	var opt S2DOpts
 	if len(opts) > 0 {
 		opt = opts[0]
@@ -103,9 +102,7 @@ func NewS2DFromH1D(h *H1D, opts ...S2DOpts) *S2D {
 // only the first element is considered.
 func NewS2DFromP1D(p *P1D, opts ...S2DOpts) *S2D {
 	s := NewS2D()
-	for k, v := range p.ann {
-		p.ann[k] = v
-	}
+	maps.Copy(s.ann, p.ann)
 	var opt S2DOpts
 	if len(opts) > 0 {
 		opt = opts[0]

--- a/hbook/s2d_test.go
+++ b/hbook/s2d_test.go
@@ -129,7 +129,7 @@ func TestS2DReadYODAv2(t *testing.T) {
 
 func TestS2DSerialization(t *testing.T) {
 	sref := NewS2D()
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		v := float64(i)
 		sref.Fill(Point2D{X: v, Y: v, ErrX: Range{Min: v, Max: 2 * v}, ErrY: Range{Min: v, Max: 3 * v}})
 	}

--- a/hbook/yodacnv/yoda_test.go
+++ b/hbook/yodacnv/yoda_test.go
@@ -113,7 +113,7 @@ func init() {
 	add(h2)
 
 	p1 = hbook.NewP1D(10, -4, +4)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		v := float64(i)
 		p1.Fill(v, v*2, 1)
 	}

--- a/hepevt/ascii_io.go
+++ b/hepevt/ascii_io.go
@@ -26,7 +26,7 @@ func (enc *Encoder) Encode(evt *Event) error {
 		return fmt.Errorf("could not encode event header line: %w", err)
 	}
 
-	for i := 0; i < evt.Nhep; i++ {
+	for i := range evt.Nhep {
 		_, err = fmt.Fprintf(
 			enc.w,
 			"%d %d %d %d %d %d %E %E %E %E %E %E %E %E %E\n",
@@ -82,7 +82,7 @@ func (dec *Decoder) Decode(evt *Event) error {
 		evt.Vhep = append(evt.Vhep, make([][4]float64, sz)...)
 	}
 
-	for i := 0; i < evt.Nhep; i++ {
+	for i := range evt.Nhep {
 		_, err = fmt.Fscanf(
 			dec.r,
 			"%d %d %d %d %d %d %E %E %E %E %E %E %E %E %E\n",

--- a/hepevt/ascii_io_test.go
+++ b/hepevt/ascii_io_test.go
@@ -151,7 +151,7 @@ func TestDecoderFail(t *testing.T) {
 }
 
 func TestEncoderFail(t *testing.T) {
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		nbytes := i
 		t.Run("", func(t *testing.T) {
 			w := newWriter(nbytes)

--- a/hepmc/decoder.go
+++ b/hepmc/decoder.go
@@ -131,7 +131,7 @@ loop:
 				return fmt.Errorf("hepmc: could not decode N token: %w", err)
 			}
 			names := make(map[string]int, nWeights)
-			for i := 0; i < nWeights; i++ {
+			for i := range nWeights {
 				tok := tokens.next()
 				nn, err := strconv.Unquote(tok)
 				if err != nil {
@@ -198,7 +198,7 @@ loop:
 	pidxToEndVtx := make(map[int]int, nVtx) // particle-idx to end_vtx barcode
 
 	// decode the vertices
-	for i := 0; i < nVtx; i++ {
+	for i := range nVtx {
 		if i != 0 {
 			tokens, err = dec.readline()
 			if err != nil {
@@ -440,7 +440,7 @@ func (dec *Decoder) decodeEvent(evt *Event, nVtx *int, tokens tokens) error {
 	}
 
 	rndmStates := make([]int64, nRndm)
-	for i := 0; i < nRndm; i++ {
+	for i := range nRndm {
 		rndmStates[i], err = tokens.int64()
 		if err != nil {
 			return err
@@ -453,7 +453,7 @@ func (dec *Decoder) decodeEvent(evt *Event, nVtx *int, tokens tokens) error {
 	}
 
 	weights := make([]float64, nWeights)
-	for i := 0; i < nWeights; i++ {
+	for i := range nWeights {
 		weights[i], err = tokens.float64()
 		if err != nil {
 			return err
@@ -541,7 +541,7 @@ func (dec *Decoder) decodeVertex(evt *Event, vtx *Vertex, pidxToEndVtx map[int]i
 
 	// FIXME: reuse buffers ?
 	vtx.Weights.Slice = make([]float64, nWeights)
-	for i := 0; i < nWeights; i++ {
+	for i := range nWeights {
 		vtx.Weights.Slice[i], err = tokens.float64()
 		if err != nil {
 			return err
@@ -551,7 +551,7 @@ func (dec *Decoder) decodeVertex(evt *Event, vtx *Vertex, pidxToEndVtx map[int]i
 	// read and create the associated particles
 	// outgoing particles are added to their production vertices immediately.
 	// incoming particles are added to a map and handled later.
-	for i := 0; i < orphans; i++ {
+	for range orphans {
 		p := &Particle{}
 		tokens, err = dec.readline()
 		if err != nil {
@@ -565,7 +565,7 @@ func (dec *Decoder) decodeVertex(evt *Event, vtx *Vertex, pidxToEndVtx map[int]i
 	}
 	// FIXME: reuse buffers ?
 	vtx.ParticlesOut = make([]*Particle, nPartsOut)
-	for i := 0; i < nPartsOut; i++ {
+	for i := range nPartsOut {
 		p := &Particle{ProdVertex: vtx}
 		tokens, err = dec.readline()
 		if err != nil {
@@ -670,7 +670,7 @@ func (dec *Decoder) decodeFlow(flow *Flow, tokens *tokens) error {
 		return err
 	}
 	flow.Icode = make(map[int]int, nFlow)
-	for i := 0; i < nFlow; i++ {
+	for range nFlow {
 		k, err := tokens.int()
 		if err != nil {
 			return err
@@ -876,7 +876,7 @@ func (dec *Decoder) decodeASCII(evt *Event, nVtx *int, tokens tokens) error {
 	}
 
 	rndmStates := make([]int64, nRndm)
-	for i := 0; i < nRndm; i++ {
+	for i := range nRndm {
 		rndmStates[i], err = tokens.int64()
 		if err != nil {
 			return err
@@ -889,7 +889,7 @@ func (dec *Decoder) decodeASCII(evt *Event, nVtx *int, tokens tokens) error {
 	}
 
 	weights := make([]float64, nWeights)
-	for i := 0; i < nWeights; i++ {
+	for i := range nWeights {
 		weights[i], err = tokens.float64()
 		if err != nil {
 			return err

--- a/hepmc/encoder.go
+++ b/hepmc/encoder.go
@@ -123,7 +123,7 @@ func (enc *Encoder) Encode(evt *Event) error {
 		if err != nil {
 			return err
 		}
-		for iw := 0; iw < nn; iw++ {
+		for iw := range nn {
 			_, err = fmt.Fprintf(enc.w, "%q ", names[iw])
 			if err != nil {
 				return err

--- a/hepmc/go-hepmc-dump/main_test.go
+++ b/hepmc/go-hepmc-dump/main_test.go
@@ -61,7 +61,7 @@ func TestDumpFail(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for i := 0; i < len(want)-1; i++ {
+	for range len(want) - 1 {
 		nbytes := 0
 		t.Run("output", func(t *testing.T) {
 			r := bytes.NewReader(ref)

--- a/hepmc/hepmc_test.go
+++ b/hepmc/hepmc_test.go
@@ -55,7 +55,7 @@ func testEventRW(t *testing.T, fname, outfname string, nevts int) {
 
 	const NEVTS = 10
 	evts := make([]*hepmc.Event, 0, NEVTS)
-	for ievt := 0; ievt < NEVTS; ievt++ {
+	for ievt := range NEVTS {
 		var evt hepmc.Event
 		err = dec.Decode(&evt)
 		if err != nil {
@@ -182,7 +182,7 @@ func TestRead(t *testing.T) {
 
 	const NEVTS = 10
 	const fname = "small.hepmc"
-	for ievt := 0; ievt < NEVTS; ievt++ {
+	for ievt := range NEVTS {
 		var evt hepmc.Event
 		err := dec.Decode(&evt)
 		if err != nil {

--- a/hplot/band_example_test.go
+++ b/hplot/band_example_test.go
@@ -36,7 +36,7 @@ func ExampleBand() {
 
 	// Draw some random values from the standard
 	// normal distribution.
-	for i := 0; i < npoints; i++ {
+	for i := range npoints {
 		x := float64(i+1) / xmax
 
 		v1 := dist.Rand()

--- a/hplot/binerrband_example_test.go
+++ b/hplot/binerrband_example_test.go
@@ -60,7 +60,7 @@ func ExampleBinnedErrBand_fromH1D() {
 
 	// Histogram
 	h := hbook.NewH1D(20, -5, 5)
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		x := gauss.Rand()
 		if 0 < x && x < 0.5 {
 			continue
@@ -98,7 +98,7 @@ func ExampleBinnedErrBand_fromH1D() {
 func newBinning(n int, xmin, xmax float64) []hbook.Range {
 	res := make([]hbook.Range, n)
 	dx := (xmax - xmin) / float64(n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		lo := xmin + float64(i)*dx
 		hi := lo + dx
 		res[i].Min = lo

--- a/hplot/example_test.go
+++ b/hplot/example_test.go
@@ -33,7 +33,7 @@ func Example_subplot() {
 	// Draw some random values from the standard
 	// normal distribution.
 	hist := hbook.NewH1D(20, -4, +4)
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		v := dist.Rand()
 		hist.Fill(v, 1)
 	}
@@ -117,7 +117,7 @@ func Example_latexplot() {
 	}
 
 	hist := hbook.NewH1D(20, -4, +4)
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		v := dist.Rand()
 		hist.Fill(v, 1)
 	}

--- a/hplot/functions.go
+++ b/hplot/functions.go
@@ -63,7 +63,7 @@ func (f *Function) Plot(c draw.Canvas, p *plot.Plot) {
 			line  = 0
 			lines = [][]vg.Point{make([]vg.Point, 0, f.Samples)}
 		)
-		for i := 0; i < f.Samples; i++ {
+		for i := range f.Samples {
 			x := min + float64(i)*d
 			y := f.F(x)
 			switch {

--- a/hplot/h1d.go
+++ b/hplot/h1d.go
@@ -487,7 +487,7 @@ func newHistFromXYer(xys plotter.XYer, n int) *hbook.H1D {
 	xmin, xmax := plotter.Range(plotter.XValues{XYer: xys})
 	h := hbook.NewH1D(n, xmin, xmax)
 
-	for i := 0; i < xys.Len(); i++ {
+	for i := range xys.Len() {
 		x, y := xys.XY(i)
 		h.Fill(x, y)
 	}
@@ -615,7 +615,7 @@ func (l *histLegend) entryWidth() (width vg.Length) {
 // Add adds an entry to the legend with the given name.
 // The entry's thumbnail is drawn as the composite of all of the
 // thumbnails.
-func (l *histLegend) Add(name string, value interface{}) {
+func (l *histLegend) Add(name string, value any) {
 	str := ""
 	switch value.(type) {
 	case float64, float32:

--- a/hplot/h1d_example_test.go
+++ b/hplot/h1d_example_test.go
@@ -32,7 +32,7 @@ func ExampleH1D() {
 	// Draw some random values from the standard
 	// normal distribution.
 	hist := hbook.NewH1D(20, -4, +4)
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		v := dist.Rand()
 		hist.Fill(v, 1)
 	}
@@ -85,7 +85,7 @@ func ExampleH1D_toPDF() {
 	// Draw some random values from the standard
 	// normal distribution.
 	hist := hbook.NewH1D(20, -4, +4)
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		v := dist.Rand()
 		hist.Fill(v, 1)
 	}
@@ -186,7 +186,7 @@ func ExampleH1D_withYErrBars() {
 	// Draw some random values from the standard
 	// normal distribution.
 	hist := hbook.NewH1D(20, -4, +4)
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		v := dist.Rand()
 		hist.Fill(v, 1)
 	}
@@ -243,7 +243,7 @@ func ExampleH1D_withYErrBars_withBand() {
 	// Draw some random values from the standard
 	// normal distribution.
 	hist := hbook.NewH1D(20, -4, +4)
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		v := dist.Rand()
 		hist.Fill(v, 1)
 	}
@@ -301,7 +301,7 @@ func ExampleH1D_withYErrBarsAndData() {
 	// Draw some random values from the standard
 	// normal distribution.
 	hist := hbook.NewH1D(20, -4, +4)
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		v := dist.Rand()
 		hist.Fill(v, 1)
 	}
@@ -369,7 +369,7 @@ func ExampleH1D_withPlotBorders() {
 	// Draw some random values from the standard
 	// normal distribution.
 	hist := hbook.NewH1D(20, -4, +4)
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		v := dist.Rand()
 		hist.Fill(v, 1)
 	}
@@ -438,7 +438,7 @@ func ExampleH1D_legendStyle() {
 		// Draw some random values from the standard
 		// normal distribution.
 		hists[id] = hbook.NewH1D(15, mu-4*sigma, mu+4*sigma)
-		for i := 0; i < npoints; i++ {
+		for range npoints {
 			v := dist.Rand()
 			hists[id].Fill(v, 1)
 		}

--- a/hplot/h1d_test.go
+++ b/hplot/h1d_test.go
@@ -75,7 +75,7 @@ func TestH1DWithBorders(t *testing.T) {
 		// Draw some random values from the standard
 		// normal distribution.
 		hist := hbook.NewH1D(20, -4, +4)
-		for i := 0; i < npoints; i++ {
+		for range npoints {
 			v := dist.Rand()
 			hist.Fill(v, 1)
 		}

--- a/hplot/h2d_example_test.go
+++ b/hplot/h2d_example_test.go
@@ -33,7 +33,7 @@ func ExampleH2D() {
 	v := make([]float64, 2)
 	// Draw some random values from the standard
 	// normal distribution.
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		v = dist.Rand(v)
 		h.Fill(v[0], v[1], 1)
 	}
@@ -68,7 +68,7 @@ func ExampleH2D_withLegend() {
 	v := make([]float64, 2)
 	// Draw some random values from the standard
 	// normal distribution.
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		v = dist.Rand(v)
 		h2d.Fill(v[0], v[1], 1)
 	}

--- a/hplot/h2d_test.go
+++ b/hplot/h2d_test.go
@@ -67,9 +67,9 @@ func TestH2MinMax(t *testing.T) {
 			{2, 1}: 1,
 			{2, 2}: 2,
 		}
-		for i := 0; i < n; i++ {
+		for i := range n {
 			ix := float64(i)
-			for j := 0; j < n; j++ {
+			for j := range n {
 				iy := float64(j)
 				p := pair{i, j}
 				v := ws[p]

--- a/hplot/hstack_example_test.go
+++ b/hplot/hstack_example_test.go
@@ -353,7 +353,7 @@ func fillH1(h *hbook.H1D, n int, mu, sigma float64, seed uint64) {
 		Src:   rand.New(rand.NewSource(seed)),
 	}
 
-	for i := 0; i < n; i++ {
+	for range n {
 		v := dist.Rand()
 		h.Fill(v, 1)
 	}

--- a/hplot/htex/handler_example_test.go
+++ b/hplot/htex/handler_example_test.go
@@ -15,7 +15,7 @@ import (
 func ExampleGoHandler() {
 	hdlr := htex.NewGoHandler(-1, "pdflatex")
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		name := fmt.Sprintf("plot-%0d", i)
 		p := hplot.New()
 		p.Title.Text = name

--- a/hplot/htex/handler_test.go
+++ b/hplot/htex/handler_test.go
@@ -67,7 +67,7 @@ func TestGoHandler(t *testing.T) {
 
 			fig := hplot.Figure(p, hplot.WithLatexHandler(tc.latex))
 
-			for i := 0; i < 10; i++ {
+			for i := range 10 {
 				fname := fmt.Sprintf("%s/%s-%02d.tex", tmp, name, i)
 				defer os.RemoveAll(fname)
 

--- a/hplot/plot_test.go
+++ b/hplot/plot_test.go
@@ -48,7 +48,7 @@ func TestNewPlotRace(t *testing.T) {
 	const N = 100
 	var wg sync.WaitGroup
 	wg.Add(N)
-	for i := 0; i < N; i++ {
+	for range N {
 		go func() {
 			defer wg.Done()
 

--- a/hplot/ratioplot_example_test.go
+++ b/hplot/ratioplot_example_test.go
@@ -30,7 +30,7 @@ func ExampleRatioPlot() {
 	hist1 := hbook.NewH1D(20, -4, +4)
 	hist2 := hbook.NewH1D(20, -4, +4)
 
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		v1 := dist.Rand() - 0.5
 		v2 := dist.Rand() + 0.5
 		hist1.Fill(v1, 1)
@@ -57,7 +57,7 @@ func ExampleRatioPlot() {
 	rp.Top.Add(hplot.NewGrid())
 
 	hist3 := hbook.NewH1D(20, -4, +4)
-	for i := 0; i < hist3.Len(); i++ {
+	for i := range hist3.Len() {
 		v1 := hist1.Value(i)
 		v2 := hist2.Value(i)
 		x1, _ := hist1.XY(i)

--- a/hplot/s2d.go
+++ b/hplot/s2d.go
@@ -173,7 +173,7 @@ func (pts *S2D) Plot(c draw.Canvas, plt *plot.Plot) {
 		pts.Band.Plot(c, plt)
 	}
 
-	for i := 0; i < pts.Data.Len(); i++ {
+	for i := range pts.Data.Len() {
 		x, y := pts.Data.XY(i)
 		c.DrawGlyph(pts.GlyphStyle, vg.Point{X: trX(x), Y: trY(y)})
 	}
@@ -246,7 +246,7 @@ func (pts *S2D) DataRange() (xmin, xmax, ymin, ymax float64) {
 // implementing the plot.GlyphBoxer interface.
 func (pts *S2D) GlyphBoxes(plt *plot.Plot) []plot.GlyphBox {
 	bs := make([]plot.GlyphBox, pts.Data.Len())
-	for i := 0; i < pts.Data.Len(); i++ {
+	for i := range pts.Data.Len() {
 		x, y := pts.Data.XY(i)
 		bs[i].X = plt.X.Norm(x)
 		bs[i].Y = plt.Y.Norm(y)

--- a/hplot/s2d_example_test.go
+++ b/hplot/s2d_example_test.go
@@ -37,7 +37,7 @@ func ExampleS2D() {
 	v := make([]float64, 2)
 	// Draw some random values from the standard
 	// normal distribution.
-	for i := 0; i < npoints; i++ {
+	for range npoints {
 		v = dist.Rand(v)
 		s2d.Fill(hbook.Point2D{X: v[0], Y: v[1]})
 	}

--- a/hplot/ticks_example_test.go
+++ b/hplot/ticks_example_test.go
@@ -20,8 +20,8 @@ func ExampleTicks() {
 	tp := hplot.NewTiledPlot(draw.Tiles{Cols: 2, Rows: 8})
 	tp.Align = true
 
-	for i := 0; i < tp.Tiles.Rows; i++ {
-		for j := 0; j < tp.Tiles.Cols; j++ {
+	for i := range tp.Tiles.Rows {
+		for j := range tp.Tiles.Cols {
 			p := tp.Plot(j, i)
 			switch i {
 			case 0:

--- a/hplot/tiledplot.go
+++ b/hplot/tiledplot.go
@@ -35,8 +35,8 @@ func NewTiledPlot(tiles draw.Tiles) *TiledPlot {
 		Tiles: tiles,
 	}
 
-	for i := 0; i < tiles.Rows; i++ {
-		for j := 0; j < tiles.Cols; j++ {
+	for i := range tiles.Rows {
+		for j := range tiles.Cols {
 			plot.Plots[i*tiles.Cols+j] = New()
 		}
 	}
@@ -59,7 +59,7 @@ func (tp *TiledPlot) Draw(c draw.Canvas) {
 	switch {
 	case tp.Align:
 		ps := make([][]*plot.Plot, tp.Tiles.Rows)
-		for row := 0; row < tp.Tiles.Rows; row++ {
+		for row := range tp.Tiles.Rows {
 			ps[row] = make([]*plot.Plot, tp.Tiles.Cols)
 			for col := range ps[row] {
 				p := tp.Plots[row*tp.Tiles.Cols+col]
@@ -70,8 +70,8 @@ func (tp *TiledPlot) Draw(c draw.Canvas) {
 			}
 		}
 		cs := plot.Align(ps, tp.Tiles, c)
-		for i := 0; i < tp.Tiles.Rows; i++ {
-			for j := 0; j < tp.Tiles.Cols; j++ {
+		for i := range tp.Tiles.Rows {
+			for j := range tp.Tiles.Cols {
 				p := ps[i][j]
 				if p == nil {
 					continue
@@ -81,8 +81,8 @@ func (tp *TiledPlot) Draw(c draw.Canvas) {
 		}
 
 	default:
-		for row := 0; row < tp.Tiles.Rows; row++ {
-			for col := 0; col < tp.Tiles.Cols; col++ {
+		for row := range tp.Tiles.Rows {
+			for col := range tp.Tiles.Cols {
 				sub := tp.Tiles.At(c, col, row)
 				i := row*tp.Tiles.Cols + col
 				p := tp.Plots[i]

--- a/hplot/tiledplot_example_test.go
+++ b/hplot/tiledplot_example_test.go
@@ -32,7 +32,7 @@ func ExampleTiledPlot() {
 	newHist := func(p *hplot.Plot) {
 		const npoints = 10000
 		hist := hbook.NewH1D(20, -4, +4)
-		for i := 0; i < npoints; i++ {
+		for range npoints {
 			v := dist.Rand()
 			hist.Fill(v, 1)
 		}
@@ -41,8 +41,8 @@ func ExampleTiledPlot() {
 		p.Add(h)
 	}
 
-	for i := 0; i < tp.Tiles.Rows; i++ {
-		for j := 0; j < tp.Tiles.Cols; j++ {
+	for i := range tp.Tiles.Rows {
+		for j := range tp.Tiles.Cols {
 			p := tp.Plot(j, i)
 			p.X.Min = -5
 			p.X.Max = +5
@@ -74,7 +74,7 @@ func ExampleTiledPlot_align() {
 		j = int(math.Pow(10, float64(n)))
 
 		var pts []hbook.Point2D
-		for ii := 0; ii < 10; ii++ {
+		for ii := range 10 {
 			pts = append(pts, hbook.Point2D{
 				X: float64(i + ii),
 				Y: float64(j + ii + 1),
@@ -84,8 +84,8 @@ func ExampleTiledPlot_align() {
 
 	}
 
-	for i := 0; i < tp.Tiles.Rows; i++ {
-		for j := 0; j < tp.Tiles.Cols; j++ {
+	for i := range tp.Tiles.Rows {
+		for j := range tp.Tiles.Cols {
 			p := tp.Plot(j, i)
 			p.X.Min = -5
 			p.X.Max = +5

--- a/hplot/vgop/canvas.go
+++ b/hplot/vgop/canvas.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"image"
 	"image/color"
+	"slices"
 
 	"gonum.org/v1/plot/font"
 	"gonum.org/v1/plot/vg"
@@ -105,7 +106,7 @@ func (c *Canvas) SetLineWidth(w vg.Length) {
 // SetLineDash implements the SetLineDash method of the vg.Canvas interface.
 func (c *Canvas) SetLineDash(dashes []vg.Length, offs vg.Length) {
 	c.append(opSetLineDash{
-		Dashes:  append([]vg.Length(nil), dashes...),
+		Dashes:  slices.Clone(dashes),
 		Offsets: offs,
 	})
 }
@@ -142,12 +143,12 @@ func (c *Canvas) Pop() {
 
 // Stroke implements the Stroke method of the vg.Canvas interface.
 func (c *Canvas) Stroke(path vg.Path) {
-	c.append(opStroke{Path: append(vg.Path(nil), path...)})
+	c.append(opStroke{Path: slices.Clone(path)})
 }
 
 // Fill implements the Fill method of the vg.Canvas interface.
 func (c *Canvas) Fill(path vg.Path) {
-	c.append(opFill{Path: append(vg.Path(nil), path...)})
+	c.append(opFill{Path: slices.Clone(path)})
 }
 
 // FillString implements the FillString method of the vg.Canvas interface.

--- a/lcio/calohit_test.go
+++ b/lcio/calohit_test.go
@@ -40,7 +40,7 @@ func testRWCalo(t *testing.T, compLevel int, fname string) {
 		CALHITSERR = "CalorimeterHitsWithEnergyError"
 	)
 
-	for i := 0; i < nevents; i++ {
+	for i := range nevents {
 		evt := lcio.Event{
 			RunNumber:   4711,
 			EventNumber: int32(i),
@@ -50,7 +50,7 @@ func testRWCalo(t *testing.T, compLevel int, fname string) {
 			calhits    = lcio.CalorimeterHitContainer{Flags: lcio.BitsRChLong}
 			calhitsErr = lcio.CalorimeterHitContainer{Flags: lcio.BitsRChLong | lcio.BitsRChEnergyError}
 		)
-		for j := 0; j < nhits; j++ {
+		for j := range nhits {
 			hit := lcio.CalorimeterHit{
 				CellID0:   int32(i*100000 + j),
 				Energy:    float32(i*j) + 117,
@@ -85,7 +85,7 @@ func testRWCalo(t *testing.T, compLevel int, fname string) {
 	}
 	defer r.Close()
 
-	for i := 0; i < nevents; i++ {
+	for i := range nevents {
 		if !r.Next() {
 			t.Errorf("%s: error reading event %d", fname, i)
 			return
@@ -114,7 +114,7 @@ func testRWCalo(t *testing.T, compLevel int, fname string) {
 		calhits := evt.Get(CALHITS).(*lcio.CalorimeterHitContainer)
 		calhitsErr := evt.Get(CALHITSERR).(*lcio.CalorimeterHitContainer)
 
-		for j := 0; j < nhits; j++ {
+		for j := range nhits {
 			got := calhits.Hits[j]
 			want := lcio.CalorimeterHit{
 				CellID0: int32(i*100000 + j),

--- a/lcio/cluster_test.go
+++ b/lcio/cluster_test.go
@@ -40,7 +40,7 @@ func testRWCluster(t *testing.T, compLevel int, fname string) {
 		CLUSERR = "ClustersWithEnergyError"
 	)
 
-	for i := 0; i < nevents; i++ {
+	for i := range nevents {
 		evt := lcio.Event{
 			RunNumber:   4711,
 			EventNumber: int32(i),
@@ -50,7 +50,7 @@ func testRWCluster(t *testing.T, compLevel int, fname string) {
 			clus    = lcio.ClusterContainer{Flags: lcio.BitsRChLong}
 			clusErr = lcio.ClusterContainer{Flags: lcio.BitsRChLong | lcio.BitsRChEnergyError}
 		)
-		for j := 0; j < N; j++ {
+		for j := range N {
 			clu := lcio.Cluster{
 				Energy: float32(i*j) + 117,
 				Pos:    [3]float32{float32(i), float32(j), float32(i * j)},
@@ -83,7 +83,7 @@ func testRWCluster(t *testing.T, compLevel int, fname string) {
 	}
 	defer r.Close()
 
-	for i := 0; i < nevents; i++ {
+	for i := range nevents {
 		if !r.Next() {
 			t.Errorf("%s: error reading event %d", fname, i)
 			return
@@ -112,7 +112,7 @@ func testRWCluster(t *testing.T, compLevel int, fname string) {
 		clus := evt.Get(CLUS).(*lcio.ClusterContainer)
 		clusErr := evt.Get(CLUSERR).(*lcio.ClusterContainer)
 
-		for j := 0; j < N; j++ {
+		for j := range N {
 			got := clus.Clusters[j]
 			want := lcio.Cluster{
 				Clusters:   []*lcio.Cluster{},

--- a/lcio/collections.go
+++ b/lcio/collections.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ID returns a unique identifier for ptr.
-func ID(ptr interface{}) uint32 {
+func ID(ptr any) uint32 {
 	rptr := reflect.ValueOf(ptr)
 	if !rptr.IsValid() || rptr.IsNil() {
 		return 0
@@ -420,8 +420,8 @@ type RelationContainer struct {
 }
 
 type Relation struct {
-	From   interface{}
-	To     interface{}
+	From   any
+	To     any
 	Weight float32
 }
 
@@ -489,7 +489,7 @@ func (rc *RelationContainer) UnmarshalSio(r sio.Reader) error {
 type References struct {
 	Flags  Flags
 	Params Params
-	Refs   []interface{}
+	Refs   []any
 }
 
 func (*References) VersionSio() uint32 {
@@ -514,7 +514,7 @@ func (refs *References) UnmarshalSio(r sio.Reader) error {
 	dec.Decode(&refs.Params)
 	var n int32
 	dec.Decode(&n)
-	refs.Refs = make([]interface{}, int(n))
+	refs.Refs = make([]any, int(n))
 	for i := range refs.Refs {
 		ref := &refs.Refs[i]
 		dec.Pointer(ref)

--- a/lcio/event.go
+++ b/lcio/event.go
@@ -269,7 +269,7 @@ type Event struct {
 	TimeStamp   int64
 	Detector    string
 	Params      Params
-	colls       map[string]interface{}
+	colls       map[string]any
 	names       []string
 }
 
@@ -279,7 +279,7 @@ func (evt *Event) Names() []string {
 }
 
 // Get returns the event data labelled name.
-func (evt *Event) Get(name string) interface{} {
+func (evt *Event) Get(name string) any {
 	return evt.colls[name]
 }
 
@@ -293,13 +293,13 @@ func (evt *Event) Has(name string) bool {
 // with the given name.
 // Add panics if there is already some data labelled with the same name.
 // Add panics if ptr is not a pointer to some data.
-func (evt *Event) Add(name string, ptr interface{}) {
+func (evt *Event) Add(name string, ptr any) {
 	if _, dup := evt.colls[name]; dup {
 		panic(fmt.Errorf("lcio: duplicate key %q", name))
 	}
 	evt.names = append(evt.names, name)
 	if evt.colls == nil {
-		evt.colls = make(map[string]interface{})
+		evt.colls = make(map[string]any)
 	}
 	if rv := reflect.ValueOf(ptr); rv.Type().Kind() != reflect.Ptr {
 		panic("lcio: expects a pointer to a value")

--- a/lcio/reader.go
+++ b/lcio/reader.go
@@ -147,7 +147,7 @@ func (r *Reader) remap() error {
 	r.evt.colls = nil
 	r.evt.names = nil
 	if len(r.ehdr.Blocks) > 0 {
-		r.evt.colls = make(map[string]interface{}, len(r.ehdr.Blocks))
+		r.evt.colls = make(map[string]any, len(r.ehdr.Blocks))
 		r.evt.names = make([]string, 0, len(r.ehdr.Blocks))
 		for _, blk := range r.ehdr.Blocks {
 			ptr := typeFrom(blk.Type)

--- a/lcio/types.go
+++ b/lcio/types.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-func typeFrom(name string) interface{} {
+func typeFrom(name string) any {
 	switch name {
 	case "MCParticle":
 		return new(McParticleContainer)
@@ -59,7 +59,7 @@ func typeFrom(name string) interface{} {
 	panic(fmt.Errorf("unhandled type %q", name))
 }
 
-func typeName(t interface{}) string {
+func typeName(t any) string {
 	switch t.(type) {
 	case *McParticleContainer:
 		return "MCParticle"

--- a/lcio/writer_test.go
+++ b/lcio/writer_test.go
@@ -43,7 +43,7 @@ func ExampleWriter() {
 	}
 
 	const NEVENTS = 1
-	for ievt := 0; ievt < NEVENTS; ievt++ {
+	for ievt := range NEVENTS {
 		evt := lcio.Event{
 			RunNumber:   run.RunNumber,
 			Detector:    run.Detector,
@@ -239,7 +239,7 @@ func testCreateEvent(t *testing.T, compLevel int, fname string) {
 			Ints:    map[string][]int32{},
 		},
 	}
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		i32 := int32(i+1) * 10
 		f32 := float32(i+1) * 10
 		f64 := float64(i+1) * 10

--- a/lhef/reader.go
+++ b/lhef/reader.go
@@ -133,7 +133,7 @@ Loop:
 	d.Run.XMAXUP = f64[2*n:]
 	d.Run.LPRUP = make([]int32, n)
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		_, err = fmt.Fscanf(
 			buf,
 			"%f %f %f %d\n",
@@ -258,7 +258,7 @@ func (d *Decoder) Decode() (*HEPEUP, error) {
 	f64 := make([]float64, 2*n)
 	evt.VTIMUP = f64[:n:n]
 	evt.SPINUP = f64[n:]
-	for i := 0; i < n; i++ {
+	for i := range n {
 		_, err = fmt.Fscanf(
 			buf,
 			"%d %d %d %d %d %d %f %f %f %f %f %f %f\n",

--- a/lhef/writer.go
+++ b/lhef/writer.go
@@ -76,7 +76,7 @@ func (e *Encoder) init() error {
 		return err
 	}
 
-	for i := 0; i < int(run.NPRUP); i++ {
+	for i := range int(run.NPRUP) {
 		_, err = fmt.Fprintf(
 			e.w,
 			" %13.6E %13.6E %13.6E %5d\n",
@@ -146,7 +146,7 @@ func (e *Encoder) Encode(evt *HEPEUP) error {
 		return err
 	}
 
-	for i := 0; i < int(evt.NUP); i++ {
+	for i := range int(evt.NUP) {
 		_, err = fmt.Fprintf(
 			e.w,
 			" %7d %4d %4d %4d %4d %4d %17.10E %17.10E %17.10E %17.10E %17.10E %1.f. %1.f.\n",

--- a/rio/block.go
+++ b/rio/block.go
@@ -41,7 +41,7 @@ func (blk *Block) RioVersion() Version {
 }
 
 // Write writes data to the Writer, in the rio format
-func (blk *Block) Write(data interface{}) error {
+func (blk *Block) Write(data any) error {
 	var err error
 
 	buf := new(bytes.Buffer) // FIXME(sbinet): use a sync.Pool
@@ -57,7 +57,7 @@ func (blk *Block) Write(data interface{}) error {
 }
 
 // Read reads data from the Reader, in the rio format
-func (blk *Block) Read(data interface{}) error {
+func (blk *Block) Read(data any) error {
 	var err error
 	buf := bytes.NewReader(blk.raw.Data) // FIXME(sbinet): use a sync.Pool
 	dec := decoder{r: buf}

--- a/rio/file.go
+++ b/rio/file.go
@@ -87,7 +87,7 @@ func (f *File) Keys() []RecordDesc {
 }
 
 // Get reads the value `name` into `ptr`
-func (f *File) Get(name string, ptr interface{}) error {
+func (f *File) Get(name string, ptr any) error {
 	offsets, ok := f.meta.Offsets[name]
 	if !ok {
 		return fmt.Errorf("rio: no record [%s]", name)

--- a/rio/reader.go
+++ b/rio/reader.go
@@ -103,7 +103,7 @@ type decoder struct {
 	r io.Reader
 }
 
-func (dec *decoder) Decode(v interface{}) error {
+func (dec *decoder) Decode(v any) error {
 	switch v := v.(type) {
 	case Unmarshaler:
 		return v.RioUnmarshal(dec.r)

--- a/rio/record.go
+++ b/rio/record.go
@@ -46,7 +46,7 @@ func newRecord(name string, options Options) *Record {
 }
 
 // Connect connects a Block to this Record (for reading or writing)
-func (rec *Record) Connect(name string, ptr interface{}) error {
+func (rec *Record) Connect(name string, ptr any) error {
 	_, dup := rec.bmap[name]
 	if dup {
 		return fmt.Errorf("rio: block [%s] already connected to record [%s]", name, rec.Name())

--- a/rio/rio_test.go
+++ b/rio/rio_test.go
@@ -107,7 +107,7 @@ func TestRW(t *testing.T) {
 	const nmax = 100
 	makeles := func(i int) []electron {
 		eles := make([]electron, 0, nmax)
-		for j := 0; j < nmax; j++ {
+		for range nmax {
 			eles = append(
 				eles,
 				electron{[4]float64{float64(i), float64(i + 1), float64(i + 2), float64(i + 3)}},
@@ -117,7 +117,7 @@ func TestRW(t *testing.T) {
 	}
 	makemuons := func(i int) []muon {
 		muons := make([]muon, 0, nmax)
-		for j := 0; j < nmax; j++ {
+		for range nmax {
 			muons = append(
 				muons,
 				muon{[4]float64{float64(-i), float64(-i - 1), float64(-i - 2), float64(-i - 3)}},
@@ -211,7 +211,7 @@ func TestRW(t *testing.T) {
 		}
 		wblk := wrec.Block("event")
 
-		for i := 0; i < nmax; i++ {
+		for i := range nmax {
 			data := event{
 				runnbr: int64(i),
 				evtnbr: int64(1000 + i),
@@ -252,7 +252,7 @@ func TestRW(t *testing.T) {
 		}
 		rblk := rrec.Block("event")
 
-		for i := 0; i < nmax; i++ {
+		for i := range nmax {
 			err := rrec.Read()
 			if err != nil {
 				t.Fatalf("test[%d]: error loading record[%d]: %v\nbuf: %v\nraw: %#v\n", ii, i, err,

--- a/rio/scanner_test.go
+++ b/rio/scanner_test.go
@@ -81,7 +81,7 @@ func TestScanner(t *testing.T) {
 
 func makeEvents(n int) []event {
 	evts := make([]event, 0, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		evts = append(evts, event{
 			runnbr: int64(1000 + n),
 			evtnbr: int64(10000 + n),

--- a/rio/writer.go
+++ b/rio/writer.go
@@ -150,7 +150,7 @@ func (w *Writer) writeRecord(rec *Record, hdr, data []byte) error {
 
 // WriteValue writes a value to the stream.
 // The value is written to a record named `name` with one block `name`.
-func (w *Writer) WriteValue(name string, value interface{}) error {
+func (w *Writer) WriteValue(name string, value any) error {
 	var err error
 
 	rec := w.Record(name)
@@ -178,7 +178,7 @@ type encoder struct {
 	w io.Writer
 }
 
-func (enc *encoder) Encode(v interface{}) error {
+func (enc *encoder) Encode(v any) error {
 	switch v := v.(type) {
 	case Marshaler:
 		return v.RioMarshal(enc.w)

--- a/sio/decoder.go
+++ b/sio/decoder.go
@@ -23,7 +23,7 @@ func NewDecoder(r Reader) *Decoder {
 
 // Decode reads the next value from the input sio stream and stores it in
 // the data, an empty interface value wrapping a pointer to a concrete value.
-func (dec *Decoder) Decode(ptr interface{}) {
+func (dec *Decoder) Decode(ptr any) {
 	if dec.err != nil {
 		return
 	}
@@ -33,7 +33,7 @@ func (dec *Decoder) Decode(ptr interface{}) {
 
 // Tag tags a pointer, assigning it a unique identifier, so links between values
 // (inside a given SIO record) can be rebuilt.
-func (dec *Decoder) Tag(ptr interface{}) {
+func (dec *Decoder) Tag(ptr any) {
 	if dec.err != nil {
 		return
 	}
@@ -42,7 +42,7 @@ func (dec *Decoder) Tag(ptr interface{}) {
 
 // Pointer marks a (pointer to a) pointer, assigning it a unique identifier,
 // so links between values (inside a given SIO record) can be rebuilt.
-func (dec *Decoder) Pointer(ptr interface{}) {
+func (dec *Decoder) Pointer(ptr any) {
 	if dec.err != nil {
 		return
 	}
@@ -56,14 +56,14 @@ func (dec *Decoder) Err() error {
 
 // unmarshal unmarshals a stream of bytes into ptr.
 // If ptr implements Codec, use it.
-func unmarshal(r Reader, ptr interface{}) error {
+func unmarshal(r Reader, ptr any) error {
 	if ptr, ok := ptr.(Unmarshaler); ok {
 		return ptr.UnmarshalSio(r)
 	}
 	return bread(r, ptr)
 }
 
-func bread(r Reader, data interface{}) error {
+func bread(r Reader, data any) error {
 	bo := binary.BigEndian
 	rv := reflect.ValueOf(data)
 	//fmt.Printf("::: [%v] :::...\n", rv.Type())
@@ -113,7 +113,7 @@ func bread(r Reader, data interface{}) error {
 		}
 		//fmt.Printf("<<< slice: %d [%v]\n", sz, rv.Type())
 		slice := reflect.MakeSlice(rv.Type(), int(sz), int(sz))
-		for i := 0; i < int(sz); i++ {
+		for i := range int(sz) {
 			err = unmarshal(r, slice.Index(i).Addr().Interface())
 			if err != nil {
 				return err

--- a/sio/encoder.go
+++ b/sio/encoder.go
@@ -22,7 +22,7 @@ func NewEncoder(w Writer) *Encoder {
 }
 
 // Encode writes the next value to the output sio stream.
-func (enc *Encoder) Encode(data interface{}) {
+func (enc *Encoder) Encode(data any) {
 	if enc.err != nil {
 		return
 	}
@@ -31,7 +31,7 @@ func (enc *Encoder) Encode(data interface{}) {
 
 // Tag tags a pointer, assigning it a unique identifier, so links between values
 // (inside a given sio record) can be stored.
-func (enc *Encoder) Tag(ptr interface{}) {
+func (enc *Encoder) Tag(ptr any) {
 	if enc.err != nil {
 		return
 	}
@@ -40,7 +40,7 @@ func (enc *Encoder) Tag(ptr interface{}) {
 
 // Pointer marks a (pointer to a) pointer, assigning it a unique identifier,
 // so links between values (inside a given SIO record) can be stored.
-func (enc *Encoder) Pointer(ptr interface{}) {
+func (enc *Encoder) Pointer(ptr any) {
 	if enc.err != nil {
 		return
 	}
@@ -54,14 +54,14 @@ func (dec *Encoder) Err() error {
 
 // marshal marshals ptr to a stream of bytes.
 // If ptr implements Codec, use it.
-func marshal(w Writer, ptr interface{}) error {
+func marshal(w Writer, ptr any) error {
 	if ptr, ok := ptr.(Marshaler); ok {
 		return ptr.MarshalSio(w)
 	}
 	return bwrite(w, ptr)
 }
 
-func bwrite(w Writer, data interface{}) error {
+func bwrite(w Writer, data any) error {
 
 	bo := binary.BigEndian
 	rrv := reflect.ValueOf(data)
@@ -107,7 +107,7 @@ func bwrite(w Writer, data interface{}) error {
 		if err != nil {
 			return err
 		}
-		for i := 0; i < int(sz); i++ {
+		for i := range int(sz) {
 			err = marshal(w, rv.Index(i).Addr().Interface())
 			if err != nil {
 				return err

--- a/sio/record.go
+++ b/sio/record.go
@@ -77,7 +77,7 @@ func (rec *Record) Disconnect() {
 }
 
 // Connect connects a Block to this Record (for reading or writing)
-func (rec *Record) Connect(name string, ptr interface{}) error {
+func (rec *Record) Connect(name string, ptr any) error {
 	var err error
 	iblk, ok := rec.bindex[name]
 	if !ok {
@@ -177,7 +177,7 @@ func (rec *Record) read(r *reader) error {
 			if beg-end != int(hdr.Len) {
 				/*
 					if true {
-						var typ interface{}
+						var typ any
 						switch blk := blk.(type) {
 						case *userBlock:
 							typ = blk.blk

--- a/sio/sio.go
+++ b/sio/sio.go
@@ -19,8 +19,8 @@ type Reader interface {
 	io.Reader
 
 	Versioner
-	Tag(ptr interface{}) error
-	Pointer(ptr interface{}) error
+	Tag(ptr any) error
+	Pointer(ptr any) error
 }
 
 // Writer is the interface that wraps the basic io.Writer interface
@@ -29,8 +29,8 @@ type Writer interface {
 	io.Writer
 
 	Versioner
-	Tag(ptr interface{}) error
-	Pointer(ptr interface{}) error
+	Tag(ptr any) error
+	Pointer(ptr any) error
 }
 
 // Marshaler is the interface implemented by an object that can marshal
@@ -68,15 +68,15 @@ type Versioner interface {
 type reader struct {
 	buf *bytes.Buffer
 	ver uint32
-	ptr map[interface{}]uint32
-	tag map[interface{}]uint32
+	ptr map[any]uint32
+	tag map[any]uint32
 }
 
 func newReader(data []byte) *reader {
 	return &reader{
 		buf: bytes.NewBuffer(data),
-		ptr: make(map[interface{}]uint32),
-		tag: make(map[interface{}]uint32),
+		ptr: make(map[any]uint32),
+		tag: make(map[any]uint32),
 	}
 }
 
@@ -102,7 +102,7 @@ func (r *reader) VersionSio() uint32 {
 	return maj*1000 + min
 }
 
-func (r *reader) Tag(ptr interface{}) error {
+func (r *reader) Tag(ptr any) error {
 	var pid uint32
 	err := binary.Read(r.buf, binary.BigEndian, &pid)
 	if err != nil {
@@ -115,7 +115,7 @@ func (r *reader) Tag(ptr interface{}) error {
 	return nil
 }
 
-func (r *reader) Pointer(ptr interface{}) error {
+func (r *reader) Pointer(ptr any) error {
 	rptr := reflect.ValueOf(ptr)
 	if !(rptr.Kind() == reflect.Ptr && (rptr.Elem().Kind() == reflect.Ptr || rptr.Elem().Kind() == reflect.Interface)) {
 		panic(fmt.Errorf("sio: Reader.Pointer expects a pointer to pointer"))
@@ -152,15 +152,15 @@ type writer struct {
 	buf *bytes.Buffer
 	ver uint32
 	ids uint32
-	ptr map[uint32]interface{}
-	tag map[interface{}]uint32
+	ptr map[uint32]any
+	tag map[any]uint32
 }
 
 func newWriter() *writer {
 	return &writer{
 		buf: new(bytes.Buffer),
-		ptr: make(map[uint32]interface{}),
-		tag: make(map[interface{}]uint32),
+		ptr: make(map[uint32]any),
+		tag: make(map[any]uint32),
 	}
 }
 
@@ -192,7 +192,7 @@ func (w *writer) VersionSio() uint32 {
 	return maj*1000 + min
 }
 
-func (w *writer) Tag(ptr interface{}) error {
+func (w *writer) Tag(ptr any) error {
 	var id uint32 = ptagMarker
 	if _, ok := w.tag[ptr]; !ok {
 		err := w.genID()
@@ -209,7 +209,7 @@ func (w *writer) Tag(ptr interface{}) error {
 	return nil
 }
 
-func (w *writer) Pointer(ptr interface{}) error {
+func (w *writer) Pointer(ptr any) error {
 	ptr = reflect.ValueOf(ptr).Elem().Interface()
 	var id uint32 = pntrMarker
 	if _, ok := w.tag[ptr]; !ok {

--- a/sio/stream.go
+++ b/sio/stream.go
@@ -390,10 +390,10 @@ func (stream *Stream) WriteRecord(record *Record) error {
 	return err
 }
 
-func (stream *Stream) read(data interface{}) error {
+func (stream *Stream) read(data any) error {
 	return binary.Read(stream.f, binary.BigEndian, data)
 }
 
-func (stream *Stream) write(data interface{}) error {
+func (stream *Stream) write(data any) error {
 	return binary.Write(stream.f, binary.BigEndian, data)
 }

--- a/sio/stream_test.go
+++ b/sio/stream_test.go
@@ -144,7 +144,7 @@ func testReadStream(t *testing.T, fname string) {
 		t.Fatalf("error connecting [RunHeader]: %v", err)
 	}
 
-	for nrecs := 0; nrecs < 100; nrecs++ {
+	for nrecs := range 100 {
 		//fmt.Printf("::: irec=%d, fname=%q\n", nrecs, fname)
 		rec, err := f.ReadRecord()
 		if err != nil {
@@ -245,7 +245,7 @@ func testWriteStream(t *testing.T, fname string) {
 		t.Fatalf("error connecting [RunHeader]: %v", err)
 	}
 
-	for irec := 0; irec < 10; irec++ {
+	for irec := range 10 {
 		runhdr = RunHeader{
 			RunNbr:   int32(irec),
 			Detector: "MyDetector",
@@ -377,7 +377,7 @@ func TestPointerStream(t *testing.T) {
 
 		for _, v := range []struct {
 			n   string
-			ptr interface{}
+			ptr any
 		}{
 			{"T1", &t1},
 			{"T2", &t2},
@@ -425,7 +425,7 @@ func TestPointerStream(t *testing.T) {
 
 		for _, v := range []struct {
 			n   string
-			ptr interface{}
+			ptr any
 		}{
 			{"T1", &t1},
 			{"T2", &t2},
@@ -591,7 +591,7 @@ func TestPointerCycleStream(t *testing.T) {
 
 		for _, v := range []struct {
 			n   string
-			ptr interface{}
+			ptr any
 		}{
 			{"C1", &c1},
 			{"C2", &c2},
@@ -631,7 +631,7 @@ func TestPointerCycleStream(t *testing.T) {
 
 		for _, v := range []struct {
 			n   string
-			ptr interface{}
+			ptr any
 		}{
 			{"C1", &c1},
 			{"C2", &c2},

--- a/slha/decode.go
+++ b/slha/decode.go
@@ -220,9 +220,9 @@ func addBlockEntry(line []byte, blk *Block) error {
 	return err
 }
 
-func anyvalue(str string) (interface{}, error) {
+func anyvalue(str string) (any, error) {
 	var err error
-	var vv interface{}
+	var vv any
 
 	vfloat, err := strconv.ParseFloat(str, 64)
 	if err == nil {

--- a/slha/encode.go
+++ b/slha/encode.go
@@ -87,7 +87,7 @@ func Encode(w io.Writer, data *SLHA) error {
 		for _, item := range blk.Data {
 			v := item.Value
 			idx := item.Index.Index() //
-			args := make([]interface{}, 0, len(idx)+2)
+			args := make([]any, 0, len(idx)+2)
 			if blk.Name != "ALPHA" {
 				for _, v := range idx {
 					args = append(args, v)

--- a/slha/slha.go
+++ b/slha/slha.go
@@ -36,8 +36,8 @@ func (v *Value) Float() float64 {
 	return v.v.Float()
 }
 
-// Interface returns the value as an interface{}.
-func (v *Value) Interface() interface{} {
+// Interface returns the value as an empty interface.
+func (v *Value) Interface() any {
 	return v.v.Interface()
 }
 
@@ -76,7 +76,7 @@ func (b *Block) Get(args ...int) (Value, error) {
 // Set sets the Value at index args with v.
 // Set creates a new empty Value if none exists at args.
 // Note that args are 1-based indices.
-func (b *Block) Set(v interface{}, args ...int) error {
+func (b *Block) Set(v any, args ...int) error {
 	var err error
 	val, _ := b.Get(args...)
 	val.v = reflect.ValueOf(v)

--- a/xrootd/fshandler.go
+++ b/xrootd/fshandler.go
@@ -145,7 +145,7 @@ func (h *fshandler) Open(sessionID [16]byte, request *open.Request) (xrdproto.Ma
 	// Right now, we hope that even if 1000000000 of 256*256*256*256 handles are obtained by single user,
 	// we have appr. 0.7 probability to find a free handle by the random guess.
 	// Then, probability that no free handle is found by 100 tries is something near pow(0.3,100) = 1e-53.
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		rand.Read(handle[:])
 		if _, dup := sess.handles[handle]; !dup {
 			resp := open.Response{FileHandle: handle}

--- a/xrootd/fshandler_test.go
+++ b/xrootd/fshandler_test.go
@@ -168,7 +168,7 @@ func TestHandler_Dirlist_With1000Requests(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(1000)
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		go func() {
 			defer wg.Done()
 			_, err := cli.FS().Dirlist(context.Background(), "/")

--- a/xrootd/internal/mux/mux_test.go
+++ b/xrootd/internal/mux/mux_test.go
@@ -17,7 +17,7 @@ func TestMux_Claim(t *testing.T) {
 	defer m.Close()
 	claimedIds := map[xrdproto.StreamID]bool{}
 
-	for i := 0; i < streamIDPoolSize; i++ {
+	for range streamIDPoolSize {
 		id, channel, err := m.Claim()
 
 		if err != nil {
@@ -45,7 +45,7 @@ func TestMux_Claim_AfterUnclaim(t *testing.T) {
 	defer m.Close()
 	claimedIds := map[xrdproto.StreamID]bool{}
 
-	for i := 0; i < streamIDPoolSize; i++ {
+	for range streamIDPoolSize {
 		id, _, _ := m.Claim()
 		claimedIds[id] = true
 	}

--- a/xrootd/xrdfs/stat.go
+++ b/xrootd/xrdfs/stat.go
@@ -84,7 +84,7 @@ func (es EntryStat) ModTime() time.Time {
 }
 
 // Sys implements os.FileInfo.
-func (es EntryStat) Sys() interface{} {
+func (es EntryStat) Sys() any {
 	return nil
 }
 

--- a/xrootd/xrdproto/gen-marshal.go
+++ b/xrootd/xrdproto/gen-marshal.go
@@ -79,7 +79,7 @@ func NewGenerator(p string) (*Generator, error) {
 	}, nil
 }
 
-func (g *Generator) printf(format string, args ...interface{}) {
+func (g *Generator) printf(format string, args ...any) {
 	fmt.Fprintf(g.buf, format, args...)
 }
 

--- a/xrootd/xrdproto/prepare/prepare_test.go
+++ b/xrootd/xrdproto/prepare/prepare_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"slices"
 	"testing"
 
 	"go-hep.org/x/hep/xrootd"
@@ -135,7 +136,7 @@ func Example() {
 
 	// cancel staging request
 
-	locid := append([]byte(nil), resp.Data...)
+	locid := slices.Clone(resp.Data)
 	req = prepare.Request{
 		Options: prepare.Cancel,
 		Paths:   []string{string(locid)},

--- a/xrootd/xrdproto/protocol/protocol.go
+++ b/xrootd/xrdproto/protocol/protocol.go
@@ -174,7 +174,7 @@ func (o *Response) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
 	o.SecurityOptions = SecurityOptions(rBuffer.ReadU8())
 	o.SecurityLevel = xrdproto.SecurityLevel(rBuffer.ReadU8())
 	o.SecurityOverrides = make([]xrdproto.SecurityOverride, rBuffer.ReadU8())
-	for i := 0; i < len(o.SecurityOverrides); i++ {
+	for i := range o.SecurityOverrides {
 		err := o.SecurityOverrides[i].UnmarshalXrd(rBuffer)
 		if err != nil {
 			return err

--- a/xrootd/xrdproto/read/read.go
+++ b/xrootd/xrdproto/read/read.go
@@ -90,7 +90,7 @@ func (o *OptionalArgs) UnmarshalXrd(rBuffer *xrdenc.RBuffer) error {
 		return nil
 	}
 	o.ReadAheads = make([]ReadAhead, (alen-8)/16)
-	for i := 0; i < len(o.ReadAheads); i++ {
+	for i := range o.ReadAheads {
 		err := o.ReadAheads[i].UnmarshalXrd(rBuffer)
 		if err != nil {
 			return err


### PR DESCRIPTION
This commit modernizes Go usage.
This was done with:

```
$> go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...
```

Then files needed to be `go fmt`ed and a few comments needed to be restored.

The modernizations include replacing

- if/else conditional assignment by a call to the built-in min or max functions added in go1.21
- sort.Slice(x, func(i, j int) bool) { return s[i] < s[j] } by a call to slices.Sort(s), added in go1.21
- interface{} by the 'any' type added in go1.18
- append([]T(nil), s...) by slices.Clone(s) or slices.Concat(s), added in go1.21
- loop around an m[k]=v map update by a call to one of the Collect, Copy, Clone, or Insert functions from the maps package, added in go1.21
- []byte(fmt.Sprintf...) by fmt.Appendf(nil, ...), added in go1.19
- append(s[:i], s[i+1]...) by slices.Delete(s, i, i+1), added in go1.21
- a 3-clause for i := 0; i < n; i++ {} loop by for i := range n {}, added in go1.22